### PR TITLE
Neural-speculator with PARD approach

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,6 @@ autocxx = "0.30"
 cxx = "1.0"
 cmake = "0.1"
 autocxx-build = "0.30"
-
 # optimize the build script in debug builds
 [profile.dev.build-override]
 opt-level = 3

--- a/crates/cli/src/handlers/run.rs
+++ b/crates/cli/src/handlers/run.rs
@@ -12,7 +12,7 @@ use uzu::session::{
     types::{Input, Output},
 };
 
-use crate::server::load_session;
+use crate::{server::load_session, speculator_args::SpeculatorArgs};
 
 fn format_output(output: Output) -> String {
     let stats = &output.stats;
@@ -53,11 +53,11 @@ pub fn handle_run(
     tokens_limit: usize,
     prefill_step_size: Option<usize>,
     seed: Option<u64>,
-    speculator: Option<String>,
     mut message: Option<String>,
     no_thinking: bool,
+    speculator_args: SpeculatorArgs,
 ) {
-    let mut session = load_session(model_path, prefill_step_size, seed, speculator);
+    let mut session = load_session(model_path, prefill_step_size, seed, speculator_args);
 
     let is_model_running = Arc::new(AtomicBool::new(false));
     let is_model_running_for_ctrlc = is_model_running.clone();

--- a/crates/cli/src/handlers/serve.rs
+++ b/crates/cli/src/handlers/serve.rs
@@ -1,11 +1,12 @@
 use tokio::runtime::Runtime;
 
-use crate::server::main::run_server;
+use crate::{server::main::run_server, speculator_args::SpeculatorArgs};
 
 pub fn handle_serve(
     model_path: String,
     prefill_step_size: Option<usize>,
+    speculator_args: SpeculatorArgs,
 ) {
     let runtime = Runtime::new().unwrap();
-    runtime.block_on(run_server(model_path, prefill_step_size));
+    runtime.block_on(run_server(model_path, prefill_step_size, speculator_args));
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod handlers;
 pub mod server;
+pub mod speculator_args;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,5 +1,8 @@
 use clap::{CommandFactory, Parser, Subcommand};
-use cli::handlers::{handle_bench, handle_run, handle_serve};
+use cli::{
+    handlers::{handle_bench, handle_run, handle_serve},
+    speculator_args::SpeculatorArgs,
+};
 
 #[derive(Parser)]
 struct Cli {
@@ -15,17 +18,17 @@ enum Commands {
         model_path: String,
         /// Prefill step size
         prefill_step_size: Option<usize>,
-        // Seed
+        /// Seed
         #[arg(long)]
         seed: Option<u64>,
-        // Speculator
-        #[arg(long)]
-        speculator: Option<String>,
         /// Non-interactive mode: run a single message and exit
         #[arg(long, short)]
         message: Option<String>,
         #[arg(long, short)]
+        /// Disable thinking mode
         no_thinking: bool,
+        #[command(flatten)]
+        speculator_args: SpeculatorArgs,
     },
     /// Start a server with the specified model path
     Serve {
@@ -33,6 +36,8 @@ enum Commands {
         model_path: String,
         /// Prefill step size
         prefill_step_size: Option<usize>,
+        #[command(flatten)]
+        speculator_args: SpeculatorArgs,
     },
     /// Run benchmarks for the specified model
     Bench {
@@ -53,17 +58,18 @@ fn main() {
             model_path,
             prefill_step_size,
             seed,
-            speculator,
             message,
             no_thinking,
+            speculator_args,
         }) => {
-            handle_run(model_path, 2048, prefill_step_size, seed, speculator, message, no_thinking);
+            handle_run(model_path, 2048, prefill_step_size, seed, message, no_thinking, speculator_args);
         },
         Some(Commands::Serve {
             model_path,
             prefill_step_size,
+            speculator_args,
         }) => {
-            handle_serve(model_path, prefill_step_size);
+            handle_serve(model_path, prefill_step_size, speculator_args);
         },
         Some(Commands::Bench {
             model_path,

--- a/crates/cli/src/server/main.rs
+++ b/crates/cli/src/server/main.rs
@@ -3,7 +3,10 @@ use std::path::PathBuf;
 use log::LevelFilter;
 use rocket::{Config, config::LogLevel, log::private as log, routes};
 
-use crate::server::{SessionState, SessionWrapper, handle_chat_completions, handle_models, load_session};
+use crate::{
+    server::{SessionState, SessionWrapper, handle_chat_completions, handle_models, load_session},
+    speculator_args::SpeculatorArgs,
+};
 
 struct SilentLogger;
 static SILENT_LOGGER: SilentLogger = SilentLogger;
@@ -26,6 +29,7 @@ impl log::Log for SilentLogger {
 pub async fn run_server(
     model_path: String,
     prefill_step_size: Option<usize>,
+    speculator_args: SpeculatorArgs,
 ) {
     // Install the silent logger **before** Rocket initializes its own logger.
     let _ = log::set_logger(&SILENT_LOGGER).map(|_| log::set_max_level(LevelFilter::Off));
@@ -43,7 +47,7 @@ pub async fn run_server(
     println!("🌐 Server will be available at: http://localhost:{}", config.port);
     println!("📝 Endpoints:\n   POST /chat/completions - Chat completions API\n");
 
-    let session = load_session(model_path, prefill_step_size, None, None);
+    let session = load_session(model_path, prefill_step_size, None, speculator_args);
     let state = SessionState {
         model_name,
         session_wrapper: std::sync::Arc::new(SessionWrapper::new(session)),

--- a/crates/cli/src/server/state.rs
+++ b/crates/cli/src/server/state.rs
@@ -6,7 +6,7 @@ use std::{
 use console::Style;
 use indicatif::{ProgressBar, ProgressStyle};
 use uzu::{
-    prelude::{SamplingSeed, SpeculatorConfig},
+    prelude::SamplingSeed,
     session::{
         Session,
         config::{DecodingConfig, RunConfig},
@@ -14,6 +14,8 @@ use uzu::{
         types::{Error, Input, Output},
     },
 };
+
+use crate::speculator_args::SpeculatorArgs;
 
 pub trait RunSession {
     fn run(
@@ -59,7 +61,7 @@ pub fn load_session(
     model_path: String,
     prefill_step_size: Option<usize>,
     seed: Option<u64>,
-    speculator: Option<String>,
+    speculator_args: SpeculatorArgs,
 ) -> Session {
     let style_bold = Style::new().bold();
 
@@ -71,12 +73,10 @@ pub fn load_session(
     progress_bar.set_style(ProgressStyle::default_spinner().template("{spinner:.green} Loading: {msg}").unwrap());
     progress_bar.set_message(model_name.clone());
 
-    let prefill_step_size_config: PrefillStepSize;
-    if let Some(value) = prefill_step_size {
-        prefill_step_size_config = PrefillStepSize::Custom(value);
-    } else {
-        prefill_step_size_config = PrefillStepSize::Default;
-    }
+    let prefill_step_size_config = match prefill_step_size {
+        Some(value) => PrefillStepSize::Custom(value),
+        None => PrefillStepSize::Default,
+    };
 
     let decoding_config = DecodingConfig::default()
         .with_prefill_step_size(prefill_step_size_config)
@@ -84,22 +84,7 @@ pub fn load_session(
             Some(seed) => SamplingSeed::Custom(seed),
             None => SamplingSeed::Default,
         })
-        .with_speculator_config(match speculator {
-            Some(speculator) => {
-                let (speculator, number_of_speculated_tokens) =
-                    speculator.split_once(':').unwrap_or((&speculator, "1"));
-
-                let number_of_speculated_tokens = number_of_speculated_tokens.parse().unwrap();
-
-                let speculator = Arc::new(uzu::speculators::ngram_speculator::NGramSpeculator::load(speculator));
-
-                SpeculatorConfig {
-                    number_of_speculated_tokens,
-                    speculator,
-                }
-            },
-            None => SpeculatorConfig::default(),
-        });
+        .with_speculator_config(speculator_args.build_speculator_config(&model_path_buf));
     let session = Session::new(model_path_buf, decoding_config).expect("Failed to create session");
 
     progress_bar.set_style(ProgressStyle::default_spinner().template("Loaded: {msg}").unwrap());

--- a/crates/cli/src/speculator_args.rs
+++ b/crates/cli/src/speculator_args.rs
@@ -1,0 +1,99 @@
+use std::{path::Path, sync::Arc};
+
+use clap::{Args, ValueEnum};
+use uzu::{
+    backends::metal::Metal,
+    prelude::{NGramSpeculator, NeuralSpeculator, SpeculatorConfig},
+};
+
+#[derive(ValueEnum, Debug, Clone)]
+pub enum SpeculatorType {
+    Pard,
+    Ngram,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct SpeculatorArgs {
+    #[arg(long, value_enum)]
+    /// Type of the speculator to use. If not specified, speculation is disabled.
+    pub speculator_type: Option<SpeculatorType>,
+    #[arg(long)]
+    /// Path to the speculator model.
+    pub speculator_path: Option<String>,
+    #[arg(long = "speculator-tokens", default_value_t = 1)]
+    /// Number of tokens to speculate.
+    pub speculated_tokens: usize,
+}
+
+impl SpeculatorArgs {
+    pub fn build_speculator_config(
+        &self,
+        model_path: &Path,
+    ) -> SpeculatorConfig {
+        let Some(spec_type) = &self.speculator_type else {
+            return SpeculatorConfig::default();
+        };
+
+        let n = self.speculated_tokens;
+
+        match spec_type {
+            SpeculatorType::Pard => {
+                let path_str = self
+                    .speculator_path
+                    .as_deref()
+                    .expect("--speculator-path is required when --speculator-type is pard");
+                let speculator =
+                    NeuralSpeculator::<Metal>::new(Path::new(path_str), n, 8).expect("Failed to load PARD draft model");
+                SpeculatorConfig::new(n + 1, Arc::new(speculator))
+            },
+            SpeculatorType::Ngram => {
+                let ngram_path = match self.speculator_path.as_deref() {
+                    Some(path) => path,
+                    None => &self.resolve_ngram_path(model_path).to_string_lossy().into_owned(),
+                };
+                let speculator = NGramSpeculator::load(ngram_path).expect("Failed to load NGram speculator");
+                SpeculatorConfig::new(n, Arc::new(speculator))
+            },
+        }
+    }
+
+    fn resolve_ngram_path(
+        &self,
+        model_path: &Path,
+    ) -> std::path::PathBuf {
+        if let Some(explicit) = self.speculator_path.as_deref() {
+            return std::path::PathBuf::from(explicit);
+        }
+
+        let speculators_dir = model_path.join("speculators");
+        let mut found: Vec<std::path::PathBuf> = Vec::new();
+
+        if let Ok(entries) = std::fs::read_dir(&speculators_dir) {
+            for entry in entries.flatten() {
+                let candidate = entry.path().join("model.bin");
+                if candidate.exists() {
+                    found.push(candidate);
+                }
+            }
+        }
+
+        if found.is_empty() {
+            eprintln!(
+                "error: no ngram speculator found in {}\n\
+                 Looked for: {}/*/model.bin\n\
+                 Specify a path explicitly with --speculator-path <path>",
+                speculators_dir.display(),
+                speculators_dir.display(),
+            );
+            std::process::exit(1);
+        }
+
+        if let Some(chat) =
+            found.iter().find(|p| p.parent().and_then(|d| d.file_name()).map(|n| n == "chat").unwrap_or(false))
+        {
+            return chat.clone();
+        }
+
+        found.remove(0)
+    }
+}

--- a/crates/uzu/Cargo.toml
+++ b/crates/uzu/Cargo.toml
@@ -46,6 +46,7 @@ is_close.workspace = true
 serde_json5.workspace = true
 schemars.workspace = true
 mpsgraph.workspace = true
+tempfile.workspace = true
 
 [build-dependencies]
 anyhow.workspace = true

--- a/crates/uzu/src/config/language_model.rs
+++ b/crates/uzu/src/config/language_model.rs
@@ -19,6 +19,8 @@ pub struct InnerModelConfig {
     pub embedding_config: EmbeddingConfig,
     pub transformer_config: TransformerConfig,
     pub vocab_size: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pard_token: Option<u64>,
 }
 
 impl InnerModelConfig {

--- a/crates/uzu/src/language_model/language_model_generator.rs
+++ b/crates/uzu/src/language_model/language_model_generator.rs
@@ -1,5 +1,6 @@
 use std::{
     any::Any,
+    collections::HashMap,
     iter::repeat_n,
     ops::{Deref, DerefMut, Range},
     path::Path,
@@ -33,7 +34,7 @@ use crate::{
         parameter::{ConfigResolvableValue, ResolvableValue, SamplingMethod},
         types::Error,
     },
-    trie::{TrieCreationConfig, TrieNode},
+    trie::TrieNode,
 };
 
 #[derive(Debug, Clone)]
@@ -161,7 +162,7 @@ impl<B: Backend> LanguageModelGeneratorTrait for LanguageModelGenerator<B> {
             &self.context.seed,
             compiled_grammar.as_deref_mut(),
             speculator.as_ref(),
-            &TrieCreationConfig::default(),
+            &speculator.trie_creation_config(),
             suffix_length + 1,
         );
         let flat_trie = suffix_root.linearize();
@@ -339,7 +340,7 @@ impl<B: Backend> LanguageModelGeneratorTrait for LanguageModelGenerator<B> {
             &self.context.seed,
             compiled_grammar.as_deref_mut(),
             speculator.as_ref(),
-            &TrieCreationConfig::default(),
+            &speculator.trie_creation_config(),
             suffix_length,
         );
 
@@ -970,5 +971,167 @@ impl<B: Backend> LanguageModelGenerator<B> {
         let has_speculative_suffix = self.decoding_config.generate_suffix_length() > 1;
 
         has_sliding_window || has_speculative_suffix
+    }
+
+    /// Single GPU pass: updates KV cache for `prefix` and returns top-k logits for `query`.
+    ///
+    /// Replaces two-pass `prefill(prefix)` + `get_multi_logits(query)`, saving one round-trip.
+    /// After the pass: KV is updated for `prefix` only, `self.tokens` is extended with `prefix`.
+    ///
+    /// Caller must ensure `prefix.len() + query.len() <= self.generate_suffix_length()`.
+    pub fn extend_kv_and_get_logits(
+        &mut self,
+        prefix: &[u64],
+        query: &[u64],
+        top_k: usize,
+    ) -> Vec<HashMap<u64, f32>> {
+        debug_assert!(!prefix.is_empty(), "prefix must be non-empty; use get_multi_logits for empty prefix");
+        debug_assert!(!query.is_empty(), "query must be non-empty");
+
+        let cache_len = self.tokens.len();
+        let total_len = prefix.len() + query.len();
+
+        let mut token_ids: Vec<u64> = Vec::with_capacity(total_len);
+        token_ids.extend_from_slice(prefix);
+        token_ids.extend_from_slice(query);
+
+        let token_positions: Vec<usize> = (cache_len..cache_len + total_len).collect();
+        let token_seeds: Vec<u64> = vec![0u64; total_len];
+
+        let task = Task {
+            token_ids: &token_ids,
+            token_positions: &token_positions,
+            token_bitmask: None,
+            token_seeds: &token_seeds,
+            expected_number_of_new_tokens: total_len,
+            active_suffix_length: total_len,
+            sampling_start: 0,
+            sampling_length: total_len,
+            is_prefilling: false,
+        };
+
+        // Causal mask required whenever processing more than 1 token.
+        let fill_bias = total_len > 1 || self.should_fill_attention_bias();
+
+        let (state, _) = self.run_model(task, false, false, SamplingMethod::default(), fill_bias).unwrap();
+
+        // Update KV cache for prefix positions only (not query — those are speculative).
+        let prefix_indices: Vec<usize> = (0..prefix.len()).collect();
+        self.update_cache_layers(&prefix_indices, None, true).unwrap();
+
+        // Register prefix positions as accepted in cache layer metadata.
+        let prefix_positions: Vec<usize> = (cache_len..cache_len + prefix.len()).collect();
+        self.context.cache_layers.borrow_mut().register_accepted_tokens(&prefix_positions);
+        self.registered_prefix_len = cache_len + prefix.len();
+
+        // Extend self.tokens with prefix (mirrors what prefill does for KV-cache-only steps).
+        self.tokens.extend_from_slice(prefix);
+
+        self.read_logits_rows(&state, prefix.len(), query.len(), top_k)
+    }
+
+    /// Forward pass over `extra_tokens` without modifying `self.tokens` or the KV cache.
+    /// Returns top-`top_k` probabilities per position.
+    pub fn get_multi_logits(
+        &mut self,
+        extra_tokens: &[u64],
+        top_k: usize,
+    ) -> Vec<HashMap<u64, f32>> {
+        let n = extra_tokens.len();
+        if n == 0 {
+            return Vec::new();
+        }
+
+        let start_pos = self.tokens.len();
+        let token_positions: Vec<usize> = (start_pos..start_pos + n).collect();
+        let token_seeds: Vec<u64> = vec![0u64; n];
+
+        let task = Task {
+            token_ids: extra_tokens,
+            token_positions: &token_positions,
+            token_bitmask: None,
+            token_seeds: &token_seeds,
+            expected_number_of_new_tokens: n,
+            active_suffix_length: n,
+            sampling_start: 0,
+            // sampling_length must be > 0 for the readout kernel to populate the logits buffer.
+            // We use n so that all positions get logits computed; we read them directly and
+            // ignore the GPU sampling output.
+            sampling_length: n,
+            is_prefilling: false,
+        };
+
+        // Always fill attention bias for multi-token decode (causal mask required).
+        let fill_bias = n > 1 || self.should_fill_attention_bias();
+
+        let (state, _) = self.run_model(task, false, false, SamplingMethod::default(), fill_bias).unwrap();
+
+        self.read_logits_rows(&state, 0, n, top_k)
+    }
+
+    /// Read `n` rows of logits from the GPU buffer starting at `row_offset`,
+    /// returning the top-`top_k` token probabilities for each position.
+    fn read_logits_rows(
+        &self,
+        state: &ForwardPassState<B>,
+        row_offset: usize,
+        n: usize,
+        top_k: usize,
+    ) -> Vec<HashMap<u64, f32>> {
+        let vocab_size = self.context.model_shape.logits_shape(1)[1];
+        let logits_borrow = state.llm_state().logits.borrow();
+        let data_type = logits_borrow.data_type();
+        let elem_size = data_type.size_in_bytes();
+        let raw_bytes = logits_borrow.as_bytes();
+
+        let mut result = Vec::with_capacity(n);
+        for pos in 0..n {
+            let offset = (row_offset + pos) * vocab_size * elem_size;
+            let row_bytes = &raw_bytes[offset..offset + vocab_size * elem_size];
+
+            let f32_logits: Vec<f32> = match data_type {
+                crate::DataType::F32 => bytemuck::cast_slice::<u8, f32>(row_bytes).to_vec(),
+                crate::DataType::F16 => {
+                    bytemuck::cast_slice::<u8, half::f16>(row_bytes).iter().map(|&x| half::f16::to_f32(x)).collect()
+                },
+                crate::DataType::BF16 => {
+                    bytemuck::cast_slice::<u8, half::bf16>(row_bytes).iter().map(|&x| half::bf16::to_f32(x)).collect()
+                },
+                dt => panic!("Unsupported logits data type: {dt:?}"),
+            };
+
+            result.push(logits_to_top_k_probs(f32_logits, top_k));
+        }
+
+        result
+    }
+}
+
+/// Convert a full-vocabulary logit vector into a top-k softmax probability map.
+///
+/// `speculator_sample` expects `HashMap<u64, f32>` where values are probabilities
+/// (it applies `ln(v)` before adding Gumbel noise, matching the GPU kernel which
+/// applies Gumbel noise to raw logits, i.e. `logit + g = ln(softmax) + const + g`).
+fn logits_to_top_k_probs(
+    f32_logits: Vec<f32>,
+    top_k: usize,
+) -> HashMap<u64, f32> {
+    let vocab_size = f32_logits.len();
+
+    // Numerically stable softmax: subtract max before exp.
+    let max_logit = f32_logits.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+    let sum_exp: f32 = f32_logits.iter().map(|&l| (l - max_logit).exp()).sum();
+    let log_sum_exp = max_logit + sum_exp.ln();
+
+    // Partial selection to find top-k by logit value in O(V) average time.
+    let effective_k = top_k.min(vocab_size);
+    let mut indexed: Vec<(u64, f32)> = f32_logits.into_iter().enumerate().map(|(i, v)| (i as u64, v)).collect();
+
+    if effective_k < indexed.len() {
+        let kth = indexed.len() - effective_k;
+        indexed.select_nth_unstable_by(kth, |a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+        indexed[kth..].iter().map(|&(tok, logit)| (tok, (logit - log_sum_exp).exp())).collect()
+    } else {
+        indexed.into_iter().map(|(tok, logit)| (tok, (logit - log_sum_exp).exp())).collect()
     }
 }

--- a/crates/uzu/src/prelude.rs
+++ b/crates/uzu/src/prelude.rs
@@ -20,6 +20,9 @@ pub use crate::{
             Error, FinishReason, Input, Message, Output, ParsedText, Role, RunStats, Stats, StepStats, Text, TotalStats,
         },
     },
-    speculators::{empty_speculator::EmptySpeculator, speculator::Speculator},
+    speculators::{
+        empty_speculator::EmptySpeculator, neural_speculator::NeuralSpeculator, ngram_speculator::NGramSpeculator,
+        speculator::Speculator,
+    },
     storage_path,
 };

--- a/crates/uzu/src/speculators/mod.rs
+++ b/crates/uzu/src/speculators/mod.rs
@@ -1,3 +1,4 @@
 pub mod empty_speculator;
+pub mod neural_speculator;
 pub mod ngram_speculator;
 pub mod speculator;

--- a/crates/uzu/src/speculators/neural_speculator.rs
+++ b/crates/uzu/src/speculators/neural_speculator.rs
@@ -1,0 +1,186 @@
+use std::{collections::HashMap, fs::File, io::BufReader, path::Path, sync::Mutex};
+
+use crate::{
+    ModelMetadata,
+    backends::common::Backend,
+    language_model::language_model_generator::{LanguageModelGenerator, LanguageModelGeneratorTrait},
+    session::{
+        config::{DecodingConfig, SpeculatorConfig},
+        parameter::SamplingMethod,
+        types::Error,
+    },
+    speculators::{empty_speculator::EmptySpeculator, speculator::Speculator},
+    trie::TrieCreationConfig,
+};
+
+/// Neural speculative decoding draft model based on PARD.
+///
+/// A single forward pass over `[last, pard_token × n_pard]` yields n_pard+1 logit
+/// distributions, so the main model can verify n_pard+1 candidates per step.
+///
+/// Distributions are cached keyed by the base prefix: when the trie descends the
+/// trunk (calling `speculate` with prefix extended by one token per depth), the
+/// cache returns the pre-computed distribution for that depth without an additional
+/// GPU pass.
+///
+/// # Safety
+/// `unsafe impl Send + Sync` is required because `B: Backend` does not carry
+/// `Send + Sync` bounds. Interior mutability is handled by `Mutex`, so concurrent
+/// calls to `prepare`/`speculate` are safe.
+pub struct NeuralSpeculator<B: Backend> {
+    draft: Mutex<LanguageModelGenerator<B>>,
+    pard_token: u64,
+    top_k: usize,
+    /// Number of PARD placeholder tokens per step. The draft model produces
+    /// n_pard+1 logit distributions: one for each of [last, pard×n_pard].
+    n_pard: usize,
+    /// Cache of the last PARD forward pass: (base_prefix, distributions).
+    /// distributions[k] is the predicted distribution at trunk depth k.
+    speculative_cache: Mutex<Option<(Vec<u64>, Vec<HashMap<u64, f32>>)>>,
+}
+
+unsafe impl<B: Backend> Send for NeuralSpeculator<B> {}
+unsafe impl<B: Backend> Sync for NeuralSpeculator<B> {}
+
+impl<B: Backend> NeuralSpeculator<B> {
+    /// Load the PARD draft model from `draft_model_path`.
+    ///
+    /// `pard_token` is read from `model_config.pard_token` in the model's
+    /// `config.json`. `n_pard` is the number of PARD placeholder tokens per step;
+    /// the draft model produces n_pard+1 logit distributions per call.
+    ///
+    /// The draft model's generate buffer is sized for 2*n_pard+1 tokens to
+    /// accommodate the combined KV-update pass: up to n_pard accepted tokens
+    /// (new_context) + 1 last token + n_pard pard tokens.
+    pub fn new(
+        draft_model_path: &Path,
+        n_pard: usize,
+        top_k: usize,
+    ) -> Result<Self, Error> {
+        let config_path = draft_model_path.join("config.json");
+        let config_file = File::open(&config_path).map_err(|_| Error::UnableToLoadConfig)?;
+        let model_metadata: ModelMetadata =
+            serde_json::from_reader(BufReader::new(config_file)).map_err(|_| Error::UnableToLoadConfig)?;
+        let pard_token = model_metadata
+            .model_config
+            .as_language_model()
+            .and_then(|lm| lm.model_config.pard_token)
+            .ok_or(Error::UnsupportedSpeculatorConfigForModel)?;
+
+        // The draft model itself uses EmptySpeculator. The generate-mode buffer is sized for
+        // 2*n_pard+1 tokens (generate_suffix_length = 2*n_pard+1) to support the combined pass:
+        // forward([accepted_1..k, last, pard×n_pard]) where k ≤ n_pard.
+        let draft_speculator_config = SpeculatorConfig::new(2 * n_pard, std::sync::Arc::new(EmptySpeculator {}));
+
+        let decoding_config =
+            DecodingConfig::default().with_speculator_config(draft_speculator_config).with_allow_pre_encode(false); // one-shot calls don't benefit from pre-encode
+
+        let draft = LanguageModelGenerator::new(draft_model_path, decoding_config)?;
+
+        Ok(Self {
+            draft: Mutex::new(draft),
+            pard_token,
+            top_k,
+            n_pard,
+            speculative_cache: Mutex::new(None),
+        })
+    }
+
+    /// Run a single PARD forward pass for `prefix`, returning `n_pard+1` distributions.
+    ///
+    /// 1. Compute `accepted` = tokens not yet in the draft KV cache.
+    /// 2. Run one GPU pass:
+    ///    - `accepted` is empty → `get_multi_logits([last, pard×n_pard])`.
+    ///    - `accepted.len() <= n_pard` → `extend_kv_and_get_logits(accepted, [last, pard×n_pard])`:
+    ///      updates KV and gets logits in one round-trip.
+    ///    - `accepted.len() > n_pard` (safety fallback) → `prefill(accepted)` + `get_multi_logits`.
+    fn pard_forward(
+        &self,
+        prefix: &[u64],
+    ) -> Vec<HashMap<u64, f32>> {
+        let n = self.n_pard + 1;
+        let mut draft = self.draft.lock().unwrap();
+
+        let target_cached = &prefix[..prefix.len() - 1];
+        let last_token = *prefix.last().unwrap();
+
+        let reuse_len = draft.tokens.iter().zip(target_cached.iter()).take_while(|(a, b)| a == b).count();
+
+        if reuse_len < draft.tokens.len() {
+            draft.reset_state();
+        }
+
+        let cache_len = draft.tokens.len();
+        let accepted = &target_cached[cache_len..];
+
+        // extra_tokens = [last, pard×n_pard]
+        let extra_tokens: Vec<u64> =
+            std::iter::once(last_token).chain(std::iter::repeat(self.pard_token).take(n - 1)).collect();
+
+        let mut logits = if accepted.is_empty() {
+            draft.get_multi_logits(&extra_tokens, self.top_k)
+        } else if accepted.len() <= self.n_pard {
+            // Combined pass: update KV for accepted tokens and get logits for extra_tokens
+            // in one GPU round-trip. Buffer (2*n_pard+1) fits: accepted.len() + extra_tokens.len()
+            // ≤ n_pard + (n_pard+1) = 2*n_pard+1.
+            draft.extend_kv_and_get_logits(accepted, &extra_tokens, self.top_k)
+        } else {
+            // Safety fallback: accepted.len() > n_pard should not occur in normal operation.
+            let _ = draft.prefill(accepted.to_vec(), None, SamplingMethod::default(), cache_len, false);
+            draft.get_multi_logits(&extra_tokens, self.top_k)
+        };
+
+        logits.resize_with(n, HashMap::new);
+        logits
+    }
+}
+
+impl<B: Backend> Speculator for NeuralSpeculator<B> {
+    /// Runs the PARD forward pass for `prefix` and caches all `n_pard+1`
+    /// distributions. Must be called once at the start of each trie build so
+    /// that the cache is valid for the current generation step.
+    fn prepare(
+        &self,
+        prefix: &[u64],
+    ) {
+        if prefix.is_empty() {
+            *self.speculative_cache.lock().unwrap() = None;
+            return;
+        }
+        let dists = self.pard_forward(prefix);
+        *self.speculative_cache.lock().unwrap() = Some((prefix.to_vec(), dists));
+    }
+
+    /// Returns the cached distribution for `prefix`.
+    ///
+    /// Valid only after `prepare(base)` has been called for the
+    /// current trie build. Returns the distribution at trunk depth
+    /// `prefix.len() - base.len()`, or an empty map if the trunk horizon
+    /// (`n_pard`) is exhausted (which stops trie growth naturally).
+    fn speculate(
+        &self,
+        prefix: &[u64],
+    ) -> HashMap<u64, f32> {
+        if prefix.is_empty() {
+            return HashMap::new();
+        }
+        let cache = self.speculative_cache.lock().unwrap();
+        if let Some((ref base, ref dists)) = *cache {
+            if prefix.starts_with(base.as_slice()) {
+                let depth = prefix.len() - base.len();
+                return dists.get(depth).cloned().unwrap_or_default();
+            }
+        }
+        HashMap::new()
+    }
+
+    /// PARD predicts tokens sequentially: dist[0] is for position 0 conditioned
+    /// on the prefix, dist[1] for position 1 conditioned on the prefix + trunk[0],
+    /// etc. The trie must be a trunk (linear chain) so the correct depth-k
+    /// distribution is used for the k-th speculated token. width=1 enforces this.
+    fn trie_creation_config(&self) -> TrieCreationConfig {
+        TrieCreationConfig {
+            width: 1,
+        }
+    }
+}

--- a/crates/uzu/src/speculators/ngram_speculator.rs
+++ b/crates/uzu/src/speculators/ngram_speculator.rs
@@ -2,6 +2,7 @@ use std::{
     collections::HashMap,
     iter::repeat_n,
     ops::{Deref, Range},
+    path::Path,
 };
 
 use bytemuck::cast_slice;
@@ -39,14 +40,23 @@ pub struct NGramSpeculator<B: Deref<Target = [u8]> + Send + Sync> {
 impl<B: Deref<Target = [u8]> + Send + Sync> NGramSpeculator<B> {
     const HEADER_SIZE: usize = size_of::<NGramSpeculatorHeader>();
 
-    pub fn new(bytes: B) -> Self {
-        let mut off = 0;
+    pub fn new(bytes: B) -> Result<Self, String> {
+        if bytes.len() < Self::HEADER_SIZE {
+            return Err("ngram speculator file is too small for header".to_string());
+        }
 
-        let header = NGramSpeculatorHeader::ref_from_bytes(&bytes[..Self::HEADER_SIZE]).unwrap();
+        let mut off = 0usize;
+        let header = NGramSpeculatorHeader::ref_from_bytes(&bytes[..Self::HEADER_SIZE])
+            .map_err(|_| "failed to parse ngram speculator header".to_string())?;
         off += Self::HEADER_SIZE;
 
-        let ngram_kv_size = 4 * header.top_k as usize * header.hashtable_size as usize;
-        let ngram_c_size = 4 * header.hashtable_size as usize;
+        let ngram_kv_size = 4usize
+            .checked_mul(header.top_k as usize)
+            .and_then(|v| v.checked_mul(header.hashtable_size as usize))
+            .ok_or_else(|| "ngram speculator file size overflow".to_string())?;
+        let ngram_c_size = 4usize
+            .checked_mul(header.hashtable_size as usize)
+            .ok_or_else(|| "ngram speculator file size overflow".to_string())?;
 
         let ngram_keys_range = off..(off + ngram_kv_size);
         off += ngram_kv_size;
@@ -57,14 +67,16 @@ impl<B: Deref<Target = [u8]> + Send + Sync> NGramSpeculator<B> {
         let ngram_counts_range = off..(off + ngram_c_size);
         off += ngram_c_size;
 
-        assert_eq!(off, bytes.len());
+        if off != bytes.len() {
+            return Err(format!("invalid ngram speculator file size: expected {off} bytes, got {}", bytes.len()));
+        }
 
-        Self {
+        Ok(Self {
             bytes,
             ngram_keys_range,
             ngram_values_range,
             ngram_counts_range,
-        }
+        })
     }
 
     #[inline]
@@ -114,9 +126,11 @@ impl<B: Deref<Target = [u8]> + Send + Sync> NGramSpeculator<B> {
 }
 
 impl NGramSpeculator<memmap2::Mmap> {
-    pub fn load(path: &str) -> Self {
-        let file = std::fs::File::open(path).unwrap();
-        let mmap = unsafe { memmap2::MmapOptions::default().map(&file).unwrap() };
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, String> {
+        let file =
+            std::fs::File::open(path.as_ref()).map_err(|e| format!("failed to open ngram speculator file: {e}"))?;
+        let mmap = unsafe { memmap2::MmapOptions::default().map(&file) }
+            .map_err(|e| format!("failed to mmap ngram speculator file: {e}"))?;
 
         Self::new(mmap)
     }
@@ -127,8 +141,22 @@ impl<B: Deref<Target = [u8]> + Send + Sync> Speculator for NGramSpeculator<B> {
         &self,
         prefix: &[u64],
     ) -> HashMap<u64, f32> {
-        let (ngram_keys, ngram_values, _ngram_counts) = self._seq_slice(prefix);
+        if prefix.is_empty() {
+            return HashMap::new();
+        }
 
-        ngram_keys.iter().copied().map(u64::from).zip(ngram_values.iter().copied()).collect()
+        let (ngram_keys, ngram_values, ngram_counts) = self._seq_slice(prefix);
+        let limit = (*ngram_counts as usize).min(ngram_keys.len()).min(ngram_values.len());
+
+        ngram_keys
+            .iter()
+            .copied()
+            .zip(ngram_values.iter().copied())
+            .take(limit)
+            .filter(|(_, p)| *p > 0.0)
+            .map(|(token, p)| (u64::from(token), p))
+            .collect()
     }
 }
+
+pub type NgramSpeculator = NGramSpeculator<memmap2::Mmap>;

--- a/crates/uzu/src/speculators/speculator.rs
+++ b/crates/uzu/src/speculators/speculator.rs
@@ -1,8 +1,30 @@
 use std::collections::HashMap;
 
+use crate::trie::TrieCreationConfig;
+
 pub trait Speculator: Send + Sync {
+    /// Call once per trie build before any `speculate` calls.
+    /// Stateful speculators (e.g. PARD) use this to run their forward pass and
+    /// prime the cache; stateless speculators ignore it.
+    fn prepare(
+        &self,
+        _prefix: &[u64],
+    ) {
+    }
+
+    /// Returns the probability distribution over next tokens given `prefix`.
     fn speculate(
         &self,
         prefix: &[u64],
     ) -> HashMap<u64, f32>;
+
+    /// Returns the trie creation configuration for this speculator.
+    ///
+    /// N-gram and empty speculators use the default (width=4) to allow multiple
+    /// candidates per position. Neural (PARD) speculators must return width=1 to
+    /// produce a trunk-only chain: root → s0 → s1 → … so that the main model
+    /// can verify the full speculation depth in a single forward pass.
+    fn trie_creation_config(&self) -> TrieCreationConfig {
+        TrieCreationConfig::default()
+    }
 }

--- a/crates/uzu/src/trie.rs
+++ b/crates/uzu/src/trie.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use thiserror::Error;
 
 use crate::{
@@ -34,6 +36,7 @@ pub struct TrieNode {
 #[derive(Debug)]
 pub struct FlatTrie<'a> {
     tokens: Box<[(&'a TrieNode, usize)]>,
+    indices: HashMap<*const TrieNode, usize>,
 }
 
 impl TrieNode {
@@ -96,7 +99,10 @@ impl TrieNode {
         assert!(prefix.len() >= 1, "need seed node");
 
         let prefix_length = prefix.len();
-        let mut speculated_suffix = prefix.to_vec();
+
+        // Prime the speculator for this trie build. Stateless speculators ignore
+        // this; PARD runs its forward pass here and caches all n_pard+1 distributions.
+        speculator.prepare(prefix);
 
         let mut length = 1;
         let mut height = 0;
@@ -105,7 +111,8 @@ impl TrieNode {
 
         let mut cur_node = &mut root;
         let mut cur_node_width = 0;
-        let mut cur_node_speculator_weights = speculator.speculate(&speculated_suffix);
+        let mut trunk_prefix = prefix.to_vec();
+        let mut cur_node_speculator_weights = speculator.speculate(&trunk_prefix);
 
         let mut next_node = None;
 
@@ -144,7 +151,6 @@ impl TrieNode {
                 }
             } else if let Some(next_node_token) = next_node.take() {
                 // Out of speculated tokens for this node, move onto the likeliest next node
-                speculated_suffix.push(next_node_token);
                 if let Some(compiled_grammar) = compiled_grammar.as_deref_mut() {
                     if compiled_grammar.accept_token(next_node_token).is_err() {
                         break;
@@ -153,7 +159,8 @@ impl TrieNode {
                 height += 1;
                 cur_node = cur_node.get_mut(next_node_token).unwrap();
                 cur_node_width = 0;
-                cur_node_speculator_weights = speculator.speculate(&speculated_suffix);
+                trunk_prefix.push(next_node_token);
+                cur_node_speculator_weights = speculator.speculate(&trunk_prefix);
                 continue;
             } else {
                 // Dead end, exit
@@ -192,8 +199,11 @@ impl TrieNode {
 
 impl<'a> FlatTrie<'a> {
     pub fn new(tokens: Box<[(&'a TrieNode, usize)]>) -> Self {
+        let indices = tokens.iter().enumerate().map(|(idx, (node, _))| (*node as *const TrieNode, idx)).collect();
+
         Self {
             tokens,
+            indices,
         }
     }
 
@@ -223,9 +233,9 @@ impl<'a> FlatTrie<'a> {
 
     pub fn index(
         &self,
-        node: &'a TrieNode,
+        node: &TrieNode,
     ) -> Option<usize> {
-        self.tokens.iter().position(|&(n, _)| std::ptr::eq(n, node))
+        self.indices.get(&(node as *const TrieNode)).copied()
     }
 
     pub fn accept(
@@ -237,7 +247,7 @@ impl<'a> FlatTrie<'a> {
         let mut accepted_tokens = Vec::new();
         let mut accepted_token_indices = Vec::new();
         loop {
-            let current_token_index = self.index(current_token).unwrap();
+            let current_token_index = self.index(current_token).expect("Linearized trie index must exist");
             let current_token_id = sampled_tokens[current_token_index];
 
             accepted_token_indices.push(current_token_index);

--- a/crates/uzu/tests/neural_speculator_test.rs
+++ b/crates/uzu/tests/neural_speculator_test.rs
@@ -1,0 +1,84 @@
+mod common;
+
+use uzu::{
+    backends::metal::Metal,
+    speculators::{neural_speculator::NeuralSpeculator, speculator::Speculator},
+    trie::TrieCreationConfig,
+};
+
+// ── stub ──────────────────────────────────────────────────────────────────────
+
+/// Creates a `NeuralSpeculator<Metal>` without loading any GPU model.
+/// All fields are left uninitialised.
+///
+/// # Safety
+/// Only use with methods that return before accessing any field:
+/// - `trie_creation_config()` — returns a constant.
+/// - `speculate(&[])` — empty prefix early return.
+///
+/// `ManuallyDrop` prevents `Drop` from running on the uninitialised value.
+#[allow(invalid_value)]
+fn stub() -> std::mem::ManuallyDrop<NeuralSpeculator<Metal>> {
+    // SAFETY: no field is accessed by the tested code paths.
+    unsafe { std::mem::ManuallyDrop::new(std::mem::MaybeUninit::<NeuralSpeculator<Metal>>::uninit().assume_init()) }
+}
+
+// ── constructor error paths (no model required) ───────────────────────────────
+
+#[test]
+fn test_new_nonexistent_path_fails() {
+    let result = NeuralSpeculator::<Metal>::new(std::path::Path::new("/nonexistent/nowhere"), 4, 8);
+    assert!(result.is_err(), "expected Err for a non-existent model path");
+}
+
+/// `Llama-3.2-1B-Instruct` has a valid `config.json` but no `pard_token` field —
+/// `new()` must fail before touching GPU weights.
+#[test]
+fn test_new_model_without_pard_token_fails() {
+    let model_path = common::get_test_model_path();
+    let result = NeuralSpeculator::<Metal>::new(&model_path, 4, 8);
+    assert!(
+        matches!(result, Err(uzu::session::types::Error::UnsupportedSpeculatorConfigForModel)),
+        "expected UnsupportedSpeculatorConfigForModel, got: {:?}",
+        result.err()
+    );
+}
+
+// ── pure-logic methods (stub, no GPU) ────────────────────────────────────────
+
+/// `trie_creation_config` must return `width = 1` (trunk-only linear chain),
+/// unlike the trait default of `width = 4`.
+#[test]
+fn test_trie_creation_config_is_width_1() {
+    let spec = stub();
+    assert_eq!(spec.trie_creation_config().width, 1);
+    assert_ne!(spec.trie_creation_config().width, TrieCreationConfig::default().width);
+}
+
+#[test]
+fn test_speculate_empty_prefix_returns_empty() {
+    let spec = stub();
+    assert!(spec.speculate(&[]).is_empty());
+}
+
+// ── integration (requires PARD_MODEL_PATH env var) ────────────────────────────
+// Run with: PARD_MODEL_PATH=/path/to/pard cargo test -- --ignored
+
+#[test]
+#[ignore = "requires PARD_MODEL_PATH env var pointing to a PARD draft model"]
+fn test_integration_trie_creation_config_is_width_1() {
+    let path = std::env::var("PARD_MODEL_PATH").expect("set PARD_MODEL_PATH");
+    let spec = NeuralSpeculator::<Metal>::new(std::path::Path::new(&path), 4, 8).expect("load PARD model");
+    assert_eq!(spec.trie_creation_config().width, 1);
+}
+
+#[test]
+#[ignore = "requires PARD_MODEL_PATH env var pointing to a PARD draft model"]
+fn test_integration_speculate_returns_candidates() {
+    let path = std::env::var("PARD_MODEL_PATH").expect("set PARD_MODEL_PATH");
+    let spec = NeuralSpeculator::<Metal>::new(std::path::Path::new(&path), 4, 8).expect("load PARD model");
+    let prefix = &[1u64, 2, 3, 10];
+    spec.prepare(prefix);
+    let result = spec.speculate(prefix);
+    assert!(!result.is_empty());
+}

--- a/crates/uzu/tests/ngram_speculator_test.rs
+++ b/crates/uzu/tests/ngram_speculator_test.rs
@@ -1,0 +1,186 @@
+use std::io::Write;
+
+use uzu::speculators::{ngram_speculator::NgramSpeculator, speculator::Speculator};
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/// Serialize a minimal `model.bin` into bytes.
+///
+/// Binary layout (all little-endian):
+/// ```text
+/// [header] u32 hashtable_size, u32 ngram_k, u32 ngram_n, u32 _pad
+/// [keys]   u32[hashtable_size × ngram_k]
+/// [values] f32[hashtable_size × ngram_k]
+/// [counts] u32[hashtable_size]
+/// ```
+fn build_model_bin(
+    hashtable_size: usize,
+    ngram_k: usize,
+    ngram_n: usize,
+    keys: &[u32],
+    values: &[f32],
+    counts: &[u32],
+) -> Vec<u8> {
+    let mut buf = Vec::new();
+    // Header
+    buf.extend_from_slice(&(hashtable_size as u32).to_le_bytes());
+    buf.extend_from_slice(&(ngram_k as u32).to_le_bytes());
+    buf.extend_from_slice(&(ngram_n as u32).to_le_bytes());
+    buf.extend_from_slice(&0u32.to_le_bytes()); // _pad
+    // Keys
+    for &k in keys {
+        buf.extend_from_slice(&k.to_le_bytes());
+    }
+    // Values
+    for &v in values {
+        buf.extend_from_slice(&v.to_le_bytes());
+    }
+    // Counts
+    for &c in counts {
+        buf.extend_from_slice(&c.to_le_bytes());
+    }
+    buf
+}
+
+/// Write bytes to a temp file and return the path.
+fn write_temp_bin(bytes: &[u8]) -> tempfile::NamedTempFile {
+    let mut f = tempfile::NamedTempFile::new().expect("temp file");
+    f.write_all(bytes).expect("write");
+    f
+}
+
+// ── load tests ───────────────────────────────────────────────────────────────
+
+#[test]
+fn test_load_empty_bytes_fails() {
+    let f = write_temp_bin(&[]);
+    assert!(NgramSpeculator::load(f.path()).is_err());
+}
+
+#[test]
+fn test_load_header_only_too_short_fails() {
+    // Header claims H=1, K=1 but actual data bytes are missing.
+    let bytes = build_model_bin(1, 1, 2, &[], &[], &[]);
+    // Truncate to just the header (16 bytes).
+    let f = write_temp_bin(&bytes[..16]);
+    assert!(NgramSpeculator::load(f.path()).is_err());
+}
+
+#[test]
+fn test_load_minimal_valid() {
+    // H=1, K=1, N=2: one slot, one candidate token.
+    let bytes = build_model_bin(1, 1, 2, &[42], &[1.0], &[1]);
+    let f = write_temp_bin(&bytes);
+    assert!(NgramSpeculator::load(f.path()).is_ok());
+}
+
+#[test]
+fn test_load_multi_slot() {
+    let h = 8;
+    let k = 3;
+    let keys: Vec<u32> = (0..(h * k) as u32).collect();
+    let values: Vec<f32> = vec![0.5; h * k];
+    let counts: Vec<u32> = vec![k as u32; h];
+    let bytes = build_model_bin(h, k, 2, &keys, &values, &counts);
+    let f = write_temp_bin(&bytes);
+    assert!(NgramSpeculator::load(f.path()).is_ok());
+}
+
+// ── speculate tests ───────────────────────────────────────────────────────────
+
+/// H=1 means all tokens hash to slot 0 regardless of value — simple to test.
+fn single_slot_speculator(
+    keys: &[u32],
+    values: &[f32],
+    count: u32,
+) -> NgramSpeculator {
+    let k = keys.len();
+    let bytes = build_model_bin(1, k, 2, keys, values, &[count]);
+    let f = write_temp_bin(&bytes);
+    NgramSpeculator::load(f.path()).expect("load single-slot speculator")
+}
+
+#[test]
+fn test_speculate_empty_prefix_returns_empty() {
+    let spec = single_slot_speculator(&[7, 13], &[0.8, 0.2], 2);
+    assert!(spec.speculate(&[]).is_empty());
+}
+
+#[test]
+fn test_speculate_hit_returns_candidates() {
+    let spec = single_slot_speculator(&[7, 13], &[0.8, 0.2], 2);
+    let result = spec.speculate(&[42]);
+    assert_eq!(result.len(), 2);
+    assert!((result[&7] - 0.8).abs() < 1e-6);
+    assert!((result[&13] - 0.2).abs() < 1e-6);
+}
+
+#[test]
+fn test_speculate_zero_count_returns_empty() {
+    // count=0 means no valid entries in the slot.
+    let spec = single_slot_speculator(&[7, 13], &[0.8, 0.2], 0);
+    assert!(spec.speculate(&[1]).is_empty());
+}
+
+#[test]
+fn test_speculate_zero_probability_filtered() {
+    // Entries with probability 0.0 must not appear in the result.
+    let spec = single_slot_speculator(&[7, 13], &[0.8, 0.0], 2);
+    let result = spec.speculate(&[1]);
+    assert_eq!(result.len(), 1);
+    assert!(result.contains_key(&7));
+    assert!(!result.contains_key(&13));
+}
+
+#[test]
+fn test_speculate_partial_count() {
+    // k=3 candidates per slot but count=2 → only first 2 entries returned.
+    let spec = single_slot_speculator(&[7, 13, 99], &[0.5, 0.4, 0.1], 2);
+    let result = spec.speculate(&[1]);
+    assert_eq!(result.len(), 2);
+    assert!(result.contains_key(&7));
+    assert!(result.contains_key(&13));
+    assert!(!result.contains_key(&99));
+}
+
+#[test]
+fn test_speculate_token_zero_as_valid_key() {
+    // Token ID 0 is a valid token and must be returned.
+    let spec = single_slot_speculator(&[0, 5], &[0.9, 0.1], 2);
+    let result = spec.speculate(&[1]);
+    assert!(result.contains_key(&0));
+}
+
+// ── determinism ───────────────────────────────────────────────────────────────
+
+#[test]
+fn test_speculate_is_deterministic() {
+    let spec = single_slot_speculator(&[7, 13], &[0.8, 0.2], 2);
+    let r1 = spec.speculate(&[100, 200, 300]);
+    let r2 = spec.speculate(&[100, 200, 300]);
+    assert_eq!(r1, r2);
+}
+
+#[test]
+fn test_different_prefixes_may_collide_with_h1() {
+    // With H=1 every prefix maps to the same slot → all return the same candidates.
+    let spec = single_slot_speculator(&[42], &[1.0], 1);
+    let r1 = spec.speculate(&[1]);
+    let r2 = spec.speculate(&[999]);
+    assert_eq!(r1, r2);
+}
+
+// ── ngram_n = 1 (context_len = 0) ────────────────────────────────────────────
+
+#[test]
+fn test_ngram_n1_ignores_prefix_content() {
+    // ngram_n=1 → context_len=0 → hash is always xxh3_64([]) % H.
+    // With H=1 this is trivially slot 0 for any prefix.
+    let bytes = build_model_bin(1, 1, 1, &[55], &[1.0], &[1]);
+    let f = write_temp_bin(&bytes);
+    let spec = NgramSpeculator::load(f.path()).unwrap();
+
+    let r_short = spec.speculate(&[1]);
+    let r_long = spec.speculate(&[1, 2, 3, 4, 5]);
+    assert_eq!(r_short, r_long);
+}


### PR DESCRIPTION
- ngram-speculator
- neural-speculator with PARD approach
- acceptance rate metric
- --no-thinking CLI flag

Results (was running on Apple M4 24 GB):
```bash
cargo run --release -p cli -- run \
  ./models/0.1.8/Qwen3-4B/ \
  --no-thinking \
  --seed 16 \
  --message "Tell me briefly about Navier–Stokes equations"
```
17.712s, 12.506t/s

```bash
cargo run --release -p cli -- run \
  ./models/0.1.8/Qwen3-4B/ \
  --no-thinking \
  --seed 16 \
  --speculator-type ngram \
  --message "Tell me briefly about Navier–Stokes equations"
```
25.713s, 13.530t/s, acc 59/1060 (6%)

```bash
cargo run --release -p cli -- run \
  ./models/0.1.8/Qwen3-4B/ \
  --no-thinking \
  --seed 16 \
  --speculator-type pard \
  --speculator-path ../lalamo/models/PARD-Qwen3-0.6B/ \
  --speculator-tokens 4 \
  --message "Tell me briefly about Navier–Stokes equations"
```
14.708s, 18.649t/s, acc 120/420 (29%)
