### PR TITLE
Off by one decoding

### DIFF
--- a/uzu/src/session/sampling_config.rs
+++ b/uzu/src/session/sampling_config.rs
@@ -29,8 +29,6 @@ impl SamplingConfig {
 
 impl Default for SamplingConfig {
     fn default() -> Self {
-        Self::TopP {
-            top_p: 0.9,
-        }
+        Self::Argmax
     }
 }


### PR DESCRIPTION
This is how it was done before, but I am not sure it's 100% correct
Gemma produces worse text with this configuration of prefix