### PR TITLE
Retune MLX transposed quant matmul on Metal

### DIFF
--- a/crates/uzu/src/backends/common/kernel/quant_matmul.rs
+++ b/crates/uzu/src/backends/common/kernel/quant_matmul.rs
@@ -116,8 +116,13 @@ impl<B: Backend> QuantizedMatmulKernelEncodable<B> {
         // Matrix-matrix
         let aligned_n_64 = configuration.output_dim % 64 == 0;
         let is_bf16 = configuration.data_type == DataType::BF16;
+        let is_zero_point = configuration.quantization_type == QuantizedMatmulType::ZeroPoint;
 
-        let matrix_matrix = if aligned_n_64 && is_bf16 && matches!(configuration.group_size, 64 | 128) {
+        let matrix_matrix = if aligned_n_64
+            && is_bf16
+            && is_zero_point
+            && matches!(configuration.group_size, 64 | 128)
+        {
             MatrixMatrixKernel::QmmTransposed64x64(
                 <B::Kernels as Kernels>::QuantizedMatmulQmmTransposed64x64Kernel::new(
                     context,
@@ -129,7 +134,7 @@ impl<B: Backend> QuantizedMatmulKernelEncodable<B> {
                 )
                 .map_err(QuantizedMatmulError::BackendError)?,
             )
-        } else if aligned_n_64 && is_bf16 {
+        } else if aligned_n_64 && is_bf16 && is_zero_point {
             MatrixMatrixKernel::QmmTransposedWide(
                 <B::Kernels as Kernels>::QuantizedMatmulQmmTransposedWideKernel::new(
                     context,

--- a/crates/uzu/src/backends/metal/kernel/quant_matmul/qmm_transposed.metal
+++ b/crates/uzu/src/backends/metal/kernel/quant_matmul/qmm_transposed.metal
@@ -16,19 +16,19 @@ PUBLIC KERNEL(QuantizedMatmulQmmTransposed)(
     const constant uint& in_vec_size,
     const constant uint& out_vec_size,
     const constant uint& batch_size,
-    threadgroup T Xs[32 * (32 + 16 / sizeof(T))],
+    threadgroup T Xs[160 * (32 + 16 / sizeof(T))],
     threadgroup T Ws[32 * (32 + 16 / sizeof(T))],
     const bool use_zero_points SPECIALIZE,
     const bool use_mlx_quant SPECIALIZE,
     const bool aligned_n SPECIALIZE,
     const uint out_block_idx GROUPS(out_vec_size.div_ceil(32)),
-    const uint batch_block_idx GROUPS(batch_size.div_ceil(32)),
+    const uint batch_block_idx GROUPS(batch_size.div_ceil(160)),
     const uint simd_lane THREADS(32),
     const uint simd_group THREADS(4)
 ) {
   if (use_mlx_quant) {
     if (aligned_n) {
-      qmm_transposed_impl<T, GROUP_SIZE, BITS, true, 32, 32, 32, true>(
+      qmm_transposed_impl<T, GROUP_SIZE, BITS, true, 160, 32, 32, true>(
           weights,
           scales,
           zero_points,
@@ -46,7 +46,7 @@ PUBLIC KERNEL(QuantizedMatmulQmmTransposed)(
           simd_lane
       );
     } else {
-      qmm_transposed_impl<T, GROUP_SIZE, BITS, false, 32, 32, 32, true>(
+      qmm_transposed_impl<T, GROUP_SIZE, BITS, false, 160, 32, 32, true>(
           weights,
           scales,
           zero_points,
@@ -66,7 +66,7 @@ PUBLIC KERNEL(QuantizedMatmulQmmTransposed)(
     }
   } else {
     if (aligned_n) {
-      qmm_transposed_impl<T, GROUP_SIZE, BITS, true, 32, 32, 32, false>(
+      qmm_transposed_impl<T, GROUP_SIZE, BITS, true, 160, 32, 32, false>(
           weights,
           scales,
           zero_points,
@@ -84,7 +84,7 @@ PUBLIC KERNEL(QuantizedMatmulQmmTransposed)(
           simd_lane
       );
     } else {
-      qmm_transposed_impl<T, GROUP_SIZE, BITS, false, 32, 32, 32, false>(
+      qmm_transposed_impl<T, GROUP_SIZE, BITS, false, 160, 32, 32, false>(
           weights,
           scales,
           zero_points,

--- a/crates/uzu/src/backends/metal/kernel/quant_matmul/quant_matmul.h
+++ b/crates/uzu/src/backends/metal/kernel/quant_matmul/quant_matmul.h
@@ -735,8 +735,8 @@ void qmm_transposed_impl(
   static_assert(BK >= 32, "BK should be larger than METAL_SIMD_SIZE");
   static_assert(BK % 32 == 0, "BK should be divisible by METAL_SIMD_SIZE");
 
-  constexpr int WM = 2;
-  constexpr int WN = 2;
+  constexpr int WM = use_mlx_quant && group_size == 64 && bits == 4 ? 4 : 2;
+  constexpr int WN = use_mlx_quant && group_size == 64 && bits == 4 ? 1 : 2;
   constexpr int pack_factor = get_pack_factor<bits, 8>();
   constexpr int bytes_per_pack = get_bytes_per_pack<bits>();
   constexpr int BK_padded = (BK + 16 / sizeof(T));


### PR DESCRIPTION
Supersedes #321 on a fresh `main`-based branch.

What changed

- keep the `64x64` and wide transposed families on the zero-point path only
- use an MLX-only `WM=4`, `WN=1` split in `qmm_transposed_impl`
- retile `QmmTransposed` from `32x32` to `160x32`

Why

`Llama-3.2-3B-Instruct-4bit` prefill on Apple was still spending most of its time in transposed quant matmul. The MLX 4-bit path was taking an unfavorable transposed kernel family and tile shape for that workload.

This keeps the change narrow and preserves the current `main` refactor: zero-point keeps the specialized transposed kernels, while MLX goes through the retuned generic transposed path.

Impact

Matched Apple blocker benchmark: `Llama-3.2-3B-Instruct-4bit`, `10049` prompt tokens, `32` generated tokens, `tiered_q4:256`.

| Variant | TTFT (s) | Prompt tok/s | Gen tok/s | Memory (GB) |
| --- | ---: | ---: | ---: | ---: |
| baseline clean `tiered_q4` | 47.33 | 212.34 | 23.33 | 2.68 |
| disable bad transposed family | 47.24 | 212.73 | 23.60 | 2.62 |
| add MLX-only `WM=4`, `WN=1` | 47.16 | 213.11 | 24.28 | 2.58 |
| final `160x32` transposed QMM | 38.99 | 257.73 | 23.95 | 2.48 |

Negative ablations on the same Apple box:

| Variant | TTFT (s) | Prompt tok/s | Gen tok/s | Memory (GB) |
| --- | ---: | ---: | ---: | ---: |
| `160x32` with old `2x2` split | 40.53 | 247.96 | 23.36 | 2.58 |
| `192x32` | 43.34 | 231.91 | 23.64 | 2.50 |
| `256x32` | 43.71 | 229.94 | 24.01 | 2.68 |

Validation

- `PATH="$HOME/.rustup/toolchains/1.94.0-x86_64-apple-darwin/bin:$PATH" cargo check -p uzu --no-default-features --lib`
- cross-chip benchmark reruns are being run from this fresh `main`-based branch
