### PR TITLE
Gemma 4 E2B text model support

### DIFF
--- a/crates/uzu/src/backends/cpu/kernel/attention/attention_single_pass.rs
+++ b/crates/uzu/src/backends/cpu/kernel/attention/attention_single_pass.rs
@@ -9,7 +9,7 @@ use crate::{
 
 #[kernel(AttentionSinglePass)]
 #[variants(T, f32, f16, bf16)]
-#[variants(HEAD_DIM, 64, 128, 256)]
+#[variants(HEAD_DIM, 64, 128, 256, 512)]
 pub fn attention_single_pass<T: ArrayElement + Float, const HEAD_DIM: u32>(
     queries: *const T,
     keys: *const T,

--- a/crates/uzu/src/backends/cpu/kernel/attention/attention_two_pass.rs
+++ b/crates/uzu/src/backends/cpu/kernel/attention/attention_two_pass.rs
@@ -11,7 +11,7 @@ const TOTAL_BLOCKS_COUNT: u32 = 32;
 
 #[kernel(AttentionTwoPass1)]
 #[variants(T, f32, f16, bf16)]
-#[variants(HEAD_DIM, 64, 128, 256)]
+#[variants(HEAD_DIM, 64, 128, 256, 512)]
 pub fn attention_two_pass1<T: ArrayElement + Float, const HEAD_DIM: u32>(
     queries: *const T,
     keys: *const T,
@@ -139,7 +139,7 @@ pub fn attention_two_pass1<T: ArrayElement + Float, const HEAD_DIM: u32>(
 
 #[kernel(AttentionTwoPass2)]
 #[variants(T, f32, f16, bf16)]
-#[variants(HEAD_DIM, 64, 128, 256)]
+#[variants(HEAD_DIM, 64, 128, 256, 512)]
 pub fn attention_two_pass2<T: ArrayElement + Float, const HEAD_DIM: u32>(
     partials: *const f32,
     sums: *const f32,

--- a/crates/uzu/src/backends/cpu/kernel/element_mul/element_mul_strided.rs
+++ b/crates/uzu/src/backends/cpu/kernel/element_mul/element_mul_strided.rs
@@ -1,0 +1,29 @@
+use dsl::kernel;
+use half::{bf16, f16};
+use num_traits::Float;
+
+use crate::ArrayElement;
+
+#[kernel(ElementWiseMulStrided)]
+#[variants(T, f32, f16, bf16)]
+pub fn element_wise_mul_strided<T: ArrayElement + Float>(
+    #[allow(unused)] input_a: *const T,
+    #[allow(unused)] input_b: *const T,
+    #[allow(unused)] output: *mut T,
+    #[allow(unused)] ple_dim: u32,
+    #[allow(unused)] stride: u32,
+    #[allow(unused)] layer_offset: u32,
+    #[allow(unused)] rows: u32,
+) {
+    unsafe {
+        for row in 0usize..(rows as usize) {
+            for col in 0usize..(ple_dim as usize) {
+                let a_idx = row * (ple_dim as usize) + col;
+                let b_idx = row * (stride as usize) + (layer_offset as usize) + col;
+                let a = (*input_a.add(a_idx)).to_f32().unwrap();
+                let b = (*input_b.add(b_idx)).to_f32().unwrap();
+                *output.add(a_idx) = T::from(a * b).unwrap();
+            }
+        }
+    }
+}

--- a/crates/uzu/src/backends/cpu/kernel/element_mul/mod.rs
+++ b/crates/uzu/src/backends/cpu/kernel/element_mul/mod.rs
@@ -1,0 +1,1 @@
+pub mod element_mul_strided;

--- a/crates/uzu/src/backends/cpu/kernel/mod.rs
+++ b/crates/uzu/src/backends/cpu/kernel/mod.rs
@@ -3,6 +3,7 @@ mod activation;
 mod attention;
 mod audio;
 mod delta_net;
+mod element_mul;
 mod embedding;
 mod kv_cache_update;
 mod layer_norm;

--- a/crates/uzu/src/backends/metal/kernel/attention/attention_single_pass.metal
+++ b/crates/uzu/src/backends/metal/kernel/attention/attention_single_pass.metal
@@ -14,7 +14,7 @@ using namespace uzu::trie;
 
 template <typename T, uint HEAD_DIM>
 VARIANTS(T, float, half, bfloat)
-VARIANTS(HEAD_DIM, 64, 128, 256)
+VARIANTS(HEAD_DIM, 64, 128, 256, 512)
 PUBLIC KERNEL(AttentionSinglePass)(
     const device T* queries,
     const device T* keys,

--- a/crates/uzu/src/backends/metal/kernel/attention/attention_two_pass.metal
+++ b/crates/uzu/src/backends/metal/kernel/attention/attention_two_pass.metal
@@ -19,7 +19,7 @@ using namespace uzu::trie;
 // via integer division. Simdgroups sharing a KV head benefit from L1 cache.
 template <typename T, uint HEAD_DIM>
 VARIANTS(T, float, half, bfloat)
-VARIANTS(HEAD_DIM, 64, 128, 256)
+VARIANTS(HEAD_DIM, 64, 128, 256, 512)
 PUBLIC KERNEL(AttentionTwoPass1)(
     const device T* queries,
     const device T* keys,
@@ -146,7 +146,7 @@ PUBLIC KERNEL(AttentionTwoPass1)(
 
 template <typename T, uint HEAD_DIM>
 VARIANTS(T, float, half, bfloat)
-VARIANTS(HEAD_DIM, 64, 128, 256)
+VARIANTS(HEAD_DIM, 64, 128, 256, 512)
 PUBLIC KERNEL(AttentionTwoPass2)(
     const device float* partials,
     const device float* sums,

--- a/crates/uzu/src/backends/metal/kernel/element_mul/element_mul_strided.metal
+++ b/crates/uzu/src/backends/metal/kernel/element_mul/element_mul_strided.metal
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include "../common/dsl.h"
+
+template <typename T>
+VARIANTS(T, float, half, bfloat)
+PUBLIC KERNEL(ElementWiseMulStrided)(
+    const device T* input_a,
+    const device T* input_b,
+    device T* output,
+    constant uint& ple_dim,
+    constant uint& stride,
+    constant uint& layer_offset,
+    constant uint& rows,
+    const uint col AXIS(ple_dim, 64),
+    const uint row AXIS(rows, 1)
+) {
+  uint a_idx = row * ple_dim + col;
+  uint b_idx = row * stride + layer_offset + col;
+  float a = float(input_a[a_idx]);
+  float b = float(input_b[b_idx]);
+  output[a_idx] = T(a * b);
+}

--- a/crates/uzu/src/config/attention.rs
+++ b/crates/uzu/src/config/attention.rs
@@ -30,6 +30,11 @@ pub struct AttentionConfig {
     pub partial_rope_dim: Option<usize>,
     #[serde(default)]
     pub value_norm_config: Option<NormalizationConfig>,
+
+    /// lalamo PR #197 uses a bool flag instead of full NormalizationConfig.
+    /// Consumed during config conversion to populate value_norm_config; not re-serialized.
+    #[serde(default, skip_serializing)]
+    pub normalize_values: bool,
 }
 
 #[cfg(test)]

--- a/crates/uzu/src/config/attention.rs
+++ b/crates/uzu/src/config/attention.rs
@@ -28,6 +28,8 @@ pub struct AttentionConfig {
     pub gate_projection_config: Option<LinearConfig>,
     #[serde(default)]
     pub partial_rope_dim: Option<usize>,
+    #[serde(default)]
+    pub value_norm_config: Option<NormalizationConfig>,
 }
 
 #[cfg(test)]

--- a/crates/uzu/src/config/attention.rs
+++ b/crates/uzu/src/config/attention.rs
@@ -34,7 +34,7 @@ pub struct AttentionConfig {
     /// lalamo PR #197 uses a bool flag instead of full NormalizationConfig.
     /// Consumed during config conversion to populate value_norm_config; not re-serialized.
     #[serde(default, skip_serializing)]
-    pub normalize_values: bool,
+    pub(crate) normalize_values: bool,
 }
 
 #[cfg(test)]

--- a/crates/uzu/src/config/classifier/classifier_config.rs
+++ b/crates/uzu/src/config/classifier/classifier_config.rs
@@ -49,6 +49,7 @@ impl ClassifierConfig {
             pre_mlp_norm_config: first_layer.pre_mlp_norm_config.clone(),
             mlp_config: first_layer.mlp_config.clone(),
             post_mlp_norm_config: first_layer.post_mlp_norm_config.clone(),
+            has_layer_scalar: false,
         };
 
         let first_mixer = &first_layer.mixer_config;
@@ -92,7 +93,15 @@ impl ClassifierConfig {
             },
             context_length: self.context_length,
             layer_configs: None, // Classifier doesn't use heterogeneous layers usually
+            hidden_dims: None,
             layer_types: None,
+            kv_shared_layer_sources: None,
+            ple_dim: None,
+            ple_embed_scale: None,
+            ple_projection_scale: None,
+            ple_combination_scale: None,
+            ple_linear_config: None,
+            ple_norm_config: None,
         })
     }
 }

--- a/crates/uzu/src/config/decoder.rs
+++ b/crates/uzu/src/config/decoder.rs
@@ -62,20 +62,13 @@ pub struct DecoderConfig {
     pub context_length: usize,
 
     /// For each layer, optionally the index of the layer whose KV cache to reuse.
-    /// None means the layer computes its own KV. Some(idx) means reuse from layer idx.
     pub kv_shared_layer_sources: Option<Box<[Option<usize>]>>,
 
-    /// Per-Layer Embedding dimension (0 = disabled, 256 for Gemma 4 E2B/E4B)
     pub ple_dim: Option<usize>,
-    /// PLE embed scale: sqrt(ple_dim), e.g. 16.0
     pub ple_embed_scale: Option<f32>,
-    /// PLE projection scale: hidden_size^-0.5
     pub ple_projection_scale: Option<f32>,
-    /// PLE combination scale: 2.0^-0.5 ≈ 0.7071
     pub ple_combination_scale: Option<f32>,
-    /// LinearConfig for PLE projections (same quantization as main model)
     pub ple_linear_config: Option<LinearConfig>,
-    /// NormalizationConfig for PLE norms
     pub ple_norm_config: Option<NormalizationConfig>,
 }
 

--- a/crates/uzu/src/config/decoder.rs
+++ b/crates/uzu/src/config/decoder.rs
@@ -6,6 +6,7 @@ use serde::{
 use super::{
     decoder_layer::{DecoderLayerConfig, MixerConfig},
     embedding::EmbeddingConfig,
+    linear::LinearConfig,
     normalization::NormalizationConfig,
     rope::RoPEConfig,
 };
@@ -56,8 +57,26 @@ pub struct DecoderConfig {
     pub attention_scale: Option<f32>,
     pub num_layers: usize,
     pub sliding_window_sizes: Option<Box<[Option<usize>]>>,
+    pub hidden_dims: Option<Box<[usize]>>,
     pub layer_types: Option<Box<[DecoderLayerType]>>,
     pub context_length: usize,
+
+    /// For each layer, optionally the index of the layer whose KV cache to reuse.
+    /// None means the layer computes its own KV. Some(idx) means reuse from layer idx.
+    pub kv_shared_layer_sources: Option<Box<[Option<usize>]>>,
+
+    /// Per-Layer Embedding dimension (0 = disabled, 256 for Gemma 4 E2B/E4B)
+    pub ple_dim: Option<usize>,
+    /// PLE embed scale: sqrt(ple_dim), e.g. 16.0
+    pub ple_embed_scale: Option<f32>,
+    /// PLE projection scale: hidden_size^-0.5
+    pub ple_projection_scale: Option<f32>,
+    /// PLE combination scale: 2.0^-0.5 ≈ 0.7071
+    pub ple_combination_scale: Option<f32>,
+    /// LinearConfig for PLE projections (same quantization as main model)
+    pub ple_linear_config: Option<LinearConfig>,
+    /// NormalizationConfig for PLE norms
+    pub ple_norm_config: Option<NormalizationConfig>,
 }
 
 impl<'de> Deserialize<'de> for DecoderConfig {
@@ -82,8 +101,16 @@ impl<'de> Deserialize<'de> for DecoderConfig {
             attention_scale,
             num_layers,
             sliding_window_sizes,
+            hidden_dims,
             layer_types,
             context_length,
+            kv_shared_layer_sources,
+            ple_dim,
+            ple_embed_scale,
+            ple_projection_scale,
+            ple_combination_scale,
+            ple_linear_config,
+            ple_norm_config,
         } = raw;
 
         let layer_configs_boxed = layer_configs.map(|layers| layers.into_boxed_slice());
@@ -134,6 +161,9 @@ impl<'de> Deserialize<'de> for DecoderConfig {
             None
         };
 
+        let hidden_dims = hidden_dims.map(|v| v.into_boxed_slice());
+        let kv_shared_layer_sources = kv_shared_layer_sources.map(|v| v.into_boxed_slice());
+
         let explicit_layer_types = layer_types.map(|types| types.into_boxed_slice());
         let derived_layer_types = if let Some(configs) = layer_configs_boxed.as_ref() {
             Some(configs.iter().map(layer_type_from_config).collect::<Vec<_>>().into_boxed_slice())
@@ -158,8 +188,16 @@ impl<'de> Deserialize<'de> for DecoderConfig {
             attention_scale: attention_scale_value,
             num_layers: num_layers_value,
             sliding_window_sizes: sliding_window_sizes_boxed,
+            hidden_dims,
             layer_types: layer_types_value,
             context_length,
+            kv_shared_layer_sources,
+            ple_dim,
+            ple_embed_scale,
+            ple_projection_scale,
+            ple_combination_scale,
+            ple_linear_config,
+            ple_norm_config,
         })
     }
 }
@@ -192,8 +230,24 @@ struct RawDecoderConfig {
     #[serde(default)]
     sliding_window_sizes: Option<Vec<Option<usize>>>,
     #[serde(default)]
+    hidden_dims: Option<Vec<usize>>,
+    #[serde(default)]
     layer_types: Option<Vec<DecoderLayerType>>,
     context_length: usize,
+    #[serde(default)]
+    kv_shared_layer_sources: Option<Vec<Option<usize>>>,
+    #[serde(default)]
+    ple_dim: Option<usize>,
+    #[serde(default)]
+    ple_embed_scale: Option<f32>,
+    #[serde(default)]
+    ple_projection_scale: Option<f32>,
+    #[serde(default)]
+    ple_combination_scale: Option<f32>,
+    #[serde(default)]
+    ple_linear_config: Option<LinearConfig>,
+    #[serde(default)]
+    ple_norm_config: Option<NormalizationConfig>,
 }
 
 fn derive_dims_from_layer(layer: &DecoderLayerConfig) -> Option<(usize, usize, usize)> {

--- a/crates/uzu/src/config/decoder_layer.rs
+++ b/crates/uzu/src/config/decoder_layer.rs
@@ -102,6 +102,10 @@ pub struct DecoderLayerConfig {
     pub mlp_config: MLPConfig,
     #[serde(alias = "post_mlp_norm_config")]
     pub post_mlp_norm_config: Option<NormalizationConfig>,
+    /// Whether this layer has a per-layer learnable scalar applied after all operations.
+    /// Used by Gemma 4 (`hidden_states *= layer_scalar`).
+    #[serde(default)]
+    pub has_layer_scalar: bool,
 }
 
 impl DecoderLayerConfig {

--- a/crates/uzu/src/config/language_model.rs
+++ b/crates/uzu/src/config/language_model.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::config::{
-    ConfigError, DecoderConfig, DecoderLayerConfig, DecoderLayerType, EmbeddingConfig, GenerationConfig,
-    MessageProcessorConfig, MixerConfig, TransformerConfig,
+    ConfigDataType, ConfigError, DecoderConfig, DecoderLayerConfig, DecoderLayerType, EmbeddingConfig,
+    GenerationConfig, MessageProcessorConfig, MixerConfig, NormalizationConfig, TransformerConfig, UpcastMode,
 };
 
 struct AttentionDims {
@@ -10,6 +10,25 @@ struct AttentionDims {
     num_groups: usize,
     head_dim: usize,
     attention_scale: Option<f32>,
+}
+
+/// Nested PLE config from lalamo PR #197 format.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct PLEModelConfig {
+    #[serde(default)]
+    pub ple_dim: Option<usize>,
+    #[serde(default)]
+    pub ple_embed_scale: Option<f32>,
+    /// Their name for our ple_projection_scale
+    #[serde(default)]
+    pub model_projection_scale: Option<f32>,
+    /// Their name for our ple_combination_scale
+    #[serde(default)]
+    pub input_scale: Option<f32>,
+    #[serde(default, alias = "linear_config")]
+    pub ple_linear_config: Option<crate::config::LinearConfig>,
+    #[serde(default, alias = "norm_config")]
+    pub ple_norm_config: Option<NormalizationConfig>,
 }
 
 /// Inner model config matching the new lalamo export format.
@@ -34,29 +53,88 @@ pub struct InnerModelConfig {
     #[serde(default)]
     pub ple_linear_config: Option<crate::config::LinearConfig>,
     #[serde(default)]
-    pub ple_norm_config: Option<crate::config::NormalizationConfig>,
+    pub ple_norm_config: Option<NormalizationConfig>,
     #[serde(default)]
     pub has_layer_scalar: bool,
+
+    /// Nested PLE config (lalamo PR #197 format)
+    #[serde(default)]
+    pub ple_model_config: Option<PLEModelConfig>,
 }
 
 impl InnerModelConfig {
+    /// Construct a default V-norm config for `normalize_values == true`.
+    fn default_value_norm_config() -> NormalizationConfig {
+        NormalizationConfig {
+            scale_precision: ConfigDataType::BFloat16,
+            accumulation_precision: ConfigDataType::Float32,
+            epsilon: 1e-6,
+            scale_offset: None,
+            upcast_mode: UpcastMode::OnlyNormalization,
+            subtract_mean: false,
+            use_bias: false,
+            has_scale: false,
+        }
+    }
+
+    /// Apply normalize_values -> value_norm_config and global_rope_dim -> partial_rope_dim
+    /// conversions on a MixerConfig, returning the (possibly modified) config.
+    fn apply_mixer_conversions(
+        mixer: &MixerConfig,
+        tf: &TransformerConfig,
+    ) -> MixerConfig {
+        match mixer {
+            MixerConfig::Attention(attn) => {
+                let mut attn = attn.clone();
+
+                // normalize_values -> value_norm_config fallback
+                if attn.normalize_values && attn.value_norm_config.is_none() {
+                    attn.value_norm_config = Some(Self::default_value_norm_config());
+                }
+
+                // global_rope_dim -> partial_rope_dim for global attention layers
+                // (global = no sliding window)
+                if attn.partial_rope_dim.is_none() {
+                    if let Some(global_rope_dim) = tf.global_rope_dim {
+                        if attn.sliding_window_size.is_none() {
+                            attn.partial_rope_dim = Some(global_rope_dim);
+                        }
+                    }
+                }
+
+                MixerConfig::Attention(attn)
+            },
+            other => other.clone(),
+        }
+    }
+
     /// Convert to DecoderConfig for backward compatibility with the rest of the codebase.
     pub fn to_decoder_config(&self) -> Result<DecoderConfig, ConfigError> {
         let tf = &self.transformer_config;
+        let ple = self.ple_model_config.as_ref();
 
         let first_layer = tf.layer_configs.first().ok_or(ConfigError::NoLayers)?;
+
+        // Resolve has_layer_scalar: top-level, or from any per-layer ple_config
+        let has_layer_scalar = if self.has_layer_scalar {
+            true
+        } else {
+            tf.layer_configs.iter().any(|l| l.ple_config.as_ref().is_some_and(|p| p.has_layer_scalar))
+        };
+
+        let first_mixer = Self::apply_mixer_conversions(&first_layer.mixer_config, tf);
 
         let layer_config = DecoderLayerConfig {
             pre_attention_norm_config: first_layer
                 .pre_attention_norm_config
                 .clone()
                 .unwrap_or_else(|| tf.output_norm_config.clone()),
-            mixer_config: first_layer.mixer_config.clone(),
+            mixer_config: first_mixer,
             post_attention_norm_config: first_layer.post_attention_norm_config.clone(),
             pre_mlp_norm_config: first_layer.pre_mlp_norm_config.clone(),
             mlp_config: first_layer.mlp_config.clone(),
             post_mlp_norm_config: first_layer.post_mlp_norm_config.clone(),
-            has_layer_scalar: self.has_layer_scalar,
+            has_layer_scalar,
         };
 
         let attention_dims = Self::derive_attention_dims(tf)?;
@@ -79,20 +157,57 @@ impl InnerModelConfig {
         let layer_configs: Box<[DecoderLayerConfig]> = tf
             .layer_configs
             .iter()
-            .map(|layer| DecoderLayerConfig {
-                pre_attention_norm_config: layer
-                    .pre_attention_norm_config
-                    .clone()
-                    .unwrap_or_else(|| tf.output_norm_config.clone()),
-                mixer_config: layer.mixer_config.clone(),
-                post_attention_norm_config: layer.post_attention_norm_config.clone(),
-                pre_mlp_norm_config: layer.pre_mlp_norm_config.clone(),
-                mlp_config: layer.mlp_config.clone(),
-                post_mlp_norm_config: layer.post_mlp_norm_config.clone(),
-                has_layer_scalar: self.has_layer_scalar,
+            .map(|layer| {
+                let mixer = Self::apply_mixer_conversions(&layer.mixer_config, tf);
+                DecoderLayerConfig {
+                    pre_attention_norm_config: layer
+                        .pre_attention_norm_config
+                        .clone()
+                        .unwrap_or_else(|| tf.output_norm_config.clone()),
+                    mixer_config: mixer,
+                    post_attention_norm_config: layer.post_attention_norm_config.clone(),
+                    pre_mlp_norm_config: layer.pre_mlp_norm_config.clone(),
+                    mlp_config: layer.mlp_config.clone(),
+                    post_mlp_norm_config: layer.post_mlp_norm_config.clone(),
+                    has_layer_scalar,
+                }
             })
             .collect::<Vec<_>>()
             .into_boxed_slice();
+
+        // hidden_dims: top-level, or build from per-layer hidden_dim
+        let hidden_dims = if self.hidden_dims.is_some() {
+            self.hidden_dims.as_ref().map(|v| v.clone().into_boxed_slice())
+        } else {
+            let per_layer: Vec<usize> = tf.layer_configs.iter().filter_map(|l| l.hidden_dim).collect();
+            if per_layer.len() == tf.layer_configs.len() && !per_layer.is_empty() {
+                Some(per_layer.into_boxed_slice())
+            } else {
+                None
+            }
+        };
+
+        // kv_shared_layer_sources: top-level, or build from per-layer kv_source_layer
+        let kv_shared_layer_sources = if self.kv_shared_layer_sources.is_some() {
+            self.kv_shared_layer_sources.as_ref().map(|v| v.clone().into_boxed_slice())
+        } else {
+            let has_any = tf.layer_configs.iter().any(|l| l.kv_source_layer.is_some());
+            if has_any {
+                let sources: Vec<Option<usize>> = tf.layer_configs.iter().map(|l| l.kv_source_layer).collect();
+                Some(sources.into_boxed_slice())
+            } else {
+                None
+            }
+        };
+
+        // PLE fields: top-level, or fallback to ple_model_config
+        let ple_dim = self.ple_dim.or_else(|| ple.and_then(|p| p.ple_dim));
+        let ple_embed_scale = self.ple_embed_scale.or_else(|| ple.and_then(|p| p.ple_embed_scale));
+        let ple_projection_scale = self.ple_projection_scale.or_else(|| ple.and_then(|p| p.model_projection_scale));
+        let ple_combination_scale = self.ple_combination_scale.or_else(|| ple.and_then(|p| p.input_scale));
+        let ple_linear_config =
+            self.ple_linear_config.clone().or_else(|| ple.and_then(|p| p.ple_linear_config.clone()));
+        let ple_norm_config = self.ple_norm_config.clone().or_else(|| ple.and_then(|p| p.ple_norm_config.clone()));
 
         Ok(DecoderConfig {
             embedding_config: self.embedding_config.clone(),
@@ -110,16 +225,16 @@ impl InnerModelConfig {
             attention_scale: attention_dims.attention_scale,
             num_layers,
             sliding_window_sizes: Some(sliding_window_sizes),
-            hidden_dims: self.hidden_dims.as_ref().map(|v| v.clone().into_boxed_slice()),
+            hidden_dims,
             layer_types: Some(layer_types),
             context_length: tf.context_length,
-            kv_shared_layer_sources: self.kv_shared_layer_sources.as_ref().map(|v| v.clone().into_boxed_slice()),
-            ple_dim: self.ple_dim,
-            ple_embed_scale: self.ple_embed_scale,
-            ple_projection_scale: self.ple_projection_scale,
-            ple_combination_scale: self.ple_combination_scale,
-            ple_linear_config: self.ple_linear_config.clone(),
-            ple_norm_config: self.ple_norm_config.clone(),
+            kv_shared_layer_sources,
+            ple_dim,
+            ple_embed_scale,
+            ple_projection_scale,
+            ple_combination_scale,
+            ple_linear_config,
+            ple_norm_config,
         })
     }
 

--- a/crates/uzu/src/config/language_model.rs
+++ b/crates/uzu/src/config/language_model.rs
@@ -19,6 +19,24 @@ pub struct InnerModelConfig {
     pub embedding_config: EmbeddingConfig,
     pub transformer_config: TransformerConfig,
     pub vocab_size: usize,
+    #[serde(default)]
+    pub hidden_dims: Option<Vec<usize>>,
+    #[serde(default)]
+    pub kv_shared_layer_sources: Option<Vec<Option<usize>>>,
+    #[serde(default)]
+    pub ple_dim: Option<usize>,
+    #[serde(default)]
+    pub ple_embed_scale: Option<f32>,
+    #[serde(default)]
+    pub ple_projection_scale: Option<f32>,
+    #[serde(default)]
+    pub ple_combination_scale: Option<f32>,
+    #[serde(default)]
+    pub ple_linear_config: Option<crate::config::LinearConfig>,
+    #[serde(default)]
+    pub ple_norm_config: Option<crate::config::NormalizationConfig>,
+    #[serde(default)]
+    pub has_layer_scalar: bool,
 }
 
 impl InnerModelConfig {
@@ -38,6 +56,7 @@ impl InnerModelConfig {
             pre_mlp_norm_config: first_layer.pre_mlp_norm_config.clone(),
             mlp_config: first_layer.mlp_config.clone(),
             post_mlp_norm_config: first_layer.post_mlp_norm_config.clone(),
+            has_layer_scalar: self.has_layer_scalar,
         };
 
         let attention_dims = Self::derive_attention_dims(tf)?;
@@ -70,6 +89,7 @@ impl InnerModelConfig {
                 pre_mlp_norm_config: layer.pre_mlp_norm_config.clone(),
                 mlp_config: layer.mlp_config.clone(),
                 post_mlp_norm_config: layer.post_mlp_norm_config.clone(),
+                has_layer_scalar: self.has_layer_scalar,
             })
             .collect::<Vec<_>>()
             .into_boxed_slice();
@@ -90,8 +110,16 @@ impl InnerModelConfig {
             attention_scale: attention_dims.attention_scale,
             num_layers,
             sliding_window_sizes: Some(sliding_window_sizes),
+            hidden_dims: self.hidden_dims.as_ref().map(|v| v.clone().into_boxed_slice()),
             layer_types: Some(layer_types),
             context_length: tf.context_length,
+            kv_shared_layer_sources: self.kv_shared_layer_sources.as_ref().map(|v| v.clone().into_boxed_slice()),
+            ple_dim: self.ple_dim,
+            ple_embed_scale: self.ple_embed_scale,
+            ple_projection_scale: self.ple_projection_scale,
+            ple_combination_scale: self.ple_combination_scale,
+            ple_linear_config: self.ple_linear_config.clone(),
+            ple_norm_config: self.ple_norm_config.clone(),
         })
     }
 

--- a/crates/uzu/src/config/language_model.rs
+++ b/crates/uzu/src/config/language_model.rs
@@ -12,17 +12,14 @@ struct AttentionDims {
     attention_scale: Option<f32>,
 }
 
-/// Nested PLE config from lalamo PR #197 format.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct PLEModelConfig {
     #[serde(default)]
     pub ple_dim: Option<usize>,
     #[serde(default)]
     pub ple_embed_scale: Option<f32>,
-    /// Their name for our ple_projection_scale
     #[serde(default)]
     pub model_projection_scale: Option<f32>,
-    /// Their name for our ple_combination_scale
     #[serde(default)]
     pub input_scale: Option<f32>,
     #[serde(default, alias = "linear_config")]
@@ -31,8 +28,6 @@ pub struct PLEModelConfig {
     pub ple_norm_config: Option<NormalizationConfig>,
 }
 
-/// Inner model config matching the new lalamo export format.
-/// Contains embedding_config at the top level, with transformer_config nested.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct InnerModelConfig {
     pub embedding_config: EmbeddingConfig,
@@ -57,7 +52,6 @@ pub struct InnerModelConfig {
     #[serde(default)]
     pub has_layer_scalar: bool,
 
-    /// Nested PLE config (lalamo PR #197 format)
     #[serde(default)]
     pub ple_model_config: Option<PLEModelConfig>,
 }
@@ -77,8 +71,6 @@ impl InnerModelConfig {
         }
     }
 
-    /// Apply normalize_values -> value_norm_config and global_rope_dim -> partial_rope_dim
-    /// conversions on a MixerConfig, returning the (possibly modified) config.
     fn apply_mixer_conversions(
         mixer: &MixerConfig,
         tf: &TransformerConfig,
@@ -87,13 +79,10 @@ impl InnerModelConfig {
             MixerConfig::Attention(attn) => {
                 let mut attn = attn.clone();
 
-                // normalize_values -> value_norm_config fallback
                 if attn.normalize_values && attn.value_norm_config.is_none() {
                     attn.value_norm_config = Some(Self::default_value_norm_config());
                 }
 
-                // global_rope_dim -> partial_rope_dim for global attention layers
-                // (global = no sliding window)
                 if attn.partial_rope_dim.is_none() {
                     if let Some(global_rope_dim) = tf.global_rope_dim {
                         if attn.sliding_window_size.is_none() {
@@ -108,14 +97,12 @@ impl InnerModelConfig {
         }
     }
 
-    /// Convert to DecoderConfig for backward compatibility with the rest of the codebase.
     pub fn to_decoder_config(&self) -> Result<DecoderConfig, ConfigError> {
         let tf = &self.transformer_config;
         let ple = self.ple_model_config.as_ref();
 
         let first_layer = tf.layer_configs.first().ok_or(ConfigError::NoLayers)?;
 
-        // Resolve has_layer_scalar: top-level, or from any per-layer ple_config
         let has_layer_scalar = if self.has_layer_scalar {
             true
         } else {
@@ -175,7 +162,6 @@ impl InnerModelConfig {
             .collect::<Vec<_>>()
             .into_boxed_slice();
 
-        // hidden_dims: top-level, or build from per-layer hidden_dim
         let hidden_dims = if self.hidden_dims.is_some() {
             self.hidden_dims.as_ref().map(|v| v.clone().into_boxed_slice())
         } else {
@@ -187,7 +173,6 @@ impl InnerModelConfig {
             }
         };
 
-        // kv_shared_layer_sources: top-level, or build from per-layer kv_source_layer
         let kv_shared_layer_sources = if self.kv_shared_layer_sources.is_some() {
             self.kv_shared_layer_sources.as_ref().map(|v| v.clone().into_boxed_slice())
         } else {
@@ -200,7 +185,6 @@ impl InnerModelConfig {
             }
         };
 
-        // PLE fields: top-level, or fallback to ple_model_config
         let ple_dim = self.ple_dim.or_else(|| ple.and_then(|p| p.ple_dim));
         let ple_embed_scale = self.ple_embed_scale.or_else(|| ple.and_then(|p| p.ple_embed_scale));
         let ple_projection_scale = self.ple_projection_scale.or_else(|| ple.and_then(|p| p.model_projection_scale));
@@ -319,8 +303,6 @@ pub struct LanguageModelConfig {
 }
 
 impl LanguageModelConfig {
-    /// Get the decoder config for backward compatibility.
-    /// This converts the new format to the old DecoderConfig format.
     pub fn decoder_config(&self) -> Result<DecoderConfig, ConfigError> {
         self.model_config.to_decoder_config()
     }

--- a/crates/uzu/src/config/language_model.rs
+++ b/crates/uzu/src/config/language_model.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::config::{
-    ConfigDataType, ConfigError, DecoderConfig, DecoderLayerConfig, DecoderLayerType, EmbeddingConfig,
+    AttentionConfig, ConfigDataType, ConfigError, DecoderConfig, DecoderLayerConfig, DecoderLayerType, EmbeddingConfig,
     GenerationConfig, MessageProcessorConfig, MixerConfig, NormalizationConfig, TransformerConfig, UpcastMode,
 };
 
@@ -34,9 +34,9 @@ pub struct InnerModelConfig {
     pub transformer_config: TransformerConfig,
     pub vocab_size: usize,
     #[serde(default)]
-    pub hidden_dims: Option<Vec<usize>>,
+    pub hidden_dims: Option<Box<[usize]>>,
     #[serde(default)]
-    pub kv_shared_layer_sources: Option<Vec<Option<usize>>>,
+    pub kv_shared_layer_sources: Option<Box<[Option<usize>]>>,
     #[serde(default)]
     pub ple_dim: Option<usize>,
     #[serde(default)]
@@ -76,23 +76,21 @@ impl InnerModelConfig {
         tf: &TransformerConfig,
     ) -> MixerConfig {
         match mixer {
-            MixerConfig::Attention(attn) => {
-                let mut attn = attn.clone();
-
-                if attn.normalize_values && attn.value_norm_config.is_none() {
-                    attn.value_norm_config = Some(Self::default_value_norm_config());
-                }
-
-                if attn.partial_rope_dim.is_none() {
-                    if let Some(global_rope_dim) = tf.global_rope_dim {
-                        if attn.sliding_window_size.is_none() {
-                            attn.partial_rope_dim = Some(global_rope_dim);
-                        }
+            MixerConfig::Attention(attn) => MixerConfig::Attention(AttentionConfig {
+                value_norm_config: if attn.normalize_values && attn.value_norm_config.is_none() {
+                    Some(Self::default_value_norm_config())
+                } else {
+                    attn.value_norm_config.clone()
+                },
+                partial_rope_dim: attn.partial_rope_dim.or_else(|| {
+                    if attn.sliding_window_size.is_none() {
+                        tf.global_rope_dim
+                    } else {
+                        None
                     }
-                }
-
-                MixerConfig::Attention(attn)
-            },
+                }),
+                ..attn.clone()
+            }),
             other => other.clone(),
         }
     }
@@ -162,20 +160,16 @@ impl InnerModelConfig {
             .collect::<Vec<_>>()
             .into_boxed_slice();
 
-        let hidden_dims = if self.hidden_dims.is_some() {
-            self.hidden_dims.as_ref().map(|v| v.clone().into_boxed_slice())
-        } else {
+        let hidden_dims = self.hidden_dims.clone().or_else(|| {
             let per_layer: Vec<usize> = tf.layer_configs.iter().filter_map(|l| l.hidden_dim).collect();
             if per_layer.len() == tf.layer_configs.len() && !per_layer.is_empty() {
                 Some(per_layer.into_boxed_slice())
             } else {
                 None
             }
-        };
+        });
 
-        let kv_shared_layer_sources = if self.kv_shared_layer_sources.is_some() {
-            self.kv_shared_layer_sources.as_ref().map(|v| v.clone().into_boxed_slice())
-        } else {
+        let kv_shared_layer_sources = self.kv_shared_layer_sources.clone().or_else(|| {
             let has_any = tf.layer_configs.iter().any(|l| l.kv_source_layer.is_some());
             if has_any {
                 let sources: Vec<Option<usize>> = tf.layer_configs.iter().map(|l| l.kv_source_layer).collect();
@@ -183,7 +177,7 @@ impl InnerModelConfig {
             } else {
                 None
             }
-        };
+        });
 
         let ple_dim = self.ple_dim.or_else(|| ple.and_then(|p| p.ple_dim));
         let ple_embed_scale = self.ple_embed_scale.or_else(|| ple.and_then(|p| p.ple_embed_scale));

--- a/crates/uzu/src/config/normalization/normalization_config.rs
+++ b/crates/uzu/src/config/normalization/normalization_config.rs
@@ -14,6 +14,12 @@ pub struct NormalizationConfig {
     pub subtract_mean: bool,
     #[serde(default)]
     pub use_bias: bool,
+    #[serde(default = "default_true")]
+    pub has_scale: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[cfg(test)]

--- a/crates/uzu/src/config/transformer.rs
+++ b/crates/uzu/src/config/transformer.rs
@@ -22,4 +22,18 @@ pub struct TransformerConfig {
     #[serde(default)]
     pub num_layers: Option<usize>,
     pub context_length: usize,
+
+    /// Global attention RoPE dimension (lalamo PR #197). Used to derive partial_rope_dim.
+    #[serde(default)]
+    pub global_rope_dim: Option<usize>,
+
+    /// Local attention RoPE dimension (lalamo PR #197). Deserialized for forward
+    /// compatibility; not used in conversion because local layers use full head_dim for RoPE.
+    #[serde(default)]
+    pub local_rope_dim: Option<usize>,
+
+    /// Global attention head dimension (lalamo PR #197). Deserialized for forward
+    /// compatibility; per-layer head_dim from AttentionConfig is used instead.
+    #[serde(default)]
+    pub global_head_dim: Option<usize>,
 }

--- a/crates/uzu/src/config/transformer.rs
+++ b/crates/uzu/src/config/transformer.rs
@@ -23,17 +23,15 @@ pub struct TransformerConfig {
     pub num_layers: Option<usize>,
     pub context_length: usize,
 
-    /// Global attention RoPE dimension (lalamo PR #197). Used to derive partial_rope_dim.
+    /// Used to derive partial_rope_dim for global (non-sliding-window) attention layers.
     #[serde(default)]
     pub global_rope_dim: Option<usize>,
 
-    /// Local attention RoPE dimension (lalamo PR #197). Deserialized for forward
-    /// compatibility; not used in conversion because local layers use full head_dim for RoPE.
+    /// Deserialized for forward compatibility; not used in conversion.
     #[serde(default)]
     pub local_rope_dim: Option<usize>,
 
-    /// Global attention head dimension (lalamo PR #197). Deserialized for forward
-    /// compatibility; per-layer head_dim from AttentionConfig is used instead.
+    /// Deserialized for forward compatibility; per-layer head_dim from AttentionConfig is used instead.
     #[serde(default)]
     pub global_head_dim: Option<usize>,
 }

--- a/crates/uzu/src/config/transformer_layer.rs
+++ b/crates/uzu/src/config/transformer_layer.rs
@@ -2,6 +2,13 @@ use serde::{Deserialize, Serialize};
 
 use super::{AttentionConfig, MLPConfig, MixerConfig, NormalizationConfig};
 
+/// Per-layer PLE config (lalamo PR #197 format).
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct PLELayerConfig {
+    #[serde(default)]
+    pub has_layer_scalar: bool,
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct TransformerLayerConfig {
     #[serde(alias = "pre_mixer_norm_config")]
@@ -12,6 +19,18 @@ pub struct TransformerLayerConfig {
     pub pre_mlp_norm_config: NormalizationConfig,
     pub mlp_config: MLPConfig,
     pub post_mlp_norm_config: Option<NormalizationConfig>,
+
+    /// Per-layer MLP hidden dimension (lalamo PR #197 format)
+    #[serde(default)]
+    pub hidden_dim: Option<usize>,
+
+    /// Source layer index for KV cache sharing (lalamo PR #197 format)
+    #[serde(default)]
+    pub kv_source_layer: Option<usize>,
+
+    /// Per-layer PLE config (lalamo PR #197 format)
+    #[serde(default)]
+    pub ple_config: Option<PLELayerConfig>,
 }
 
 impl TransformerLayerConfig {

--- a/crates/uzu/src/config/transformer_layer.rs
+++ b/crates/uzu/src/config/transformer_layer.rs
@@ -2,7 +2,6 @@ use serde::{Deserialize, Serialize};
 
 use super::{AttentionConfig, MLPConfig, MixerConfig, NormalizationConfig};
 
-/// Per-layer PLE config (lalamo PR #197 format).
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct PLELayerConfig {
     #[serde(default)]
@@ -20,15 +19,12 @@ pub struct TransformerLayerConfig {
     pub mlp_config: MLPConfig,
     pub post_mlp_norm_config: Option<NormalizationConfig>,
 
-    /// Per-layer MLP hidden dimension (lalamo PR #197 format)
     #[serde(default)]
     pub hidden_dim: Option<usize>,
 
-    /// Source layer index for KV cache sharing (lalamo PR #197 format)
     #[serde(default)]
     pub kv_source_layer: Option<usize>,
 
-    /// Per-layer PLE config (lalamo PR #197 format)
     #[serde(default)]
     pub ple_config: Option<PLELayerConfig>,
 }

--- a/crates/uzu/src/encodable_block/attention.rs
+++ b/crates/uzu/src/encodable_block/attention.rs
@@ -71,7 +71,9 @@ impl<B: Backend> Attention<B> {
         let mut two_pass_1_kernels = HashMap::new();
         let mut two_pass_2_kernels = HashMap::new();
 
-        for (head_dim, is_trie, is_kv_cache_ring) in iproduct!([64u32, 128u32, 256u32], [false, true], [false, true]) {
+        for (head_dim, is_trie, is_kv_cache_ring) in
+            iproduct!([64u32, 128u32, 256u32, 512u32], [false, true], [false, true])
+        {
             let key = KernelKey {
                 head_dim,
                 is_trie,
@@ -167,6 +169,7 @@ impl<B: Backend> Attention<B> {
         state: &mut ForwardPassState<B>,
         parameters: &EncodingParameters,
         encoder: &mut Encoder<B>,
+        skip_kv_update: bool,
     ) -> Result<(), B::Error> {
         let qkv_array = state.array(ArrayId::QKV);
         let queries_array = state.array(ArrayId::RotatedQueries);
@@ -297,8 +300,10 @@ impl<B: Backend> Attention<B> {
         let sinks_buf_borrow = sinks_buf_rc.as_ref().map(|rc| rc.borrow());
         let sinks_buffer: Option<&B::Buffer> = sinks_buf_borrow.as_ref().map(|b| b.deref());
 
-        // Only update KV cache for LLM mode (not for classifiers)
-        if has_kv_cache {
+        // Only update KV cache for LLM mode (not for classifiers).
+        // Skip for KV-shared layers — their cache buffer is aliased to the source layer's
+        // cache, which was already populated. Writing here would overwrite the source layer's data.
+        if has_kv_cache && !skip_kv_update {
             self.update_kv_cache_kernel.encode(
                 Some(rotated_keys_buf_borrow.deref()),
                 qkv_buf_borrow.deref(),

--- a/crates/uzu/src/encodable_block/classifier_layer.rs
+++ b/crates/uzu/src/encodable_block/classifier_layer.rs
@@ -89,6 +89,7 @@ impl<B: Backend> ClassifierLayer<B> {
                 intermediate_data_type,
                 attention_config.query_norm_config.clone(),
                 attention_config.key_norm_config.clone(),
+                attention_config.value_norm_config.clone(),
                 ArrayId::QKV,
                 &layer_loader.subtree("mixer").unwrap(),
                 num_heads,
@@ -239,7 +240,7 @@ impl<B: Backend> ClassifierLayer<B> {
             qk_norm.encode(state, encoder)?;
         }
         self.rope.encode(state, encoder)?;
-        self.attention.encode(state, parameters, encoder)?;
+        self.attention.encode(state, parameters, encoder, false)?;
         self.out_projection.encode(state, encoder)?;
         #[cfg(feature = "tracing")]
         if let Some(ref layer_traces) = layer_traces {

--- a/crates/uzu/src/encodable_block/decoder.rs
+++ b/crates/uzu/src/encodable_block/decoder.rs
@@ -37,7 +37,6 @@ pub enum DecoderError<B: Backend> {
     EmbeddingError(#[from] EmbeddingError<B>),
 }
 
-/// PLE model-level weights loaded from the weight tree.
 struct PleModelWeights<B: Backend> {
     embed: Option<Embedding<B>>,
     projection: Option<Box<dyn Linear<B>>>,
@@ -62,32 +61,21 @@ impl<B: Backend> Default for PleModelWeights<B> {
     }
 }
 
-/// Full decoder executable with all layers and components.
 pub struct Decoder<B: Backend> {
     pub embed: Embedding<B>,
     pub layers: Box<[LayerExecutables<B>]>,
     pub norm: RMSNorm<B>,
-    /// PLE: per-layer embedding lookup table [vocab_size, ple_total_dim] (embedding index lookup)
     pub ple_embed: Option<Embedding<B>>,
-    /// PLE: model projection [model_dim, ple_dim] (projects main embeddings into PLE space)
     pub ple_projection: Option<Box<dyn Linear<B>>>,
-    /// PLE: RMSNorm kernel for normalizing projected embeddings (norm dim = ple_dim, NOT ple_total_dim)
     ple_norm_kernel: Option<<B::Kernels as KernelsTrait>::RMSNormKernel>,
-    /// PLE: RMSNorm scales buffer [ple_dim] for per-layer-chunk normalization
     ple_norm_scales: Option<Rc<RefCell<B::Buffer>>>,
-    /// PLE: RMSNorm config (epsilon, scale_offset, upcast_mode)
     ple_norm_config: Option<NormalizationConfig>,
-    /// PLE: TensorAddScale kernel for scaling and combining PLE buffers
     ple_scale_kernel: Option<<B::Kernels as KernelsTrait>::TensorAddScaleKernel>,
-    /// PLE: zero-valued bias buffer [ple_total_dim] used for scalar-only multiply via TensorAddScale
+    /// Zero-valued bias buffer used for scalar-only multiply via TensorAddScale: (input + 0) * scale
     ple_zero_bias: Option<Array<B>>,
-    /// PLE: scale applied to the projected embeddings before normalization
     ple_projection_scale: f32,
-    /// PLE: scale applied when combining projection + embedding
     ple_combination_scale: f32,
-    /// PLE: number of layers (needed for RMSNorm batch dimension)
     ple_num_layers: usize,
-    /// PLE: per-layer embedding dimension (normalization dimension)
     ple_dim: usize,
 }
 
@@ -249,6 +237,21 @@ impl<B: Backend> Decoder<B> {
 
                 let layer_loader = decoder_weight_loader.subtree(&format!("layers.{}", layer_index)).unwrap();
 
+                // When the previous layer did an explicit residual add (PLE or layer_scalar),
+                // this layer's pre_attention_norm must NOT fuse a residual add — the
+                // previous layer's output already includes the full residual sum.
+                let previous_layer_did_explicit_residual = if layer_index > 0 {
+                    let prev_has_ple = decoder_config.ple_dim.map_or(false, |d| d > 0);
+                    let prev_has_scalar = decoder_config
+                        .layer_configs
+                        .as_ref()
+                        .and_then(|lcs| lcs.get(layer_index - 1))
+                        .map_or(false, |l| l.has_layer_scalar);
+                    prev_has_ple || prev_has_scalar
+                } else {
+                    false
+                };
+
                 LayerExecutables::new(
                     context,
                     layer_config,
@@ -275,10 +278,15 @@ impl<B: Backend> Decoder<B> {
                         .as_ref()
                         .and_then(|sources| sources.get(layer_index).copied().flatten())
                         .is_some(),
+                    previous_layer_did_explicit_residual,
                 )
             })
             .collect::<Vec<_>>();
 
+        let last_layer_has_ple = decoder_config.ple_dim.map_or(false, |d| d > 0);
+        let last_layer_has_scalar =
+            decoder_config.layer_configs.as_ref().and_then(|lcs| lcs.last()).map_or(false, |l| l.has_layer_scalar);
+        let output_norm_residual_add = !(last_layer_has_ple || last_layer_has_scalar);
         let norm_block = RMSNorm::new(
             context,
             norm_data_type,
@@ -287,7 +295,7 @@ impl<B: Backend> Decoder<B> {
             ArrayId::Main,
             &decoder_weight_loader.subtree("output_norm").unwrap(),
             Some(ArrayId::Shortcut),
-            true,
+            output_norm_residual_add,
         )
         .map(RMSNorm::with_sampling_range)
         .expect("Failed to create output RMS norm kernel");
@@ -314,7 +322,6 @@ impl<B: Backend> Decoder<B> {
 
         let ple_total_dim = decoder_config.num_layers * ple_dim;
 
-        // embed_tokens_per_layer: [vocab_size, ple_total_dim] — embedding index lookup by token ID
         let ple_embed_config = EmbeddingConfig::Untied {
             common: EmbeddingConfigCommon {
                 input_scale: Some(decoder_config.ple_embed_scale.unwrap_or(1.0)),
@@ -332,7 +339,6 @@ impl<B: Backend> Decoder<B> {
         )
         .expect("Failed to create PLE embed_tokens_per_layer");
 
-        // per_layer_model_projection: projects model_dim → ple_total_dim
         let ple_projection = <dyn Linear<B>>::new(
             ple_linear_config,
             false,
@@ -345,11 +351,9 @@ impl<B: Backend> Decoder<B> {
         )
         .expect("Failed to create PLE per_layer_model_projection");
 
-        // per_layer_projection_norm: RMSNorm kernel + scales (norm over ple_dim per layer-chunk)
-        // We use the kernel directly instead of the RMSNorm encodable because:
-        // - The scale weight has [ple_dim=256] elements, not [ple_total_dim=8960]
-        // - We need batch_len = suffix_length * num_layers, not just suffix_length
-        // - The norm operates on [suffix_length * num_layers, ple_dim] reshaped view
+        // We use the kernel directly instead of the RMSNorm encodable because the scale
+        // weight has [ple_dim] elements and we need batch_len = suffix_length * num_layers,
+        // operating on a [suffix_length * num_layers, ple_dim] reshaped view.
         let norm_scales = ple_loader
             .subtree("per_layer_projection_norm")
             .unwrap()
@@ -373,11 +377,9 @@ impl<B: Backend> Decoder<B> {
         )
         .expect("Failed to create PLE RMSNorm kernel");
 
-        // TensorAddScale kernel used for scaling PleProjection and combining PleProjection + PleEmbeddings
         let ple_scale_kernel = <B::Kernels as KernelsTrait>::TensorAddScaleKernel::new(context, ple_data_type)
             .expect("Failed to create TensorAddScale kernel for PLE");
 
-        // Zero-valued bias buffer for scalar-only multiply via TensorAddScale (input + 0) * scale
         let ple_zero_bias = context.create_array_zeros(&[ple_total_dim], ple_data_type, "ple_zero_bias");
 
         PleModelWeights {
@@ -420,16 +422,12 @@ impl<B: Backend> Decoder<B> {
     ) -> Result<(), DecoderError<B>> {
         self.embed.encode_lookup(state, encoder)?;
 
-        // PLE model-level computation: embedding lookup + projection + normalization + combine
         if let (Some(ple_embed), Some(ple_projection)) = (&self.ple_embed, &self.ple_projection) {
-            // Step 1: PLE embedding lookup → PleEmbeddings [seq, ple_total_dim]
-            // input_scale (ple_embed_scale) is applied automatically by the embedding lookup kernel.
             ple_embed.encode_lookup_to(state, encoder, ArrayId::PleEmbeddings)?;
 
-            // Step 2: Project main embeddings → PleProjection [seq, ple_total_dim]
             ple_projection.encode(state, encoder).map_err(DecoderError::BackendError)?;
 
-            // Step 3: Scale PleProjection by ple_projection_scale (in-place via TensorAddScale with zero bias)
+            // Scale PleProjection by ple_projection_scale (in-place via TensorAddScale with zero bias)
             {
                 let ple_proj = state.array(ArrayId::PleProjection);
                 let length = ple_proj.num_elements();
@@ -453,11 +451,9 @@ impl<B: Backend> Decoder<B> {
                 );
             }
 
-            // Step 4: RMSNorm on PleProjection (in-place, BEFORE adding embeddings)
-            // HF: per_layer_projection = per_layer_projection_norm(per_layer_projection)
-            // The norm weight has [ple_dim=256] elements. The buffer is [suffix_length, ple_total_dim=8960].
-            // We treat it as [suffix_length * num_layers, ple_dim] so norm operates over 256 elements
-            // per layer-chunk, matching the HF reshape-then-norm pattern.
+            // RMSNorm on PleProjection. The norm weight has [ple_dim] elements but the buffer
+            // is [suffix_length, ple_total_dim]. We treat it as [suffix_length * num_layers, ple_dim]
+            // so norm operates per layer-chunk, matching the HF reshape-then-norm pattern.
             {
                 let ple_proj = state.array(ArrayId::PleProjection);
                 let ple_norm_kernel = self.ple_norm_kernel.as_ref().unwrap();
@@ -482,8 +478,6 @@ impl<B: Backend> Decoder<B> {
                 );
             }
 
-            // Step 5: Combine (add only): PlePerLayerInputs = PleProjection (now normed) + PleEmbeddings
-            // HF: return (per_layer_projection + per_layer_inputs) * input_scale
             {
                 let ple_proj = state.array(ArrayId::PleProjection);
                 let ple_embed_arr = state.array(ArrayId::PleEmbeddings);
@@ -503,7 +497,6 @@ impl<B: Backend> Decoder<B> {
                 );
             }
 
-            // Step 6: Scale PlePerLayerInputs by ple_combination_scale (0.7071)
             {
                 let ple_combined = state.array(ArrayId::PlePerLayerInputs);
                 let length = ple_combined.num_elements();

--- a/crates/uzu/src/encodable_block/decoder.rs
+++ b/crates/uzu/src/encodable_block/decoder.rs
@@ -1,14 +1,27 @@
 //! Decoder executables - combines embedding, layers, normalization, and readout.
 
-use std::rc::Rc;
+use std::{
+    cell::RefCell,
+    ops::{Deref, DerefMut},
+    rc::Rc,
+};
 
 use thiserror::Error;
 
 use crate::{
     DataType,
-    backends::common::{Backend, Encoder},
-    config::{DecoderConfig, DecoderLayerType, MixerConfig},
-    encodable_block::{Embedding, EncodingParameters, LayerExecutables, RMSNorm, Rope, embedding::EmbeddingError},
+    array::{Array, ArrayContextExt},
+    backends::common::{
+        Backend, Encoder,
+        kernel::{Kernels as KernelsTrait, RMSNormKernel, TensorAddScaleKernel},
+    },
+    config::{
+        DecoderConfig, DecoderLayerType, EmbeddingConfig, EmbeddingConfigCommon, MixerConfig, NormalizationConfig,
+        UpcastMode,
+    },
+    encodable_block::{
+        Embedding, EncodingParameters, LayerExecutables, Linear, RMSNorm, Rope, embedding::EmbeddingError,
+    },
     forward_pass::{
         model_shape::ModelShape,
         state::{ArrayId, ForwardPassState, RopeType},
@@ -24,11 +37,58 @@ pub enum DecoderError<B: Backend> {
     EmbeddingError(#[from] EmbeddingError<B>),
 }
 
+/// PLE model-level weights loaded from the weight tree.
+struct PleModelWeights<B: Backend> {
+    embed: Option<Embedding<B>>,
+    projection: Option<Box<dyn Linear<B>>>,
+    norm_kernel: Option<<B::Kernels as KernelsTrait>::RMSNormKernel>,
+    norm_scales: Option<Rc<RefCell<B::Buffer>>>,
+    norm_config: Option<NormalizationConfig>,
+    scale_kernel: Option<<B::Kernels as KernelsTrait>::TensorAddScaleKernel>,
+    zero_bias: Option<Array<B>>,
+}
+
+impl<B: Backend> Default for PleModelWeights<B> {
+    fn default() -> Self {
+        Self {
+            embed: None,
+            projection: None,
+            norm_kernel: None,
+            norm_scales: None,
+            norm_config: None,
+            scale_kernel: None,
+            zero_bias: None,
+        }
+    }
+}
+
 /// Full decoder executable with all layers and components.
 pub struct Decoder<B: Backend> {
     pub embed: Embedding<B>,
     pub layers: Box<[LayerExecutables<B>]>,
     pub norm: RMSNorm<B>,
+    /// PLE: per-layer embedding lookup table [vocab_size, ple_total_dim] (embedding index lookup)
+    pub ple_embed: Option<Embedding<B>>,
+    /// PLE: model projection [model_dim, ple_dim] (projects main embeddings into PLE space)
+    pub ple_projection: Option<Box<dyn Linear<B>>>,
+    /// PLE: RMSNorm kernel for normalizing projected embeddings (norm dim = ple_dim, NOT ple_total_dim)
+    ple_norm_kernel: Option<<B::Kernels as KernelsTrait>::RMSNormKernel>,
+    /// PLE: RMSNorm scales buffer [ple_dim] for per-layer-chunk normalization
+    ple_norm_scales: Option<Rc<RefCell<B::Buffer>>>,
+    /// PLE: RMSNorm config (epsilon, scale_offset, upcast_mode)
+    ple_norm_config: Option<NormalizationConfig>,
+    /// PLE: TensorAddScale kernel for scaling and combining PLE buffers
+    ple_scale_kernel: Option<<B::Kernels as KernelsTrait>::TensorAddScaleKernel>,
+    /// PLE: zero-valued bias buffer [ple_total_dim] used for scalar-only multiply via TensorAddScale
+    ple_zero_bias: Option<Array<B>>,
+    /// PLE: scale applied to the projected embeddings before normalization
+    ple_projection_scale: f32,
+    /// PLE: scale applied when combining projection + embedding
+    ple_combination_scale: f32,
+    /// PLE: number of layers (needed for RMSNorm batch dimension)
+    ple_num_layers: usize,
+    /// PLE: per-layer embedding dimension (normalization dimension)
+    ple_dim: usize,
 }
 
 impl<B: Backend> Decoder<B> {
@@ -51,10 +111,23 @@ impl<B: Backend> Decoder<B> {
         let (layers, norm) =
             Self::build_transformer_layers_and_norm(context, decoder_config, root_weight_loader, "transformer");
 
+        let ple = Self::load_ple_model_weights(context, decoder_config, root_weight_loader);
+
         Self {
             embed,
             layers,
             norm,
+            ple_embed: ple.embed,
+            ple_projection: ple.projection,
+            ple_norm_kernel: ple.norm_kernel,
+            ple_norm_scales: ple.norm_scales,
+            ple_norm_config: ple.norm_config,
+            ple_scale_kernel: ple.scale_kernel,
+            ple_zero_bias: ple.zero_bias,
+            ple_projection_scale: decoder_config.ple_projection_scale.unwrap_or(1.0),
+            ple_combination_scale: decoder_config.ple_combination_scale.unwrap_or(1.0),
+            ple_num_layers: decoder_config.num_layers,
+            ple_dim: decoder_config.ple_dim.unwrap_or(0),
         }
     }
 
@@ -85,10 +158,23 @@ impl<B: Backend> Decoder<B> {
         let (layers, norm) =
             Self::build_transformer_layers_and_norm(context, decoder_config, root_weight_loader, transformer_subtree);
 
+        let ple = Self::load_ple_model_weights(context, decoder_config, root_weight_loader);
+
         Self {
             embed,
             layers,
             norm,
+            ple_embed: ple.embed,
+            ple_projection: ple.projection,
+            ple_norm_kernel: ple.norm_kernel,
+            ple_norm_scales: ple.norm_scales,
+            ple_norm_config: ple.norm_config,
+            ple_scale_kernel: ple.scale_kernel,
+            ple_zero_bias: ple.zero_bias,
+            ple_projection_scale: decoder_config.ple_projection_scale.unwrap_or(1.0),
+            ple_combination_scale: decoder_config.ple_combination_scale.unwrap_or(1.0),
+            ple_num_layers: decoder_config.num_layers,
+            ple_dim: decoder_config.ple_dim.unwrap_or(0),
         }
     }
 
@@ -169,13 +255,26 @@ impl<B: Backend> Decoder<B> {
                     layer_type,
                     layer_index,
                     decoder_config.model_dim,
-                    decoder_config.hidden_dim,
+                    decoder_config
+                        .hidden_dims
+                        .as_ref()
+                        .map(|dims| dims[layer_index])
+                        .unwrap_or(decoder_config.hidden_dim),
                     decoder_config.num_heads,
                     decoder_config.head_dim,
                     decoder_config.num_groups,
                     decoder_config.attention_scale,
                     &layer_loader,
                     rope_for_layer,
+                    decoder_config.ple_dim,
+                    decoder_config.ple_linear_config.as_ref(),
+                    decoder_config.ple_norm_config.as_ref(),
+                    decoder_config.num_layers,
+                    decoder_config
+                        .kv_shared_layer_sources
+                        .as_ref()
+                        .and_then(|sources| sources.get(layer_index).copied().flatten())
+                        .is_some(),
                 )
             })
             .collect::<Vec<_>>();
@@ -194,6 +293,102 @@ impl<B: Backend> Decoder<B> {
         .expect("Failed to create output RMS norm kernel");
 
         (layers.into_boxed_slice(), norm_block)
+    }
+
+    fn load_ple_model_weights(
+        context: &B::Context,
+        decoder_config: &DecoderConfig,
+        root_weight_loader: &ParameterTree<B::Context>,
+    ) -> PleModelWeights<B> {
+        let ple_dim = match decoder_config.ple_dim {
+            Some(dim) if dim > 0 => dim,
+            _ => return PleModelWeights::default(),
+        };
+        let ple_linear_config =
+            decoder_config.ple_linear_config.as_ref().expect("ple_linear_config required when ple_dim > 0");
+        let ple_norm_config =
+            decoder_config.ple_norm_config.as_ref().expect("ple_norm_config required when ple_dim > 0");
+
+        let ple_loader = root_weight_loader.subtree("ple").expect("PLE subtree not found");
+        let ple_data_type: DataType = ple_linear_config.activation_precision().into();
+
+        let ple_total_dim = decoder_config.num_layers * ple_dim;
+
+        // embed_tokens_per_layer: [vocab_size, ple_total_dim] — embedding index lookup by token ID
+        let ple_embed_config = EmbeddingConfig::Untied {
+            common: EmbeddingConfigCommon {
+                input_scale: Some(decoder_config.ple_embed_scale.unwrap_or(1.0)),
+                logit_soft_cap: None,
+            },
+            precision: ple_linear_config.activation_precision(),
+        };
+
+        let ple_embed = Embedding::new_lookup_only(
+            context,
+            decoder_config.vocab_size as u32,
+            ple_total_dim as u32,
+            &ple_embed_config,
+            &ple_loader.subtree("embed_tokens_per_layer").unwrap(),
+        )
+        .expect("Failed to create PLE embed_tokens_per_layer");
+
+        // per_layer_model_projection: projects model_dim → ple_total_dim
+        let ple_projection = <dyn Linear<B>>::new(
+            ple_linear_config,
+            false,
+            decoder_config.model_dim,
+            [ple_total_dim],
+            context,
+            &ple_loader.subtree("per_layer_model_projection").unwrap(),
+            ArrayId::Main,
+            ArrayId::PleProjection,
+        )
+        .expect("Failed to create PLE per_layer_model_projection");
+
+        // per_layer_projection_norm: RMSNorm kernel + scales (norm over ple_dim per layer-chunk)
+        // We use the kernel directly instead of the RMSNorm encodable because:
+        // - The scale weight has [ple_dim=256] elements, not [ple_total_dim=8960]
+        // - We need batch_len = suffix_length * num_layers, not just suffix_length
+        // - The norm operates on [suffix_length * num_layers, ple_dim] reshaped view
+        let norm_scales = ple_loader
+            .subtree("per_layer_projection_norm")
+            .unwrap()
+            .leaf_array("scales")
+            .expect("Failed to load PLE norm scales");
+        let accumulation_data_type: DataType = ple_norm_config.accumulation_precision.into();
+        let scale_data_type: DataType = ple_norm_config.scale_precision.into();
+        let (input_type, scales_type, output_type) = match ple_norm_config.upcast_mode {
+            UpcastMode::OnlyNormalization => (ple_data_type, scale_data_type, scale_data_type),
+            UpcastMode::FullLayer => (ple_data_type, scale_data_type, scale_data_type),
+        };
+        let ple_norm_kernel = <B::Kernels as KernelsTrait>::RMSNormKernel::new(
+            context,
+            input_type,
+            scales_type,
+            output_type,
+            accumulation_data_type,
+            true,
+            false,
+            false,
+        )
+        .expect("Failed to create PLE RMSNorm kernel");
+
+        // TensorAddScale kernel used for scaling PleProjection and combining PleProjection + PleEmbeddings
+        let ple_scale_kernel = <B::Kernels as KernelsTrait>::TensorAddScaleKernel::new(context, ple_data_type)
+            .expect("Failed to create TensorAddScale kernel for PLE");
+
+        // Zero-valued bias buffer for scalar-only multiply via TensorAddScale (input + 0) * scale
+        let ple_zero_bias = context.create_array_zeros(&[ple_total_dim], ple_data_type, "ple_zero_bias");
+
+        PleModelWeights {
+            embed: Some(ple_embed),
+            projection: Some(ple_projection),
+            norm_kernel: Some(ple_norm_kernel),
+            norm_scales: Some(norm_scales.buffer()),
+            norm_config: Some(ple_norm_config.clone()),
+            scale_kernel: Some(ple_scale_kernel),
+            zero_bias: Some(ple_zero_bias),
+        }
     }
 
     fn create_rope_block(
@@ -224,6 +419,113 @@ impl<B: Backend> Decoder<B> {
         encoder: &mut Encoder<B>,
     ) -> Result<(), DecoderError<B>> {
         self.embed.encode_lookup(state, encoder)?;
+
+        // PLE model-level computation: embedding lookup + projection + normalization + combine
+        if let (Some(ple_embed), Some(ple_projection)) = (&self.ple_embed, &self.ple_projection) {
+            // Step 1: PLE embedding lookup → PleEmbeddings [seq, ple_total_dim]
+            // input_scale (ple_embed_scale) is applied automatically by the embedding lookup kernel.
+            ple_embed.encode_lookup_to(state, encoder, ArrayId::PleEmbeddings)?;
+
+            // Step 2: Project main embeddings → PleProjection [seq, ple_total_dim]
+            ple_projection.encode(state, encoder).map_err(DecoderError::BackendError)?;
+
+            // Step 3: Scale PleProjection by ple_projection_scale (in-place via TensorAddScale with zero bias)
+            {
+                let ple_proj = state.array(ArrayId::PleProjection);
+                let length = ple_proj.num_elements();
+                let zero_bias = self.ple_zero_bias.as_ref().unwrap();
+                let kernel = self.ple_scale_kernel.as_ref().unwrap();
+
+                let proj_buffer_rc = ple_proj.buffer();
+                let mut proj_buffer = proj_buffer_rc.borrow_mut();
+                // TensorAddScale is element-wise, so in-place read/write aliasing is valid.
+                let proj_input: &B::Buffer = unsafe { &*(&*proj_buffer as *const B::Buffer) };
+
+                let num_cols = zero_bias.num_elements() as u32;
+                kernel.encode(
+                    (proj_input, ple_proj.offset()),
+                    &*zero_bias.buffer().borrow(),
+                    (&mut *proj_buffer, ple_proj.offset()),
+                    num_cols,
+                    length as u32,
+                    self.ple_projection_scale,
+                    encoder,
+                );
+            }
+
+            // Step 4: RMSNorm on PleProjection (in-place, BEFORE adding embeddings)
+            // HF: per_layer_projection = per_layer_projection_norm(per_layer_projection)
+            // The norm weight has [ple_dim=256] elements. The buffer is [suffix_length, ple_total_dim=8960].
+            // We treat it as [suffix_length * num_layers, ple_dim] so norm operates over 256 elements
+            // per layer-chunk, matching the HF reshape-then-norm pattern.
+            {
+                let ple_proj = state.array(ArrayId::PleProjection);
+                let ple_norm_kernel = self.ple_norm_kernel.as_ref().unwrap();
+                let ple_norm_scales = self.ple_norm_scales.as_ref().unwrap();
+                let ple_norm_config = self.ple_norm_config.as_ref().unwrap();
+
+                let active_rows = state.active_row_count();
+                let batch_len = (active_rows * self.ple_num_layers) as u32;
+                let element_count = self.ple_dim as u32;
+
+                ple_norm_kernel.encode(
+                    None::<(&B::Buffer, usize)>,
+                    ple_norm_scales.borrow().deref(),
+                    (ple_proj.buffer().borrow_mut().deref_mut(), ple_proj.offset()),
+                    None::<(&mut B::Buffer, usize)>,
+                    batch_len,
+                    element_count,
+                    ple_norm_config.epsilon,
+                    ple_norm_config.scale_offset.unwrap_or(0.0),
+                    ple_norm_config.upcast_mode == UpcastMode::FullLayer,
+                    encoder,
+                );
+            }
+
+            // Step 5: Combine (add only): PlePerLayerInputs = PleProjection (now normed) + PleEmbeddings
+            // HF: return (per_layer_projection + per_layer_inputs) * input_scale
+            {
+                let ple_proj = state.array(ArrayId::PleProjection);
+                let ple_embed_arr = state.array(ArrayId::PleEmbeddings);
+                let ple_combined = state.array(ArrayId::PlePerLayerInputs);
+                let length = ple_proj.num_elements();
+                let kernel = self.ple_scale_kernel.as_ref().unwrap();
+
+                debug_assert_eq!(ple_embed_arr.offset(), 0, "PLE combine assumes zero offset on embeddings bias");
+                kernel.encode(
+                    (&*ple_proj.buffer().borrow(), ple_proj.offset()),
+                    &*ple_embed_arr.buffer().borrow(),
+                    (&mut *ple_combined.buffer().borrow_mut(), ple_combined.offset()),
+                    length as u32,
+                    length as u32,
+                    1.0, // no scale yet — just add
+                    encoder,
+                );
+            }
+
+            // Step 6: Scale PlePerLayerInputs by ple_combination_scale (0.7071)
+            {
+                let ple_combined = state.array(ArrayId::PlePerLayerInputs);
+                let length = ple_combined.num_elements();
+                let zero_bias = self.ple_zero_bias.as_ref().unwrap();
+                let kernel = self.ple_scale_kernel.as_ref().unwrap();
+
+                let combined_buffer_rc = ple_combined.buffer();
+                let mut combined_buffer = combined_buffer_rc.borrow_mut();
+                let combined_input: &B::Buffer = unsafe { &*(&*combined_buffer as *const B::Buffer) };
+
+                let num_cols = zero_bias.num_elements() as u32;
+                kernel.encode(
+                    (combined_input, ple_combined.offset()),
+                    &*zero_bias.buffer().borrow(),
+                    (&mut *combined_buffer, ple_combined.offset()),
+                    num_cols,
+                    length as u32,
+                    self.ple_combination_scale,
+                    encoder,
+                );
+            }
+        }
 
         for layer in self.layers.iter() {
             layer.encode(state, parameters, encoder).map_err(DecoderError::BackendError)?;

--- a/crates/uzu/src/encodable_block/decoder.rs
+++ b/crates/uzu/src/encodable_block/decoder.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 
 use crate::{
     DataType,
-    array::{Array, ArrayContextExt},
+    array::ArrayContextExt,
     backends::common::{
         Backend, Encoder,
         kernel::{Kernels as KernelsTrait, RMSNormKernel, TensorAddScaleKernel},
@@ -38,45 +38,25 @@ pub enum DecoderError<B: Backend> {
 }
 
 struct PleModelWeights<B: Backend> {
-    embed: Option<Embedding<B>>,
-    projection: Option<Box<dyn Linear<B>>>,
-    norm_kernel: Option<<B::Kernels as KernelsTrait>::RMSNormKernel>,
-    norm_scales: Option<Rc<RefCell<B::Buffer>>>,
-    norm_config: Option<NormalizationConfig>,
-    scale_kernel: Option<<B::Kernels as KernelsTrait>::TensorAddScaleKernel>,
-    zero_bias: Option<Array<B>>,
-}
-
-impl<B: Backend> Default for PleModelWeights<B> {
-    fn default() -> Self {
-        Self {
-            embed: None,
-            projection: None,
-            norm_kernel: None,
-            norm_scales: None,
-            norm_config: None,
-            scale_kernel: None,
-            zero_bias: None,
-        }
-    }
+    embed: Embedding<B>,
+    projection: Box<dyn Linear<B>>,
+    norm_kernel: <B::Kernels as KernelsTrait>::RMSNormKernel,
+    norm_scales: Rc<RefCell<B::Buffer>>,
+    norm_config: NormalizationConfig,
+    scale_kernel: <B::Kernels as KernelsTrait>::TensorAddScaleKernel,
+    zero_bias: B::Buffer,
+    zero_bias_len: usize,
+    projection_scale: f32,
+    combination_scale: f32,
+    num_layers: usize,
+    dim: usize,
 }
 
 pub struct Decoder<B: Backend> {
     pub embed: Embedding<B>,
     pub layers: Box<[LayerExecutables<B>]>,
     pub norm: RMSNorm<B>,
-    pub ple_embed: Option<Embedding<B>>,
-    pub ple_projection: Option<Box<dyn Linear<B>>>,
-    ple_norm_kernel: Option<<B::Kernels as KernelsTrait>::RMSNormKernel>,
-    ple_norm_scales: Option<Rc<RefCell<B::Buffer>>>,
-    ple_norm_config: Option<NormalizationConfig>,
-    ple_scale_kernel: Option<<B::Kernels as KernelsTrait>::TensorAddScaleKernel>,
-    /// Zero-valued bias buffer used for scalar-only multiply via TensorAddScale: (input + 0) * scale
-    ple_zero_bias: Option<Array<B>>,
-    ple_projection_scale: f32,
-    ple_combination_scale: f32,
-    ple_num_layers: usize,
-    ple_dim: usize,
+    ple: Option<PleModelWeights<B>>,
 }
 
 impl<B: Backend> Decoder<B> {
@@ -99,23 +79,11 @@ impl<B: Backend> Decoder<B> {
         let (layers, norm) =
             Self::build_transformer_layers_and_norm(context, decoder_config, root_weight_loader, "transformer");
 
-        let ple = Self::load_ple_model_weights(context, decoder_config, root_weight_loader);
-
         Self {
             embed,
             layers,
             norm,
-            ple_embed: ple.embed,
-            ple_projection: ple.projection,
-            ple_norm_kernel: ple.norm_kernel,
-            ple_norm_scales: ple.norm_scales,
-            ple_norm_config: ple.norm_config,
-            ple_scale_kernel: ple.scale_kernel,
-            ple_zero_bias: ple.zero_bias,
-            ple_projection_scale: decoder_config.ple_projection_scale.unwrap_or(1.0),
-            ple_combination_scale: decoder_config.ple_combination_scale.unwrap_or(1.0),
-            ple_num_layers: decoder_config.num_layers,
-            ple_dim: decoder_config.ple_dim.unwrap_or(0),
+            ple: Self::load_ple_model_weights(context, decoder_config, root_weight_loader),
         }
     }
 
@@ -146,23 +114,11 @@ impl<B: Backend> Decoder<B> {
         let (layers, norm) =
             Self::build_transformer_layers_and_norm(context, decoder_config, root_weight_loader, transformer_subtree);
 
-        let ple = Self::load_ple_model_weights(context, decoder_config, root_weight_loader);
-
         Self {
             embed,
             layers,
             norm,
-            ple_embed: ple.embed,
-            ple_projection: ple.projection,
-            ple_norm_kernel: ple.norm_kernel,
-            ple_norm_scales: ple.norm_scales,
-            ple_norm_config: ple.norm_config,
-            ple_scale_kernel: ple.scale_kernel,
-            ple_zero_bias: ple.zero_bias,
-            ple_projection_scale: decoder_config.ple_projection_scale.unwrap_or(1.0),
-            ple_combination_scale: decoder_config.ple_combination_scale.unwrap_or(1.0),
-            ple_num_layers: decoder_config.num_layers,
-            ple_dim: decoder_config.ple_dim.unwrap_or(0),
+            ple: Self::load_ple_model_weights(context, decoder_config, root_weight_loader),
         }
     }
 
@@ -307,10 +263,10 @@ impl<B: Backend> Decoder<B> {
         context: &B::Context,
         decoder_config: &DecoderConfig,
         root_weight_loader: &ParameterTree<B::Context>,
-    ) -> PleModelWeights<B> {
+    ) -> Option<PleModelWeights<B>> {
         let ple_dim = match decoder_config.ple_dim {
             Some(dim) if dim > 0 => dim,
-            _ => return PleModelWeights::default(),
+            _ => return None,
         };
         let ple_linear_config =
             decoder_config.ple_linear_config.as_ref().expect("ple_linear_config required when ple_dim > 0");
@@ -380,17 +336,26 @@ impl<B: Backend> Decoder<B> {
         let ple_scale_kernel = <B::Kernels as KernelsTrait>::TensorAddScaleKernel::new(context, ple_data_type)
             .expect("Failed to create TensorAddScale kernel for PLE");
 
-        let ple_zero_bias = context.create_array_zeros(&[ple_total_dim], ple_data_type, "ple_zero_bias");
+        let ple_zero_bias_arr = context.create_array_zeros(&[ple_total_dim], ple_data_type, "ple_zero_bias");
+        let ple_zero_bias_len = ple_zero_bias_arr.num_elements();
+        let ple_zero_bias_rc = ple_zero_bias_arr.buffer();
+        drop(ple_zero_bias_arr);
+        let ple_zero_bias = Rc::try_unwrap(ple_zero_bias_rc).expect("unique owner").into_inner();
 
-        PleModelWeights {
-            embed: Some(ple_embed),
-            projection: Some(ple_projection),
-            norm_kernel: Some(ple_norm_kernel),
-            norm_scales: Some(norm_scales.buffer()),
-            norm_config: Some(ple_norm_config.clone()),
-            scale_kernel: Some(ple_scale_kernel),
-            zero_bias: Some(ple_zero_bias),
-        }
+        Some(PleModelWeights {
+            embed: ple_embed,
+            projection: ple_projection,
+            norm_kernel: ple_norm_kernel,
+            norm_scales: norm_scales.buffer(),
+            norm_config: ple_norm_config.clone(),
+            scale_kernel: ple_scale_kernel,
+            zero_bias: ple_zero_bias,
+            zero_bias_len: ple_zero_bias_len,
+            projection_scale: decoder_config.ple_projection_scale.unwrap_or(1.0),
+            combination_scale: decoder_config.ple_combination_scale.unwrap_or(1.0),
+            num_layers: decoder_config.num_layers,
+            dim: ple_dim,
+        })
     }
 
     fn create_rope_block(
@@ -422,31 +387,29 @@ impl<B: Backend> Decoder<B> {
     ) -> Result<(), DecoderError<B>> {
         self.embed.encode_lookup(state, encoder)?;
 
-        if let (Some(ple_embed), Some(ple_projection)) = (&self.ple_embed, &self.ple_projection) {
-            ple_embed.encode_lookup_to(state, encoder, ArrayId::PleEmbeddings)?;
+        if let Some(ref ple) = self.ple {
+            ple.embed.encode_lookup_to(state, encoder, ArrayId::PleEmbeddings)?;
 
-            ple_projection.encode(state, encoder).map_err(DecoderError::BackendError)?;
+            ple.projection.encode(state, encoder).map_err(DecoderError::BackendError)?;
 
-            // Scale PleProjection by ple_projection_scale (in-place via TensorAddScale with zero bias)
+            // Scale PleProjection by projection_scale (in-place via TensorAddScale with zero bias)
             {
                 let ple_proj = state.array(ArrayId::PleProjection);
                 let length = ple_proj.num_elements();
-                let zero_bias = self.ple_zero_bias.as_ref().unwrap();
-                let kernel = self.ple_scale_kernel.as_ref().unwrap();
 
                 let proj_buffer_rc = ple_proj.buffer();
                 let mut proj_buffer = proj_buffer_rc.borrow_mut();
                 // TensorAddScale is element-wise, so in-place read/write aliasing is valid.
                 let proj_input: &B::Buffer = unsafe { &*(&*proj_buffer as *const B::Buffer) };
 
-                let num_cols = zero_bias.num_elements() as u32;
-                kernel.encode(
+                let num_cols = ple.zero_bias_len as u32;
+                ple.scale_kernel.encode(
                     (proj_input, ple_proj.offset()),
-                    &*zero_bias.buffer().borrow(),
+                    &ple.zero_bias,
                     (&mut *proj_buffer, ple_proj.offset()),
                     num_cols,
                     length as u32,
-                    self.ple_projection_scale,
+                    ple.projection_scale,
                     encoder,
                 );
             }
@@ -456,24 +419,21 @@ impl<B: Backend> Decoder<B> {
             // so norm operates per layer-chunk, matching the HF reshape-then-norm pattern.
             {
                 let ple_proj = state.array(ArrayId::PleProjection);
-                let ple_norm_kernel = self.ple_norm_kernel.as_ref().unwrap();
-                let ple_norm_scales = self.ple_norm_scales.as_ref().unwrap();
-                let ple_norm_config = self.ple_norm_config.as_ref().unwrap();
 
                 let active_rows = state.active_row_count();
-                let batch_len = (active_rows * self.ple_num_layers) as u32;
-                let element_count = self.ple_dim as u32;
+                let batch_len = (active_rows * ple.num_layers) as u32;
+                let element_count = ple.dim as u32;
 
-                ple_norm_kernel.encode(
+                ple.norm_kernel.encode(
                     None::<(&B::Buffer, usize)>,
-                    ple_norm_scales.borrow().deref(),
+                    ple.norm_scales.borrow().deref(),
                     (ple_proj.buffer().borrow_mut().deref_mut(), ple_proj.offset()),
                     None::<(&mut B::Buffer, usize)>,
                     batch_len,
                     element_count,
-                    ple_norm_config.epsilon,
-                    ple_norm_config.scale_offset.unwrap_or(0.0),
-                    ple_norm_config.upcast_mode == UpcastMode::FullLayer,
+                    ple.norm_config.epsilon,
+                    ple.norm_config.scale_offset.unwrap_or(0.0),
+                    ple.norm_config.upcast_mode == UpcastMode::FullLayer,
                     encoder,
                 );
             }
@@ -483,10 +443,9 @@ impl<B: Backend> Decoder<B> {
                 let ple_embed_arr = state.array(ArrayId::PleEmbeddings);
                 let ple_combined = state.array(ArrayId::PlePerLayerInputs);
                 let length = ple_proj.num_elements();
-                let kernel = self.ple_scale_kernel.as_ref().unwrap();
 
                 debug_assert_eq!(ple_embed_arr.offset(), 0, "PLE combine assumes zero offset on embeddings bias");
-                kernel.encode(
+                ple.scale_kernel.encode(
                     (&*ple_proj.buffer().borrow(), ple_proj.offset()),
                     &*ple_embed_arr.buffer().borrow(),
                     (&mut *ple_combined.buffer().borrow_mut(), ple_combined.offset()),
@@ -500,21 +459,19 @@ impl<B: Backend> Decoder<B> {
             {
                 let ple_combined = state.array(ArrayId::PlePerLayerInputs);
                 let length = ple_combined.num_elements();
-                let zero_bias = self.ple_zero_bias.as_ref().unwrap();
-                let kernel = self.ple_scale_kernel.as_ref().unwrap();
 
                 let combined_buffer_rc = ple_combined.buffer();
                 let mut combined_buffer = combined_buffer_rc.borrow_mut();
                 let combined_input: &B::Buffer = unsafe { &*(&*combined_buffer as *const B::Buffer) };
 
-                let num_cols = zero_bias.num_elements() as u32;
-                kernel.encode(
+                let num_cols = ple.zero_bias_len as u32;
+                ple.scale_kernel.encode(
                     (combined_input, ple_combined.offset()),
-                    &*zero_bias.buffer().borrow(),
+                    &ple.zero_bias,
                     (&mut *combined_buffer, ple_combined.offset()),
                     num_cols,
                     length as u32,
-                    self.ple_combination_scale,
+                    ple.combination_scale,
                     encoder,
                 );
             }

--- a/crates/uzu/src/encodable_block/embedding.rs
+++ b/crates/uzu/src/encodable_block/embedding.rs
@@ -93,6 +93,9 @@ enum EmbeddingTying<B: Backend> {
         input_ty: UntiedEmbeddingLookupType<B>,
         output_ty: UntiedEmbeddingReadoutType<B>,
     },
+    LookupOnly {
+        input_ty: UntiedEmbeddingLookupType<B>,
+    },
 }
 
 pub struct Embedding<B: Backend> {
@@ -483,10 +486,76 @@ impl<B: Backend> Embedding<B> {
         })
     }
 
+    /// Creates a lookup-only embedding (no readout weights).
+    /// Used for PLE embed_tokens_per_layer which only needs index-based lookup.
+    pub fn new_lookup_only(
+        context: &B::Context,
+        vocab_size: u32,
+        embedding_dim: u32,
+        config: &EmbeddingConfig,
+        parameter_tree: &ParameterTree<B::Context>,
+    ) -> Result<Self, EmbeddingError<B>> {
+        let common = config.common();
+
+        let tying = match config {
+            EmbeddingConfig::Tied {
+                common: _,
+                precision,
+            }
+            | EmbeddingConfig::Untied {
+                common: _,
+                precision,
+            } => {
+                let data_type = (*precision).into();
+
+                let weights_leaf = parameter_tree.leaf("weights")?;
+                validate_tensor(&weights_leaf, [vocab_size as usize, embedding_dim as usize], data_type)?;
+                let weights = weights_leaf.read_buffer()?;
+
+                let lookup = <B::Kernels as Kernels>::FullPrecisionEmbeddingLookupKernel::new(context, data_type)
+                    .map_err(EmbeddingError::BackendError)?;
+
+                EmbeddingTying::LookupOnly {
+                    input_ty: UntiedEmbeddingLookupType::FullPrecision {
+                        weights,
+                        lookup,
+                    },
+                }
+            },
+            _ => {
+                return Err(EmbeddingError::UnsupportedConfiguration(
+                    "new_lookup_only only supports Tied/Untied full-precision configs".to_string(),
+                ));
+            },
+        };
+
+        let input_scale = common.input_scale.unwrap_or(1.0);
+
+        if let Some(logit_soft_cap) = common.logit_soft_cap {
+            return Err(EmbeddingError::UnsupportedConfiguration(format!("logit_soft_cap={logit_soft_cap:?}")));
+        }
+
+        Ok(Self {
+            tying,
+            input_scale,
+            vocab_size,
+            model_dim: embedding_dim,
+        })
+    }
+
     pub fn encode_lookup(
         &self,
         state: &mut ForwardPassState<B>,
         encoder: &mut Encoder<B>,
+    ) -> Result<(), EmbeddingError<B>> {
+        self.encode_lookup_to(state, encoder, ArrayId::Main)
+    }
+
+    pub fn encode_lookup_to(
+        &self,
+        state: &mut ForwardPassState<B>,
+        encoder: &mut Encoder<B>,
+        output_array_id: ArrayId,
     ) -> Result<(), EmbeddingError<B>> {
         let batch_dim = state.active_row_count() as u32;
 
@@ -495,7 +564,7 @@ impl<B: Backend> Embedding<B> {
         let token_ids_buffer_borrow = token_ids_buffer_rc.borrow();
         let token_ids = token_ids_buffer_borrow.deref();
 
-        let output_array = state.array(ArrayId::Main);
+        let output_array = state.array(output_array_id);
         let output_buffer_rc = output_array.buffer();
         let mut output_buffer_borrow = output_buffer_rc.borrow_mut();
         let output = output_buffer_borrow.deref_mut();
@@ -516,6 +585,13 @@ impl<B: Backend> Embedding<B> {
                         lookup,
                     },
                 output_ty: _,
+            }
+            | EmbeddingTying::LookupOnly {
+                input_ty:
+                    UntiedEmbeddingLookupType::FullPrecision {
+                        weights,
+                        lookup,
+                    },
             } => lookup.encode(
                 token_ids,
                 weights,
@@ -545,6 +621,15 @@ impl<B: Backend> Embedding<B> {
                         lookup,
                     },
                 output_ty: _,
+            }
+            | EmbeddingTying::LookupOnly {
+                input_ty:
+                    UntiedEmbeddingLookupType::Quantized {
+                        weights,
+                        scales,
+                        biases,
+                        lookup,
+                    },
             } => {
                 lookup.encode(
                     token_ids,
@@ -654,6 +739,13 @@ impl<B: Backend> Embedding<B> {
                         batch_dim,
                     },
                 )?;
+            },
+            EmbeddingTying::LookupOnly {
+                ..
+            } => {
+                return Err(EmbeddingError::UnsupportedConfiguration(
+                    "encode_readout called on a LookupOnly embedding (no readout weights loaded)".to_string(),
+                ));
             },
         };
 

--- a/crates/uzu/src/encodable_block/layer/executables.rs
+++ b/crates/uzu/src/encodable_block/layer/executables.rs
@@ -35,38 +35,28 @@ pub struct LayerExecutables<B: Backend> {
     pub pre_mlp_norm: RMSNorm<B>,
     pub mlp: Box<dyn Mlp<B>>,
     pub post_mlp_norm: Option<RMSNorm<B>>,
-    /// PLE: gate projection (model_dim -> ple_dim), applied to hidden_states within layer
+    /// Explicit residual add for layers with PLE/scalar. These must operate on the full
+    /// residual sum (input + attn + mlp), so the normally-deferred MLP residual add is
+    /// performed here instead of in the next layer's pre_attention_norm.
+    mlp_residual_add: Option<TensorAddSwap<B>>,
     pub ple_gate: Option<Box<dyn Linear<B>>>,
-    /// PLE: projection back (ple_dim -> model_dim), applied after gating
     pub ple_projection: Option<Box<dyn Linear<B>>>,
-    /// PLE: RMSNorm applied after PLE projection, before residual add
     pub post_ple_norm: Option<RMSNorm<B>>,
-    /// PLE: GELU activation applied to PleGate buffer
     ple_activation: Option<Activation<B>>,
-    /// PLE: element-wise multiply kernel for strided PLE per-layer inputs
     ple_mul_strided_kernel: Option<<B::Kernels as Kernels>::ElementWiseMulStridedKernel>,
-    /// PLE: residual add after PLE injection (Main = PLE_output + Shortcut)
     ple_add_swap: Option<TensorAddSwap<B>>,
-    /// PLE: dimension of per-layer embedding
     ple_dim: usize,
-    /// PLE: total dimension across all layers (num_layers * ple_dim)
     ple_total_dim: usize,
-    /// Per-layer learnable scalar applied after all operations (Gemma 4).
-    /// Stored as f32 for use as the scale parameter in TensorAddScale.
     layer_scalar: f32,
-    /// TensorAddScale kernel for applying layer_scalar (only created when needed)
     layer_scalar_kernel: Option<<B::Kernels as Kernels>::TensorAddScaleKernel>,
-    /// Zero-bias buffer [model_dim] for scalar-only multiply via TensorAddScale: (input + 0) * scale
+    /// Zero-bias buffer for scalar-only multiply via TensorAddScale: (input + 0) * scale
     layer_scalar_zero_bias: Option<Array<B>>,
-    /// Model dimension, needed for num_cols when encoding layer_scalar
     model_dim: usize,
-    /// Per-layer attention dimensions for buffer reshaping (num_heads, num_groups, head_dim).
-    /// These are the actual dimensions for this layer's attention, which may differ from the
-    /// max dimensions used for buffer allocation.
+    /// Per-layer attention dimensions for buffer reshaping. May differ from the max
+    /// dimensions used for buffer allocation.
     attention_num_heads: usize,
     attention_num_groups: usize,
     attention_head_dim: usize,
-    /// Whether this layer uses shared KV cache from another layer.
     /// When true, the KV cache update is skipped to avoid overwriting the source layer's cache.
     is_kv_shared_layer: bool,
 }
@@ -91,6 +81,7 @@ impl<B: Backend> LayerExecutables<B> {
         ple_norm_config: Option<&NormalizationConfig>,
         num_layers: usize,
         is_kv_shared_layer: bool,
+        previous_layer_did_explicit_residual: bool,
     ) -> Self {
         let intermediate_data_type: DataType = match &layer_config.mixer_config {
             MixerConfig::Attention(attention) => attention.qkv_projection_config.activation_precision().into(),
@@ -103,6 +94,7 @@ impl<B: Backend> LayerExecutables<B> {
         let tensor_add = TensorAddBiasKernel::new(context, intermediate_data_type, false)
             .expect("Failed to create TensorAddBiasKernel kernel"); // TODO: this function return Result
 
+        let fused_residual_add = layer_index > 0 && !previous_layer_did_explicit_residual;
         let pre_attention_norm = RMSNorm::new(
             context,
             intermediate_data_type,
@@ -111,11 +103,10 @@ impl<B: Backend> LayerExecutables<B> {
             ArrayId::Main,
             &decoder_layer_loader.subtree("pre_mixer_norm").unwrap(),
             Some(ArrayId::Shortcut),
-            layer_index > 0,
+            fused_residual_add,
         )
         .expect("Failed to create RMS norm kernel");
 
-        // Extract per-layer attention dimensions (defaults for non-attention layers)
         let (attn_num_heads, attn_num_groups, attn_head_dim) = match &layer_config.mixer_config {
             MixerConfig::Attention(attention_config) => (
                 attention_config.num_heads.unwrap_or(num_heads),
@@ -400,7 +391,16 @@ impl<B: Backend> LayerExecutables<B> {
             _ => (None, None, None, None, None, None, 0, 0),
         };
 
-        // Load per-layer scalar if configured (Gemma 4)
+        let has_ple = ple_gate.is_some();
+        let mlp_residual_add = if has_ple || layer_config.has_layer_scalar {
+            Some(
+                TensorAddSwap::new(context, intermediate_data_type, ArrayId::Shortcut, ArrayId::Main)
+                    .expect("Failed to create MLP residual add-swap"),
+            )
+        } else {
+            None
+        };
+
         let (layer_scalar, layer_scalar_kernel, layer_scalar_zero_bias) = if layer_config.has_layer_scalar {
             let scalar_array =
                 decoder_layer_loader.leaf_array("layer_scalar").expect("Failed to load layer_scalar weight");
@@ -445,6 +445,7 @@ impl<B: Backend> LayerExecutables<B> {
             pre_mlp_norm,
             mlp,
             post_mlp_norm,
+            mlp_residual_add,
             ple_gate,
             ple_projection,
             post_ple_norm,
@@ -480,7 +481,6 @@ impl<B: Backend> LayerExecutables<B> {
             state.encode_copy_array(encoder, ArrayId::Main, layer_traces.borrow().pre_attention_norm.clone());
         }
 
-        // Reshape shared rotated Q/K/V and attention buffers to this layer's dimensions.
         // Buffers are allocated with max dims; each layer views the subset it needs.
         if matches!(&self.mixer, MixerExecutables::Attention { .. }) {
             let suffix_length = state.active_row_count();
@@ -574,10 +574,7 @@ impl<B: Backend> LayerExecutables<B> {
                 state.encode_copy_array(encoder, ArrayId::Main, layer_traces.borrow().post_attention_norm.clone());
             }
         }
-        // main = attention_result
-
         self.pre_mlp_norm.encode(state, encoder)?;
-        // shortcut = attention_result + shortcut; main = normalized(shortcut)
         #[cfg(feature = "tracing")]
         if let Some(ref layer_traces) = layer_traces {
             state.encode_copy_array(encoder, ArrayId::Shortcut, layer_traces.borrow().mlp_inputs.clone());
@@ -597,8 +594,9 @@ impl<B: Backend> LayerExecutables<B> {
                 state.encode_copy_array(encoder, ArrayId::Main, layer_traces.borrow().post_mlp_norm.clone());
             }
         }
-        // main = mlp_result
-        // next layer's pre_attention_norm (or output_norm) fuses the residual add
+        if let Some(ref residual_add) = self.mlp_residual_add {
+            residual_add.encode(state, encoder)?;
+        }
 
         if let (Some(ple_gate), Some(ple_projection), Some(post_ple_norm), Some(ple_activation), Some(ple_mul_kernel)) = (
             &self.ple_gate,
@@ -607,13 +605,10 @@ impl<B: Backend> LayerExecutables<B> {
             &self.ple_activation,
             &self.ple_mul_strided_kernel,
         ) {
-            // Step 1: Gate projection: Main → PleGate [seq, ple_dim]
             ple_gate.encode(state, encoder)?;
-
-            // Step 2: GELU activation on PleGate (in-place)
             ple_activation.encode(state, encoder)?;
 
-            // Step 3: Element-wise multiply PleGate * PlePerLayerInputs[layer_i] (strided)
+            // Element-wise multiply PleGate * PlePerLayerInputs[layer_i] (strided)
             {
                 let ple_gate_arr = state.array(ArrayId::PleGate);
                 let ple_inputs = state.array(ArrayId::PlePerLayerInputs);
@@ -639,17 +634,11 @@ impl<B: Backend> LayerExecutables<B> {
                 );
             }
 
-            // Step 4: Project gated PLE back to model_dim: PleGate → Main
             ple_projection.encode(state, encoder)?;
-
-            // Step 5: Post-PLE norm on Main
             post_ple_norm.encode(state, encoder)?;
-
-            // Step 6: Residual add: Main = PLE_output + pre-PLE hidden_states (in Shortcut)
             self.ple_add_swap.as_ref().unwrap().encode(state, encoder)?;
         }
 
-        // Apply per-layer scalar: hidden_states *= layer_scalar (Gemma 4)
         if let (Some(kernel), Some(zero_bias)) = (&self.layer_scalar_kernel, &self.layer_scalar_zero_bias) {
             let main = state.array(ArrayId::Main);
             let length = main.num_elements();
@@ -674,17 +663,22 @@ impl<B: Backend> LayerExecutables<B> {
         #[cfg(feature = "tracing")]
         if let Some(ref layer_traces) = layer_traces {
             let size = state.array(ArrayId::Main).shape().into_iter().copied().product::<usize>() as u32;
-            let input_a = state.array(ArrayId::Main).buffer();
-            let input_b = state.array(ArrayId::Shortcut).buffer();
             let output = layer_traces.borrow().outputs.buffer();
-            self.tensor_add.encode(
-                Some(input_a.borrow().deref()),
-                input_b.borrow().deref(),
-                output.borrow_mut().deref_mut(),
-                size,
-                size,
-                encoder,
-            );
+
+            if self.mlp_residual_add.is_some() {
+                state.encode_copy_array(encoder, ArrayId::Main, layer_traces.borrow().outputs.clone());
+            } else {
+                let input_a = state.array(ArrayId::Main).buffer();
+                let input_b = state.array(ArrayId::Shortcut).buffer();
+                self.tensor_add.encode(
+                    Some(input_a.borrow().deref()),
+                    input_b.borrow().deref(),
+                    output.borrow_mut().deref_mut(),
+                    size,
+                    size,
+                    encoder,
+                );
+            }
         }
 
         Ok(())

--- a/crates/uzu/src/encodable_block/layer/executables.rs
+++ b/crates/uzu/src/encodable_block/layer/executables.rs
@@ -9,7 +9,7 @@ use super::MixerExecutables;
 use crate::backends::common::kernel::TensorAddBiasKernel;
 use crate::{
     DataType,
-    array::{Array, ArrayContextExt},
+    array::ArrayContextExt,
     backends::common::{
         ActivationConfig, Backend, Encoder, Kernels,
         kernel::{ElementWiseMulStridedKernel, TensorAddScaleKernel},
@@ -22,6 +22,17 @@ use crate::{
     forward_pass::state::{ArrayId, ForwardPassState},
     parameters::ParameterTree,
 };
+
+struct PleLayerComponents<B: Backend> {
+    gate: Box<dyn Linear<B>>,
+    projection: Box<dyn Linear<B>>,
+    post_norm: RMSNorm<B>,
+    activation: Activation<B>,
+    mul_strided_kernel: <B::Kernels as Kernels>::ElementWiseMulStridedKernel,
+    add_swap: TensorAddSwap<B>,
+    dim: usize,
+    total_dim: usize,
+}
 
 /// A single decoder layer with all its components.
 pub struct LayerExecutables<B: Backend> {
@@ -39,18 +50,11 @@ pub struct LayerExecutables<B: Backend> {
     /// residual sum (input + attn + mlp), so the normally-deferred MLP residual add is
     /// performed here instead of in the next layer's pre_attention_norm.
     mlp_residual_add: Option<TensorAddSwap<B>>,
-    pub ple_gate: Option<Box<dyn Linear<B>>>,
-    pub ple_projection: Option<Box<dyn Linear<B>>>,
-    pub post_ple_norm: Option<RMSNorm<B>>,
-    ple_activation: Option<Activation<B>>,
-    ple_mul_strided_kernel: Option<<B::Kernels as Kernels>::ElementWiseMulStridedKernel>,
-    ple_add_swap: Option<TensorAddSwap<B>>,
-    ple_dim: usize,
-    ple_total_dim: usize,
+    ple: Option<PleLayerComponents<B>>,
     layer_scalar: f32,
     layer_scalar_kernel: Option<<B::Kernels as Kernels>::TensorAddScaleKernel>,
     /// Zero-bias buffer for scalar-only multiply via TensorAddScale: (input + 0) * scale
-    layer_scalar_zero_bias: Option<Array<B>>,
+    layer_scalar_zero_bias: Option<B::Buffer>,
     model_dim: usize,
     /// Per-layer attention dimensions for buffer reshaping. May differ from the max
     /// dimensions used for buffer allocation.
@@ -315,16 +319,7 @@ impl<B: Backend> LayerExecutables<B> {
             None
         };
 
-        let (
-            ple_gate,
-            ple_projection,
-            post_ple_norm,
-            ple_activation,
-            ple_mul_strided_kernel,
-            ple_add_swap,
-            ple_dim_val,
-            ple_total_dim_val,
-        ) = match (ple_dim, ple_linear_config, ple_norm_config) {
+        let ple = match (ple_dim, ple_linear_config, ple_norm_config) {
             (Some(ple_dim), Some(linear_config), Some(norm_config)) if ple_dim > 0 => {
                 let ple_data_type: DataType = linear_config.activation_precision().into();
 
@@ -352,7 +347,7 @@ impl<B: Backend> LayerExecutables<B> {
                 )
                 .expect("Failed to create PLE projection");
 
-                let norm = RMSNorm::new(
+                let post_norm = RMSNorm::new(
                     context,
                     ple_data_type,
                     norm_config.clone(),
@@ -377,21 +372,21 @@ impl<B: Backend> LayerExecutables<B> {
                 let add_swap = TensorAddSwap::new(context, ple_data_type, ArrayId::Shortcut, ArrayId::Main)
                     .expect("Failed to create PLE add-swap");
 
-                (
-                    Some(gate),
-                    Some(projection),
-                    Some(norm),
-                    Some(activation),
-                    Some(mul_strided_kernel),
-                    Some(add_swap),
-                    ple_dim,
-                    ple_total_dim,
-                )
+                Some(PleLayerComponents {
+                    gate,
+                    projection,
+                    post_norm,
+                    activation,
+                    mul_strided_kernel,
+                    add_swap,
+                    dim: ple_dim,
+                    total_dim: ple_total_dim,
+                })
             },
-            _ => (None, None, None, None, None, None, 0, 0),
+            _ => None,
         };
 
-        let has_ple = ple_gate.is_some();
+        let has_ple = ple.is_some();
         let mlp_residual_add = if has_ple || layer_config.has_layer_scalar {
             Some(
                 TensorAddSwap::new(context, intermediate_data_type, ArrayId::Shortcut, ArrayId::Main)
@@ -419,14 +414,17 @@ impl<B: Backend> LayerExecutables<B> {
                     let bytes = scalar_array.as_bytes();
                     f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
                 },
-                dt => panic!("Unsupported data type {:?} for layer_scalar", dt),
+                dt => panic!("Failed to decode layer_scalar weight: unsupported data type {dt:?}"),
             };
 
             if (scalar_value - 1.0).abs() > f32::EPSILON {
                 let kernel = <B::Kernels as Kernels>::TensorAddScaleKernel::new(context, intermediate_data_type)
                     .expect("Failed to create TensorAddScale kernel for layer_scalar");
-                let zero_bias =
+                let zero_bias_arr =
                     context.create_array_zeros(&[model_dim], intermediate_data_type, "layer_scalar_zero_bias");
+                let zero_bias_rc = zero_bias_arr.buffer();
+                drop(zero_bias_arr);
+                let zero_bias = Rc::try_unwrap(zero_bias_rc).expect("unique owner").into_inner();
                 (scalar_value, Some(kernel), Some(zero_bias))
             } else {
                 (scalar_value, None, None)
@@ -446,14 +444,7 @@ impl<B: Backend> LayerExecutables<B> {
             mlp,
             post_mlp_norm,
             mlp_residual_add,
-            ple_gate,
-            ple_projection,
-            post_ple_norm,
-            ple_activation,
-            ple_mul_strided_kernel,
-            ple_add_swap,
-            ple_dim: ple_dim_val,
-            ple_total_dim: ple_total_dim_val,
+            ple,
             layer_scalar,
             layer_scalar_kernel,
             layer_scalar_zero_bias,
@@ -484,25 +475,28 @@ impl<B: Backend> LayerExecutables<B> {
         // Buffers are allocated with max dims; each layer views the subset it needs.
         if matches!(&self.mixer, MixerExecutables::Attention { .. }) {
             let suffix_length = state.active_row_count();
-            let nh = self.attention_num_heads;
-            let ng = self.attention_num_groups;
-            let hd = self.attention_head_dim;
+            let num_heads = self.attention_num_heads;
+            let num_groups = self.attention_num_groups;
+            let head_dim = self.attention_head_dim;
 
-            state.common_aux.rotated_queries = state.common_aux.rotated_queries.view(&[nh, suffix_length, hd]);
-            state.common_aux.rotated_keys = state.common_aux.rotated_keys.view(&[ng, suffix_length, hd]);
-            state.common_aux.extracted_values = state.common_aux.extracted_values.view(&[ng, suffix_length, hd]);
-            state.common_aux.attention_output = state.common_aux.attention_output.view(&[suffix_length, nh * hd]);
+            state.common_aux.rotated_queries =
+                state.common_aux.rotated_queries.view(&[num_heads, suffix_length, head_dim]);
+            state.common_aux.rotated_keys = state.common_aux.rotated_keys.view(&[num_groups, suffix_length, head_dim]);
+            state.common_aux.extracted_values =
+                state.common_aux.extracted_values.view(&[num_groups, suffix_length, head_dim]);
+            state.common_aux.attention_output =
+                state.common_aux.attention_output.view(&[suffix_length, num_heads * head_dim]);
 
             const TOTAL_BLOCKS_COUNT: usize = 32;
             state.common_aux.attention_partials =
-                state.common_aux.attention_partials.view(&[nh * suffix_length * TOTAL_BLOCKS_COUNT * hd]);
+                state.common_aux.attention_partials.view(&[num_heads * suffix_length * TOTAL_BLOCKS_COUNT * head_dim]);
             state.common_aux.attention_sums =
-                state.common_aux.attention_sums.view(&[nh * suffix_length * TOTAL_BLOCKS_COUNT]);
+                state.common_aux.attention_sums.view(&[num_heads * suffix_length * TOTAL_BLOCKS_COUNT]);
             state.common_aux.attention_maxs =
-                state.common_aux.attention_maxs.view(&[nh * suffix_length * TOTAL_BLOCKS_COUNT]);
+                state.common_aux.attention_maxs.view(&[num_heads * suffix_length * TOTAL_BLOCKS_COUNT]);
 
             if let Some(ref gate) = state.common_aux.gate {
-                state.common_aux.gate = Some(gate.view(&[suffix_length, nh * hd]));
+                state.common_aux.gate = Some(gate.view(&[suffix_length, num_heads * head_dim]));
             }
         }
 
@@ -598,22 +592,15 @@ impl<B: Backend> LayerExecutables<B> {
             residual_add.encode(state, encoder)?;
         }
 
-        if let (Some(ple_gate), Some(ple_projection), Some(post_ple_norm), Some(ple_activation), Some(ple_mul_kernel)) = (
-            &self.ple_gate,
-            &self.ple_projection,
-            &self.post_ple_norm,
-            &self.ple_activation,
-            &self.ple_mul_strided_kernel,
-        ) {
-            ple_gate.encode(state, encoder)?;
-            ple_activation.encode(state, encoder)?;
+        if let Some(ref ple) = self.ple {
+            ple.gate.encode(state, encoder)?;
+            ple.activation.encode(state, encoder)?;
 
             // Element-wise multiply PleGate * PlePerLayerInputs[layer_i] (strided)
             {
                 let ple_gate_arr = state.array(ArrayId::PleGate);
                 let ple_inputs = state.array(ArrayId::PlePerLayerInputs);
                 let rows = ple_gate_arr.shape()[0] as u32; // suffix_length
-                let kernel = ple_mul_kernel;
 
                 // PleGate is both input_a and output (in-place mul).
                 // This is safe because ElementWiseMulStrided reads input_a[row * ple_dim + col]
@@ -622,21 +609,21 @@ impl<B: Backend> LayerExecutables<B> {
                 let mut ple_gate_buffer = ple_gate_buffer_rc.borrow_mut();
                 let ple_gate_input: &B::Buffer = unsafe { &*(&*ple_gate_buffer as *const B::Buffer) };
 
-                kernel.encode(
+                ple.mul_strided_kernel.encode(
                     ple_gate_input,
                     &*ple_inputs.buffer().borrow(),
                     &mut *ple_gate_buffer,
-                    self.ple_dim as u32,
-                    self.ple_total_dim as u32,
-                    (self.layer_index * self.ple_dim) as u32,
+                    ple.dim as u32,
+                    ple.total_dim as u32,
+                    (self.layer_index * ple.dim) as u32,
                     rows,
                     encoder,
                 );
             }
 
-            ple_projection.encode(state, encoder)?;
-            post_ple_norm.encode(state, encoder)?;
-            self.ple_add_swap.as_ref().unwrap().encode(state, encoder)?;
+            ple.projection.encode(state, encoder)?;
+            ple.post_norm.encode(state, encoder)?;
+            ple.add_swap.encode(state, encoder)?;
         }
 
         if let (Some(kernel), Some(zero_bias)) = (&self.layer_scalar_kernel, &self.layer_scalar_zero_bias) {
@@ -651,7 +638,7 @@ impl<B: Backend> LayerExecutables<B> {
             let num_cols = self.model_dim as u32;
             kernel.encode(
                 (main_input, main.offset()),
-                &*zero_bias.buffer().borrow(),
+                zero_bias,
                 (&mut *main_buffer, main.offset()),
                 num_cols,
                 length as u32,

--- a/crates/uzu/src/encodable_block/layer/executables.rs
+++ b/crates/uzu/src/encodable_block/layer/executables.rs
@@ -6,13 +6,18 @@ use std::rc::Rc;
 
 use super::MixerExecutables;
 #[cfg(feature = "tracing")]
-use crate::backends::common::{Kernels, kernel::TensorAddBiasKernel};
+use crate::backends::common::kernel::TensorAddBiasKernel;
 use crate::{
     DataType,
-    backends::common::{Backend, Encoder},
-    config::{DecoderLayerConfig, DecoderLayerType, MixerConfig},
+    array::{Array, ArrayContextExt},
+    backends::common::{
+        ActivationConfig, Backend, Encoder, Kernels,
+        kernel::{ElementWiseMulStridedKernel, TensorAddScaleKernel},
+    },
+    config::{DecoderLayerConfig, DecoderLayerType, LinearConfig, MixerConfig, NormalizationConfig},
     encodable_block::{
-        Attention, DeltaNetMixer, EncodingParameters, Linear, MambaMixer, Mlp, QKNorm, RMSNorm, Rope, ShortConvMixer,
+        Activation, Attention, DeltaNetMixer, EncodingParameters, Linear, MambaMixer, Mlp, QKNorm, RMSNorm, Rope,
+        ShortConvMixer, TensorAddSwap,
     },
     forward_pass::state::{ArrayId, ForwardPassState},
     parameters::ParameterTree,
@@ -20,7 +25,7 @@ use crate::{
 
 /// A single decoder layer with all its components.
 pub struct LayerExecutables<B: Backend> {
-    #[cfg(feature = "tracing")]
+    #[allow(dead_code)]
     pub layer_index: usize,
     #[cfg(feature = "tracing")]
     pub tensor_add: <B::Kernels as Kernels>::TensorAddBiasKernel,
@@ -30,6 +35,40 @@ pub struct LayerExecutables<B: Backend> {
     pub pre_mlp_norm: RMSNorm<B>,
     pub mlp: Box<dyn Mlp<B>>,
     pub post_mlp_norm: Option<RMSNorm<B>>,
+    /// PLE: gate projection (model_dim -> ple_dim), applied to hidden_states within layer
+    pub ple_gate: Option<Box<dyn Linear<B>>>,
+    /// PLE: projection back (ple_dim -> model_dim), applied after gating
+    pub ple_projection: Option<Box<dyn Linear<B>>>,
+    /// PLE: RMSNorm applied after PLE projection, before residual add
+    pub post_ple_norm: Option<RMSNorm<B>>,
+    /// PLE: GELU activation applied to PleGate buffer
+    ple_activation: Option<Activation<B>>,
+    /// PLE: element-wise multiply kernel for strided PLE per-layer inputs
+    ple_mul_strided_kernel: Option<<B::Kernels as Kernels>::ElementWiseMulStridedKernel>,
+    /// PLE: residual add after PLE injection (Main = PLE_output + Shortcut)
+    ple_add_swap: Option<TensorAddSwap<B>>,
+    /// PLE: dimension of per-layer embedding
+    ple_dim: usize,
+    /// PLE: total dimension across all layers (num_layers * ple_dim)
+    ple_total_dim: usize,
+    /// Per-layer learnable scalar applied after all operations (Gemma 4).
+    /// Stored as f32 for use as the scale parameter in TensorAddScale.
+    layer_scalar: f32,
+    /// TensorAddScale kernel for applying layer_scalar (only created when needed)
+    layer_scalar_kernel: Option<<B::Kernels as Kernels>::TensorAddScaleKernel>,
+    /// Zero-bias buffer [model_dim] for scalar-only multiply via TensorAddScale: (input + 0) * scale
+    layer_scalar_zero_bias: Option<Array<B>>,
+    /// Model dimension, needed for num_cols when encoding layer_scalar
+    model_dim: usize,
+    /// Per-layer attention dimensions for buffer reshaping (num_heads, num_groups, head_dim).
+    /// These are the actual dimensions for this layer's attention, which may differ from the
+    /// max dimensions used for buffer allocation.
+    attention_num_heads: usize,
+    attention_num_groups: usize,
+    attention_head_dim: usize,
+    /// Whether this layer uses shared KV cache from another layer.
+    /// When true, the KV cache update is skipped to avoid overwriting the source layer's cache.
+    is_kv_shared_layer: bool,
 }
 
 impl<B: Backend> LayerExecutables<B> {
@@ -47,6 +86,11 @@ impl<B: Backend> LayerExecutables<B> {
         attention_scale: Option<f32>,
         decoder_layer_loader: &ParameterTree<B::Context>,
         rope: Option<Rc<Rope<B>>>,
+        ple_dim: Option<usize>,
+        ple_linear_config: Option<&LinearConfig>,
+        ple_norm_config: Option<&NormalizationConfig>,
+        num_layers: usize,
+        is_kv_shared_layer: bool,
     ) -> Self {
         let intermediate_data_type: DataType = match &layer_config.mixer_config {
             MixerConfig::Attention(attention) => attention.qkv_projection_config.activation_precision().into(),
@@ -71,13 +115,23 @@ impl<B: Backend> LayerExecutables<B> {
         )
         .expect("Failed to create RMS norm kernel");
 
+        // Extract per-layer attention dimensions (defaults for non-attention layers)
+        let (attn_num_heads, attn_num_groups, attn_head_dim) = match &layer_config.mixer_config {
+            MixerConfig::Attention(attention_config) => (
+                attention_config.num_heads.unwrap_or(num_heads),
+                attention_config.num_groups.unwrap_or(num_groups),
+                attention_config.head_dim.unwrap_or(head_dim),
+            ),
+            _ => (num_heads, num_groups, head_dim),
+        };
+
         let mixer = match &layer_config.mixer_config {
             MixerConfig::Attention(attention_config) => {
                 let rope_block = rope.expect("RoPE encoder missing for attention layer");
 
-                let layer_num_heads = attention_config.num_heads.unwrap_or(num_heads);
-                let layer_num_groups = attention_config.num_groups.unwrap_or(num_groups);
-                let layer_head_dim = attention_config.head_dim.unwrap_or(head_dim);
+                let layer_num_heads = attn_num_heads;
+                let layer_num_groups = attn_num_groups;
+                let layer_head_dim = attn_head_dim;
 
                 let q_dim = layer_num_heads * layer_head_dim;
                 let kv_dim = layer_num_groups * layer_head_dim;
@@ -117,25 +171,28 @@ impl<B: Backend> LayerExecutables<B> {
                     None
                 };
 
-                let qk_norm =
-                    if attention_config.query_norm_config.is_some() || attention_config.key_norm_config.is_some() {
-                        match QKNorm::new(
-                            context,
-                            intermediate_data_type,
-                            attention_config.query_norm_config.clone(),
-                            attention_config.key_norm_config.clone(),
-                            ArrayId::QKV,
-                            &decoder_layer_loader.subtree("mixer").unwrap(),
-                            layer_num_heads,
-                            layer_num_groups,
-                            layer_head_dim,
-                        ) {
-                            Ok(qk_norm) => Some(qk_norm),
-                            Err(e) => panic!("Failed to create QK norm kernel for layer {}: {:?}", layer_index, e),
-                        }
-                    } else {
-                        None
-                    };
+                let qk_norm = if attention_config.query_norm_config.is_some()
+                    || attention_config.key_norm_config.is_some()
+                    || attention_config.value_norm_config.is_some()
+                {
+                    match QKNorm::new(
+                        context,
+                        intermediate_data_type,
+                        attention_config.query_norm_config.clone(),
+                        attention_config.key_norm_config.clone(),
+                        attention_config.value_norm_config.clone(),
+                        ArrayId::QKV,
+                        &decoder_layer_loader.subtree("mixer").unwrap(),
+                        layer_num_heads,
+                        layer_num_groups,
+                        layer_head_dim,
+                    ) {
+                        Ok(qk_norm) => Some(qk_norm),
+                        Err(e) => panic!("Failed to create QK norm kernel for layer {}: {:?}", layer_index, e),
+                    }
+                } else {
+                    None
+                };
 
                 let out_projection = <dyn Linear<B>>::new(
                     &attention_config.out_projection_config,
@@ -267,8 +324,118 @@ impl<B: Backend> LayerExecutables<B> {
             None
         };
 
+        let (
+            ple_gate,
+            ple_projection,
+            post_ple_norm,
+            ple_activation,
+            ple_mul_strided_kernel,
+            ple_add_swap,
+            ple_dim_val,
+            ple_total_dim_val,
+        ) = match (ple_dim, ple_linear_config, ple_norm_config) {
+            (Some(ple_dim), Some(linear_config), Some(norm_config)) if ple_dim > 0 => {
+                let ple_data_type: DataType = linear_config.activation_precision().into();
+
+                let gate = <dyn Linear<B>>::new(
+                    linear_config,
+                    false,
+                    model_dim,
+                    [ple_dim],
+                    context,
+                    &decoder_layer_loader.subtree("ple_gate").unwrap(),
+                    ArrayId::Main,
+                    ArrayId::PleGate,
+                )
+                .expect("Failed to create PLE gate");
+
+                let projection = <dyn Linear<B>>::new(
+                    linear_config,
+                    false,
+                    ple_dim,
+                    [model_dim],
+                    context,
+                    &decoder_layer_loader.subtree("ple_projection").unwrap(),
+                    ArrayId::PleGate,
+                    ArrayId::Main,
+                )
+                .expect("Failed to create PLE projection");
+
+                let norm = RMSNorm::new(
+                    context,
+                    ple_data_type,
+                    norm_config.clone(),
+                    ArrayId::Main,
+                    ArrayId::Main,
+                    &decoder_layer_loader.subtree("post_ple_norm").unwrap(),
+                    None,
+                    false,
+                )
+                .expect("Failed to create post-PLE norm");
+
+                let activation =
+                    Activation::new(context, ple_data_type, ActivationConfig::GELU, ArrayId::PleGate, ArrayId::PleGate)
+                        .expect("Failed to create PLE GELU activation");
+
+                let mul_strided_kernel =
+                    <B::Kernels as Kernels>::ElementWiseMulStridedKernel::new(context, ple_data_type)
+                        .expect("Failed to create ElementWiseMulStrided kernel");
+
+                let ple_total_dim = num_layers * ple_dim;
+
+                let add_swap = TensorAddSwap::new(context, ple_data_type, ArrayId::Shortcut, ArrayId::Main)
+                    .expect("Failed to create PLE add-swap");
+
+                (
+                    Some(gate),
+                    Some(projection),
+                    Some(norm),
+                    Some(activation),
+                    Some(mul_strided_kernel),
+                    Some(add_swap),
+                    ple_dim,
+                    ple_total_dim,
+                )
+            },
+            _ => (None, None, None, None, None, None, 0, 0),
+        };
+
+        // Load per-layer scalar if configured (Gemma 4)
+        let (layer_scalar, layer_scalar_kernel, layer_scalar_zero_bias) = if layer_config.has_layer_scalar {
+            let scalar_array =
+                decoder_layer_loader.leaf_array("layer_scalar").expect("Failed to load layer_scalar weight");
+            let scalar_value = match scalar_array.data_type() {
+                DataType::BF16 => {
+                    let bytes = scalar_array.as_bytes();
+                    let raw = u16::from_le_bytes([bytes[0], bytes[1]]);
+                    half::bf16::from_bits(raw).to_f32()
+                },
+                DataType::F16 => {
+                    let bytes = scalar_array.as_bytes();
+                    let raw = u16::from_le_bytes([bytes[0], bytes[1]]);
+                    half::f16::from_bits(raw).to_f32()
+                },
+                DataType::F32 => {
+                    let bytes = scalar_array.as_bytes();
+                    f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
+                },
+                dt => panic!("Unsupported data type {:?} for layer_scalar", dt),
+            };
+
+            if (scalar_value - 1.0).abs() > f32::EPSILON {
+                let kernel = <B::Kernels as Kernels>::TensorAddScaleKernel::new(context, intermediate_data_type)
+                    .expect("Failed to create TensorAddScale kernel for layer_scalar");
+                let zero_bias =
+                    context.create_array_zeros(&[model_dim], intermediate_data_type, "layer_scalar_zero_bias");
+                (scalar_value, Some(kernel), Some(zero_bias))
+            } else {
+                (scalar_value, None, None)
+            }
+        } else {
+            (1.0, None, None)
+        };
+
         Self {
-            #[cfg(feature = "tracing")]
             layer_index,
             #[cfg(feature = "tracing")]
             tensor_add,
@@ -278,6 +445,22 @@ impl<B: Backend> LayerExecutables<B> {
             pre_mlp_norm,
             mlp,
             post_mlp_norm,
+            ple_gate,
+            ple_projection,
+            post_ple_norm,
+            ple_activation,
+            ple_mul_strided_kernel,
+            ple_add_swap,
+            ple_dim: ple_dim_val,
+            ple_total_dim: ple_total_dim_val,
+            layer_scalar,
+            layer_scalar_kernel,
+            layer_scalar_zero_bias,
+            model_dim,
+            attention_num_heads: attn_num_heads,
+            attention_num_groups: attn_num_groups,
+            attention_head_dim: attn_head_dim,
+            is_kv_shared_layer,
         }
     }
 
@@ -297,6 +480,32 @@ impl<B: Backend> LayerExecutables<B> {
             state.encode_copy_array(encoder, ArrayId::Main, layer_traces.borrow().pre_attention_norm.clone());
         }
 
+        // Reshape shared rotated Q/K/V and attention buffers to this layer's dimensions.
+        // Buffers are allocated with max dims; each layer views the subset it needs.
+        if matches!(&self.mixer, MixerExecutables::Attention { .. }) {
+            let suffix_length = state.active_row_count();
+            let nh = self.attention_num_heads;
+            let ng = self.attention_num_groups;
+            let hd = self.attention_head_dim;
+
+            state.common_aux.rotated_queries = state.common_aux.rotated_queries.view(&[nh, suffix_length, hd]);
+            state.common_aux.rotated_keys = state.common_aux.rotated_keys.view(&[ng, suffix_length, hd]);
+            state.common_aux.extracted_values = state.common_aux.extracted_values.view(&[ng, suffix_length, hd]);
+            state.common_aux.attention_output = state.common_aux.attention_output.view(&[suffix_length, nh * hd]);
+
+            const TOTAL_BLOCKS_COUNT: usize = 32;
+            state.common_aux.attention_partials =
+                state.common_aux.attention_partials.view(&[nh * suffix_length * TOTAL_BLOCKS_COUNT * hd]);
+            state.common_aux.attention_sums =
+                state.common_aux.attention_sums.view(&[nh * suffix_length * TOTAL_BLOCKS_COUNT]);
+            state.common_aux.attention_maxs =
+                state.common_aux.attention_maxs.view(&[nh * suffix_length * TOTAL_BLOCKS_COUNT]);
+
+            if let Some(ref gate) = state.common_aux.gate {
+                state.common_aux.gate = Some(gate.view(&[suffix_length, nh * hd]));
+            }
+        }
+
         match &self.mixer {
             MixerExecutables::Attention {
                 qkv_projection,
@@ -310,11 +519,19 @@ impl<B: Backend> LayerExecutables<B> {
                 if let Some(gate_proj) = gate_projection {
                     gate_proj.encode(state, encoder)?;
                 }
+                #[cfg(feature = "tracing")]
+                if let Some(ref layer_traces) = layer_traces {
+                    state.encode_copy_array(encoder, ArrayId::QKV, layer_traces.borrow().qkv_projection.clone());
+                }
                 if let Some(norm) = qk_norm {
                     norm.encode(state, encoder)?;
                 }
+                #[cfg(feature = "tracing")]
+                if let Some(ref layer_traces) = layer_traces {
+                    state.encode_copy_array(encoder, ArrayId::QKV, layer_traces.borrow().qk_norm.clone());
+                }
                 rope.encode(state, encoder)?;
-                attention.encode(state, parameters, encoder)?;
+                attention.encode(state, parameters, encoder, self.is_kv_shared_layer)?;
                 out_projection.encode(state, encoder)?;
                 #[cfg(feature = "tracing")]
                 if let Some(ref layer_traces) = layer_traces {
@@ -382,6 +599,77 @@ impl<B: Backend> LayerExecutables<B> {
         }
         // main = mlp_result
         // next layer's pre_attention_norm (or output_norm) fuses the residual add
+
+        if let (Some(ple_gate), Some(ple_projection), Some(post_ple_norm), Some(ple_activation), Some(ple_mul_kernel)) = (
+            &self.ple_gate,
+            &self.ple_projection,
+            &self.post_ple_norm,
+            &self.ple_activation,
+            &self.ple_mul_strided_kernel,
+        ) {
+            // Step 1: Gate projection: Main → PleGate [seq, ple_dim]
+            ple_gate.encode(state, encoder)?;
+
+            // Step 2: GELU activation on PleGate (in-place)
+            ple_activation.encode(state, encoder)?;
+
+            // Step 3: Element-wise multiply PleGate * PlePerLayerInputs[layer_i] (strided)
+            {
+                let ple_gate_arr = state.array(ArrayId::PleGate);
+                let ple_inputs = state.array(ArrayId::PlePerLayerInputs);
+                let rows = ple_gate_arr.shape()[0] as u32; // suffix_length
+                let kernel = ple_mul_kernel;
+
+                // PleGate is both input_a and output (in-place mul).
+                // This is safe because ElementWiseMulStrided reads input_a[row * ple_dim + col]
+                // and writes output[row * ple_dim + col] — same index, element-wise.
+                let ple_gate_buffer_rc = ple_gate_arr.buffer();
+                let mut ple_gate_buffer = ple_gate_buffer_rc.borrow_mut();
+                let ple_gate_input: &B::Buffer = unsafe { &*(&*ple_gate_buffer as *const B::Buffer) };
+
+                kernel.encode(
+                    ple_gate_input,
+                    &*ple_inputs.buffer().borrow(),
+                    &mut *ple_gate_buffer,
+                    self.ple_dim as u32,
+                    self.ple_total_dim as u32,
+                    (self.layer_index * self.ple_dim) as u32,
+                    rows,
+                    encoder,
+                );
+            }
+
+            // Step 4: Project gated PLE back to model_dim: PleGate → Main
+            ple_projection.encode(state, encoder)?;
+
+            // Step 5: Post-PLE norm on Main
+            post_ple_norm.encode(state, encoder)?;
+
+            // Step 6: Residual add: Main = PLE_output + pre-PLE hidden_states (in Shortcut)
+            self.ple_add_swap.as_ref().unwrap().encode(state, encoder)?;
+        }
+
+        // Apply per-layer scalar: hidden_states *= layer_scalar (Gemma 4)
+        if let (Some(kernel), Some(zero_bias)) = (&self.layer_scalar_kernel, &self.layer_scalar_zero_bias) {
+            let main = state.array(ArrayId::Main);
+            let length = main.num_elements();
+
+            let main_buffer_rc = main.buffer();
+            let mut main_buffer = main_buffer_rc.borrow_mut();
+            // TensorAddScale is element-wise, so in-place read/write aliasing is valid.
+            let main_input: &B::Buffer = unsafe { &*(&*main_buffer as *const B::Buffer) };
+
+            let num_cols = self.model_dim as u32;
+            kernel.encode(
+                (main_input, main.offset()),
+                &*zero_bias.buffer().borrow(),
+                (&mut *main_buffer, main.offset()),
+                num_cols,
+                length as u32,
+                self.layer_scalar,
+                encoder,
+            );
+        }
 
         #[cfg(feature = "tracing")]
         if let Some(ref layer_traces) = layer_traces {

--- a/crates/uzu/src/encodable_block/qk_norm.rs
+++ b/crates/uzu/src/encodable_block/qk_norm.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 
 use crate::{
     DataType,
+    array::ArrayContextExt,
     backends::common::{
         Backend, Encoder,
         kernel::{Kernels, QKNormKernel},
@@ -30,11 +31,14 @@ pub enum QKNormError<B: Backend> {
 pub struct QKNorm<B: Backend> {
     query_kernel: Option<<B::Kernels as Kernels>::QKNormKernel>,
     key_kernel: Option<<B::Kernels as Kernels>::QKNormKernel>,
+    value_kernel: Option<<B::Kernels as Kernels>::QKNormKernel>,
     query_config: Option<NormalizationConfig>,
     key_config: Option<NormalizationConfig>,
+    value_config: Option<NormalizationConfig>,
     qkv_array_id: ArrayId,
     query_scales_buffer: Option<Rc<RefCell<B::Buffer>>>,
     key_scales_buffer: Option<Rc<RefCell<B::Buffer>>>,
+    value_scales_buffer: Option<Rc<RefCell<B::Buffer>>>,
     num_q_heads: usize,
     num_kv_heads: usize,
     head_dim: usize,
@@ -46,6 +50,7 @@ impl<B: Backend> QKNorm<B> {
         intermediate_data_type: DataType,
         query_config: Option<NormalizationConfig>,
         key_config: Option<NormalizationConfig>,
+        value_config: Option<NormalizationConfig>,
         qkv_array_id: ArrayId,
         parameter_tree: &ParameterTree<B::Context>,
         num_q_heads: usize,
@@ -54,8 +59,10 @@ impl<B: Backend> QKNorm<B> {
     ) -> Result<Self, QKNormError<B>> {
         let mut query_kernel = None;
         let mut key_kernel = None;
+        let mut value_kernel = None;
         let mut query_scales_buffer = None;
         let mut key_scales_buffer = None;
+        let mut value_scales_buffer = None;
 
         // Setup query normalization if configured
         if let Some(ref q_config) = query_config {
@@ -107,14 +114,61 @@ impl<B: Backend> QKNorm<B> {
             key_scales_buffer = Some(scales.buffer());
         }
 
+        // Setup value normalization if configured (for V-norm, e.g. Gemma 4)
+        if let Some(ref v_config) = value_config {
+            let accumulation_data_type: DataType = v_config.accumulation_precision.into();
+            let scale_data_type: DataType = v_config.scale_precision.into();
+            let (input_type, scales_type, output_type) = match v_config.upcast_mode {
+                UpcastMode::OnlyNormalization => (intermediate_data_type, scale_data_type, scale_data_type),
+                UpcastMode::FullLayer => (intermediate_data_type, scale_data_type, scale_data_type),
+            };
+
+            let kernel = <B::Kernels as Kernels>::QKNormKernel::new(
+                context,
+                input_type,
+                scales_type,
+                output_type,
+                accumulation_data_type,
+                true,
+            )
+            .map_err(QKNormError::BackendError)?;
+
+            let scales_array = if v_config.has_scale {
+                parameter_tree.leaf_array("value_norm.scales").map_err(QKNormError::ParameterError)?
+            } else {
+                // V-norm without learnable scale: create all-ones buffer.
+                // Must match scale_data_type so the kernel reads correct values.
+                match scale_data_type {
+                    DataType::BF16 => {
+                        let ones: Vec<half::bf16> = vec![half::bf16::ONE; head_dim];
+                        context.create_array_from(&[head_dim], &ones, "v_norm_ones")
+                    },
+                    DataType::F16 => {
+                        let ones: Vec<half::f16> = vec![half::f16::ONE; head_dim];
+                        context.create_array_from(&[head_dim], &ones, "v_norm_ones")
+                    },
+                    _ => {
+                        let ones: Vec<f32> = vec![1.0; head_dim];
+                        context.create_array_from(&[head_dim], &ones, "v_norm_ones")
+                    },
+                }
+            };
+
+            value_kernel = Some(kernel);
+            value_scales_buffer = Some(scales_array.buffer());
+        }
+
         Ok(Self {
             query_kernel,
             key_kernel,
+            value_kernel,
             query_config,
             key_config,
+            value_config,
             qkv_array_id,
             query_scales_buffer,
             key_scales_buffer,
+            value_scales_buffer,
             num_q_heads,
             num_kv_heads,
             head_dim,
@@ -167,6 +221,27 @@ impl<B: Backend> QKNorm<B> {
                 self.num_q_heads as u32,
                 self.num_kv_heads as u32,
                 key_config.upcast_mode == UpcastMode::FullLayer,
+                encoder,
+            );
+        }
+
+        // Process value normalization if configured (V heads follow K heads in QKV layout)
+        if let (Some(value_kernel), Some(value_scales_buffer), Some(value_config)) =
+            (&self.value_kernel, &self.value_scales_buffer, &self.value_config)
+        {
+            value_kernel.encode(
+                None::<&B::Buffer>,
+                value_scales_buffer.borrow().deref(),
+                qkv_array.buffer().borrow_mut().deref_mut(),
+                batch_dim,
+                self.num_q_heads as u32,
+                self.num_kv_heads as u32,
+                self.head_dim as u32,
+                value_config.epsilon,
+                value_config.scale_offset.unwrap_or(0.0),
+                (self.num_q_heads + self.num_kv_heads) as u32,
+                self.num_kv_heads as u32,
+                value_config.upcast_mode == UpcastMode::FullLayer,
                 encoder,
             );
         }

--- a/crates/uzu/src/encodable_block/qk_norm.rs
+++ b/crates/uzu/src/encodable_block/qk_norm.rs
@@ -25,7 +25,7 @@ pub enum QKNormError<B: Backend> {
     #[error("Backend error: {0}")]
     BackendError(#[source] B::Error),
     #[error("Parameter loading error: {0}")]
-    ParameterError(ParameterLoaderError<B>),
+    ParameterError(#[source] ParameterLoaderError<B>),
 }
 
 pub struct QKNorm<B: Backend> {

--- a/crates/uzu/src/forward_pass/cache_layers.rs
+++ b/crates/uzu/src/forward_pass/cache_layers.rs
@@ -100,6 +100,7 @@ pub struct CacheLayers<B: Backend> {
     max_suffix_length: usize,
     max_prefix_length: usize,
     pub data: Box<[CacheLayer<B>]>,
+    kv_shared_layer_sources: Option<Box<[Option<usize>]>>,
 }
 
 #[derive(Clone)]
@@ -118,7 +119,7 @@ impl<B: Backend> CacheLayers<B> {
         let kv_shapes: Vec<[usize; 3]> =
             model_shape.kv_cache_layer_shapes(max_prefix_length, max_suffix_length).collect();
 
-        let data: Box<[CacheLayer<B>]> = model_shape
+        let mut layers: Vec<CacheLayer<B>> = model_shape
             .layer_types()
             .iter()
             .enumerate()
@@ -230,10 +231,43 @@ impl<B: Backend> CacheLayers<B> {
             })
             .collect();
 
+        // Share KV cache buffers for shared layers (e.g. Gemma 4 E2B layers 15-34).
+        // Array<B> uses Rc<RefCell<B::Buffer>>, so .clone() creates a shared reference
+        // to the same underlying GPU buffer — both source and shared layers will read
+        // from identical K/V data without extra allocations.
+        if let Some(sources) = &model_shape.kv_shared_layer_sources {
+            // First pass: collect cloned arrays from source layers to avoid simultaneous
+            // mutable + immutable borrows on the layers Vec.
+            let shared_refs: Vec<Option<(crate::array::Array<B>, crate::array::Array<B>)>> = sources
+                .iter()
+                .enumerate()
+                .map(|(_i, source)| {
+                    source.map(|src| {
+                        let src_layer =
+                            layers[src].as_transformer().expect("KV shared source must be a Transformer layer");
+                        (src_layer.keys.clone(), src_layer.values.clone())
+                    })
+                })
+                .collect();
+
+            // Second pass: replace shared layers' keys/values with the cloned references.
+            for (layer_idx, refs) in shared_refs.into_iter().enumerate() {
+                if let Some((keys, values)) = refs {
+                    if let CacheLayer::Transformer(ref mut cache) = layers[layer_idx] {
+                        cache.keys = keys;
+                        cache.values = values;
+                    }
+                }
+            }
+        }
+
+        let data: Box<[CacheLayer<B>]> = layers.into_boxed_slice();
+
         Self {
             max_suffix_length,
             max_prefix_length,
             data,
+            kv_shared_layer_sources: model_shape.kv_shared_layer_sources.clone(),
         }
     }
 
@@ -461,10 +495,41 @@ impl<B: Backend> CacheLayers<B> {
             })
             .collect();
 
+        // Re-establish KV sharing after creating all layers.
+        // Array<B> uses Rc<RefCell<B::Buffer>>, so .clone() creates a shared
+        // reference to the same underlying buffer.
+        let mut layers: Vec<CacheLayer<B>> = data.into_vec();
+
+        if let Some(sources) = &self.kv_shared_layer_sources {
+            let shared_refs: Vec<Option<(crate::array::Array<B>, crate::array::Array<B>)>> = sources
+                .iter()
+                .enumerate()
+                .map(|(_i, source)| {
+                    source.map(|src| {
+                        let src_layer =
+                            layers[src].as_transformer().expect("KV shared source must be a Transformer layer");
+                        (src_layer.keys.clone(), src_layer.values.clone())
+                    })
+                })
+                .collect();
+
+            for (layer_idx, refs) in shared_refs.into_iter().enumerate() {
+                if let Some((keys, values)) = refs {
+                    if let CacheLayer::Transformer(ref mut cache) = layers[layer_idx] {
+                        cache.keys = keys;
+                        cache.values = values;
+                    }
+                }
+            }
+        }
+
+        let data: Box<[CacheLayer<B>]> = layers.into_boxed_slice();
+
         Self {
             max_suffix_length: self.max_suffix_length,
             max_prefix_length: max_prefix_capacity_across_layers,
             data,
+            kv_shared_layer_sources: self.kv_shared_layer_sources.clone(),
         }
     }
 }

--- a/crates/uzu/src/forward_pass/cache_layers.rs
+++ b/crates/uzu/src/forward_pass/cache_layers.rs
@@ -231,13 +231,9 @@ impl<B: Backend> CacheLayers<B> {
             })
             .collect();
 
-        // Share KV cache buffers for shared layers (e.g. Gemma 4 E2B layers 15-34).
         // Array<B> uses Rc<RefCell<B::Buffer>>, so .clone() creates a shared reference
-        // to the same underlying GPU buffer — both source and shared layers will read
-        // from identical K/V data without extra allocations.
+        // to the same underlying GPU buffer — no extra allocations.
         if let Some(sources) = &model_shape.kv_shared_layer_sources {
-            // First pass: collect cloned arrays from source layers to avoid simultaneous
-            // mutable + immutable borrows on the layers Vec.
             let shared_refs: Vec<Option<(crate::array::Array<B>, crate::array::Array<B>)>> = sources
                 .iter()
                 .enumerate()
@@ -250,7 +246,6 @@ impl<B: Backend> CacheLayers<B> {
                 })
                 .collect();
 
-            // Second pass: replace shared layers' keys/values with the cloned references.
             for (layer_idx, refs) in shared_refs.into_iter().enumerate() {
                 if let Some((keys, values)) = refs {
                     if let CacheLayer::Transformer(ref mut cache) = layers[layer_idx] {
@@ -495,9 +490,6 @@ impl<B: Backend> CacheLayers<B> {
             })
             .collect();
 
-        // Re-establish KV sharing after creating all layers.
-        // Array<B> uses Rc<RefCell<B::Buffer>>, so .clone() creates a shared
-        // reference to the same underlying buffer.
         let mut layers: Vec<CacheLayer<B>> = data.into_vec();
 
         if let Some(sources) = &self.kv_shared_layer_sources {

--- a/crates/uzu/src/forward_pass/model_shape.rs
+++ b/crates/uzu/src/forward_pass/model_shape.rs
@@ -41,7 +41,6 @@ pub struct ModelShape {
     ple_dim: Option<usize>,
     ple_total_dim: Option<usize>,
     pub kv_shared_layer_sources: Option<Box<[Option<usize>]>>,
-    /// Per-layer (num_groups, head_dim) for KV cache. None means use uniform values.
     kv_cache_per_layer_shapes: Option<Box<[(usize, usize)]>>,
 }
 
@@ -144,7 +143,6 @@ impl ModelShape {
                     has_gate = has_gate || attn.has_gate || attn.gate_projection_config.is_some();
                     linear_configs.extend([&attn.qkv_projection_config, &attn.out_projection_config]);
 
-                    // Track max attention dimensions across all layers for buffer sizing.
                     max_num_heads = max_num_heads.max(nh);
                     max_num_groups = max_num_groups.max(ng);
                     max_head_dim = max_head_dim.max(hd);

--- a/crates/uzu/src/forward_pass/model_shape.rs
+++ b/crates/uzu/src/forward_pass/model_shape.rs
@@ -16,6 +16,10 @@ pub struct ModelShape {
     num_heads: usize,
     num_groups: usize,
     head_dim: usize,
+    max_num_heads: usize,
+    max_num_groups: usize,
+    max_head_dim: usize,
+    max_attention_dim: usize,
     pub num_layers: usize,
     pub sliding_window_length_per_layer: Box<[Option<usize>]>,
     pub layer_types: Box<[DecoderLayerType]>,
@@ -26,12 +30,19 @@ pub struct ModelShape {
     max_mamba_state_dim: usize,
     max_mamba_kernel_size: usize,
     max_rope_dim: usize,
+    global_rope_dim: usize,
+    local_rope_dim: usize,
     max_lora_intermediate: Option<usize>,
     has_gate: bool,
     max_delta_net_kernel_size: usize,
     max_delta_net_key_dim: usize,
     max_delta_net_num_heads: usize,
     max_qkv_dim: usize,
+    ple_dim: Option<usize>,
+    ple_total_dim: Option<usize>,
+    pub kv_shared_layer_sources: Option<Box<[Option<usize>]>>,
+    /// Per-layer (num_groups, head_dim) for KV cache. None means use uniform values.
+    kv_cache_per_layer_shapes: Option<Box<[(usize, usize)]>>,
 }
 
 impl ModelShape {
@@ -99,6 +110,8 @@ impl ModelShape {
         }
 
         let mut max_rope_dim = 0usize;
+        let mut global_rope_dim = 0usize;
+        let mut local_rope_dim = 0usize;
         let mut max_lora_intermediate = None;
         let mut has_gate = false;
 
@@ -109,15 +122,34 @@ impl ModelShape {
             .unwrap_or_else(|| vec![&decoder_config.layer_config; num_layers]);
 
         let mut max_qkv_dim = 0usize;
+        let mut max_num_heads = decoder_config.num_heads;
+        let mut max_num_groups = decoder_config.num_groups;
+        let mut max_head_dim = decoder_config.head_dim;
+        let mut max_attention_dim = decoder_config.num_heads * decoder_config.head_dim;
         for layer_config in &all_layer_configs {
             let mut linear_configs = Vec::new();
 
             match &layer_config.mixer_config {
                 MixerConfig::Attention(attn) => {
                     let hd = attn.head_dim.unwrap_or(decoder_config.head_dim);
-                    max_rope_dim = max_rope_dim.max(attn.partial_rope_dim.unwrap_or(hd));
+                    let nh = attn.num_heads.unwrap_or(decoder_config.num_heads);
+                    let ng = attn.num_groups.unwrap_or(decoder_config.num_groups);
+                    let rope_dim = hd;
+                    max_rope_dim = max_rope_dim.max(rope_dim);
+                    if attn.sliding_window_size.is_some() {
+                        local_rope_dim = local_rope_dim.max(rope_dim);
+                    } else {
+                        global_rope_dim = global_rope_dim.max(rope_dim);
+                    }
                     has_gate = has_gate || attn.has_gate || attn.gate_projection_config.is_some();
                     linear_configs.extend([&attn.qkv_projection_config, &attn.out_projection_config]);
+
+                    // Track max attention dimensions across all layers for buffer sizing.
+                    max_num_heads = max_num_heads.max(nh);
+                    max_num_groups = max_num_groups.max(ng);
+                    max_head_dim = max_head_dim.max(hd);
+                    max_attention_dim = max_attention_dim.max(nh * hd);
+                    max_qkv_dim = max_qkv_dim.max((nh + 2 * ng) * hd);
                 },
                 MixerConfig::Mamba(mamba) => {
                     linear_configs.extend([&mamba.in_projection_config, &mamba.out_projection_config]);
@@ -158,17 +190,47 @@ impl ModelShape {
         if max_rope_dim == 0 {
             max_rope_dim = decoder_config.head_dim;
         }
+        if global_rope_dim == 0 {
+            global_rope_dim = decoder_config.head_dim;
+        }
+        if local_rope_dim == 0 {
+            local_rope_dim = decoder_config.head_dim;
+        }
+
+        let kv_cache_per_layer_shapes = decoder_config.layer_configs.as_ref().map(|configs| {
+            configs
+                .iter()
+                .map(|layer_config| match &layer_config.mixer_config {
+                    MixerConfig::Attention(attn) => {
+                        let hd = attn.head_dim.unwrap_or(decoder_config.head_dim);
+                        let ng = attn.num_groups.unwrap_or(decoder_config.num_groups);
+                        (ng, hd)
+                    },
+                    // Non-attention layers don't have KV cache, but we still need entries
+                    _ => (decoder_config.num_groups, decoder_config.head_dim),
+                })
+                .collect::<Vec<_>>()
+                .into_boxed_slice()
+        });
 
         Self {
             activation_type,
             kv_cache_type: activation_type,
             vocabulary_size: decoder_config.vocab_size,
             model_dim: decoder_config.model_dim,
-            hidden_dim: decoder_config.hidden_dim,
+            hidden_dim: decoder_config
+                .hidden_dims
+                .as_ref()
+                .and_then(|dims| dims.iter().copied().max())
+                .unwrap_or(decoder_config.hidden_dim),
             context_length: decoder_config.context_length,
             num_heads: decoder_config.num_heads,
             num_groups: decoder_config.num_groups,
             head_dim: decoder_config.head_dim,
+            max_num_heads,
+            max_num_groups,
+            max_head_dim,
+            max_attention_dim,
             num_layers: num_layers,
             sliding_window_length_per_layer: decoder_config
                 .sliding_window_sizes
@@ -182,12 +244,18 @@ impl ModelShape {
             max_mamba_state_dim,
             max_mamba_kernel_size,
             max_rope_dim,
+            global_rope_dim,
+            local_rope_dim,
             max_lora_intermediate,
             has_gate,
             max_delta_net_kernel_size,
             max_delta_net_key_dim,
             max_delta_net_num_heads,
             max_qkv_dim,
+            ple_dim: decoder_config.ple_dim,
+            ple_total_dim: decoder_config.ple_dim.map(|dim| num_layers * dim),
+            kv_shared_layer_sources: decoder_config.kv_shared_layer_sources.clone(),
+            kv_cache_per_layer_shapes,
         }
     }
 
@@ -209,6 +277,14 @@ impl ModelShape {
 
     pub fn rope_dim(&self) -> usize {
         self.max_rope_dim
+    }
+
+    pub fn global_rope_dim(&self) -> usize {
+        self.global_rope_dim
+    }
+
+    pub fn local_rope_dim(&self) -> usize {
+        self.local_rope_dim
     }
 
     pub fn num_groups(&self) -> usize {
@@ -284,7 +360,7 @@ impl ModelShape {
         &self,
         suffix_length: usize,
     ) -> [usize; 2] {
-        let attention_dim = self.num_heads * self.head_dim;
+        let attention_dim = self.max_attention_dim;
         let delta_net_dim = self
             .layer_types
             .iter()
@@ -305,21 +381,21 @@ impl ModelShape {
         &self,
         suffix_length: usize,
     ) -> Option<[usize; 2]> {
-        self.has_gate.then(|| [suffix_length, self.num_heads * self.head_dim])
+        self.has_gate.then(|| [suffix_length, self.max_attention_dim])
     }
 
     pub fn rotated_queries_shape(
         &self,
         suffix_length: usize,
     ) -> [usize; 3] {
-        [self.num_heads, suffix_length, self.head_dim]
+        [self.max_num_heads, suffix_length, self.max_head_dim]
     }
 
     pub fn rotated_keys_shape(
         &self,
         suffix_length: usize,
     ) -> [usize; 3] {
-        [self.num_groups, suffix_length, self.head_dim]
+        [self.max_num_groups, suffix_length, self.max_head_dim]
     }
 
     pub fn extracted_values_shape(
@@ -327,17 +403,23 @@ impl ModelShape {
         suffix_length: usize,
     ) -> [usize; 3] {
         // Values share the same grouping as keys (grouped by num_groups)
-        [self.num_groups, suffix_length, self.head_dim]
+        [self.max_num_groups, suffix_length, self.max_head_dim]
     }
 
     pub fn kv_cache_layer_shapes(
         &self,
         max_prefix_length: usize,
         max_suffix_length: usize,
-    ) -> impl Iterator<Item = [usize; 3]> {
-        self.sliding_window_length_per_layer.iter().map(move |length| {
+    ) -> impl Iterator<Item = [usize; 3]> + '_ {
+        let default_groups = self.num_groups;
+        let default_head_dim = self.head_dim;
+        let per_layer = self.kv_cache_per_layer_shapes.as_ref();
+
+        self.sliding_window_length_per_layer.iter().enumerate().map(move |(i, length)| {
             let length = length.unwrap_or(max_prefix_length);
-            [self.num_groups, length + max_suffix_length, self.head_dim]
+            let (groups, hd) =
+                per_layer.and_then(|shapes| shapes.get(i)).copied().unwrap_or((default_groups, default_head_dim));
+            [groups, length + max_suffix_length, hd]
         })
     }
 
@@ -350,7 +432,7 @@ impl ModelShape {
         suffix_length: usize,
     ) -> [usize; 1] {
         const TOTAL_BLOCKS_COUNT: usize = 32;
-        [self.num_heads * suffix_length * TOTAL_BLOCKS_COUNT * self.head_dim]
+        [self.max_num_heads * suffix_length * TOTAL_BLOCKS_COUNT * self.max_head_dim]
     }
 
     pub fn attention_sums_shape(
@@ -358,7 +440,7 @@ impl ModelShape {
         suffix_length: usize,
     ) -> [usize; 1] {
         const TOTAL_BLOCKS_COUNT: usize = 32;
-        [self.num_heads * suffix_length * TOTAL_BLOCKS_COUNT]
+        [self.max_num_heads * suffix_length * TOTAL_BLOCKS_COUNT]
     }
 
     pub fn attention_maxs_shape(
@@ -366,7 +448,7 @@ impl ModelShape {
         suffix_length: usize,
     ) -> [usize; 1] {
         const TOTAL_BLOCKS_COUNT: usize = 32;
-        [self.num_heads * suffix_length * TOTAL_BLOCKS_COUNT]
+        [self.max_num_heads * suffix_length * TOTAL_BLOCKS_COUNT]
     }
 
     pub fn moe_topk_ids_shape(
@@ -657,6 +739,42 @@ impl ModelShape {
         suffix_length: usize,
     ) -> Option<[usize; 2]> {
         self.max_lora_intermediate.map(|max_lora_intermediate| [suffix_length, max_lora_intermediate])
+    }
+
+    pub fn ple_dim(&self) -> Option<usize> {
+        self.ple_dim
+    }
+
+    pub fn ple_total_dim(&self) -> Option<usize> {
+        self.ple_total_dim
+    }
+
+    pub fn ple_embeddings_shape(
+        &self,
+        suffix_length: usize,
+    ) -> Option<[usize; 2]> {
+        self.ple_total_dim.map(|total_dim| [suffix_length, total_dim])
+    }
+
+    pub fn ple_projection_shape(
+        &self,
+        suffix_length: usize,
+    ) -> Option<[usize; 2]> {
+        self.ple_total_dim.map(|total_dim| [suffix_length, total_dim])
+    }
+
+    pub fn ple_combined_shape(
+        &self,
+        suffix_length: usize,
+    ) -> Option<[usize; 2]> {
+        self.ple_total_dim.map(|total_dim| [suffix_length, total_dim])
+    }
+
+    pub fn ple_gate_shape(
+        &self,
+        suffix_length: usize,
+    ) -> Option<[usize; 2]> {
+        self.ple_dim.map(|dim| [suffix_length, dim])
     }
 
     fn max_mamba_inproj_dim_internal(&self) -> Option<usize> {

--- a/crates/uzu/src/forward_pass/scratch_buffers.rs
+++ b/crates/uzu/src/forward_pass/scratch_buffers.rs
@@ -49,6 +49,12 @@ pub struct ScratchBuffers<B: Backend> {
     pub attention_sums: Array<B>,     // [num_heads * max_suffix_len * total_blocks_count]
     pub attention_maxs: Array<B>,     // [num_heads * max_suffix_len * total_blocks_count]
 
+    // PLE buffers
+    pub ple_embeddings: Option<Array<B>>,
+    pub ple_projection: Option<Array<B>>,
+    pub ple_combined: Option<Array<B>>,
+    pub ple_gate: Option<Array<B>>,
+
     pub moe_topk_ids: Option<Array<B>>,
     pub moe_topk_probs: Option<Array<B>>,
     pub moe_offsets: Option<Array<B>>,
@@ -156,6 +162,17 @@ impl<B: Backend> ScratchBuffers<B> {
             ),
             attention_sums: alloc(&sums_maxs_shape, act_ty, "attention_sums"),
             attention_maxs: alloc(&sums_maxs_shape, act_ty, "attention_maxs"),
+
+            ple_embeddings: model_shape
+                .ple_embeddings_shape(max_suffix_len)
+                .map(|shape| alloc(&shape, act_ty, "ple_embeddings")),
+            ple_projection: model_shape
+                .ple_projection_shape(max_suffix_len)
+                .map(|shape| alloc(&shape, act_ty, "ple_projection")),
+            ple_combined: model_shape
+                .ple_combined_shape(max_suffix_len)
+                .map(|shape| alloc(&shape, act_ty, "ple_combined")),
+            ple_gate: model_shape.ple_gate_shape(max_suffix_len).map(|shape| alloc(&shape, act_ty, "ple_gate")),
 
             moe_topk_ids: moe.map(|moe| {
                 alloc(

--- a/crates/uzu/src/forward_pass/state/array_id.rs
+++ b/crates/uzu/src/forward_pass/state/array_id.rs
@@ -68,6 +68,16 @@ pub enum ArrayId {
     MoeScatterBlockBases,
     MoeBlockAlloc,
 
+    // Per-Layer Embedding (PLE) buffers
+    /// PLE per-layer embedding lookup output [batch, seq, num_layers * ple_dim]
+    PleEmbeddings,
+    /// PLE projection output (main embeddings projected into PLE space) [batch, seq, num_layers * ple_dim]
+    PleProjection,
+    /// PLE combined per-layer inputs [batch, seq, num_layers, ple_dim]
+    PlePerLayerInputs,
+    /// PLE gate output within a layer [batch, seq, ple_dim]
+    PleGate,
+
     // Classifier prediction head buffers
     ClassifierPooling,
     ClassifierPredictionHeadDense,

--- a/crates/uzu/src/forward_pass/state/language_model_generator_aux_buffers.rs
+++ b/crates/uzu/src/forward_pass/state/language_model_generator_aux_buffers.rs
@@ -19,6 +19,11 @@ pub struct LanguageModelGeneratorAuxBuffers<B: Backend> {
     pub delta_net_prep_k_norm: Option<Array<B>>,
     pub delta_net_prep_beta: Option<Array<B>>,
     pub delta_net_prep_decay: Option<Array<B>>,
+    // PLE buffers
+    pub ple_embeddings: Option<Array<B>>,
+    pub ple_projection: Option<Array<B>>,
+    pub ple_combined: Option<Array<B>>,
+    pub ple_gate: Option<Array<B>>,
     // MoE buffers
     pub moe_topk_ids: Option<Array<B>>,
     pub moe_topk_probs: Option<Array<B>>,
@@ -117,6 +122,26 @@ impl<B: Backend> LanguageModelGeneratorAuxBuffers<B> {
                 .delta_net_prep_decay
                 .as_ref()
                 .zip(model_shape.delta_net_prep_beta_decay_shape(suffix_length))
+                .map(|(buf, shape)| buf.view(&shape)),
+            ple_embeddings: scratch
+                .ple_embeddings
+                .as_ref()
+                .zip(model_shape.ple_embeddings_shape(suffix_length))
+                .map(|(buf, shape)| buf.view(&shape)),
+            ple_projection: scratch
+                .ple_projection
+                .as_ref()
+                .zip(model_shape.ple_projection_shape(suffix_length))
+                .map(|(buf, shape)| buf.view(&shape)),
+            ple_combined: scratch
+                .ple_combined
+                .as_ref()
+                .zip(model_shape.ple_combined_shape(suffix_length))
+                .map(|(buf, shape)| buf.view(&shape)),
+            ple_gate: scratch
+                .ple_gate
+                .as_ref()
+                .zip(model_shape.ple_gate_shape(suffix_length))
                 .map(|(buf, shape)| buf.view(&shape)),
             moe_topk_ids: moe.zip(scratch.moe_topk_ids.as_ref()).map(|(moe, buf)| {
                 buf.view(&model_shape.moe_topk_ids_shape(suffix_length, moe.num_active_routed_experts))

--- a/crates/uzu/src/forward_pass/state/rope_buffers.rs
+++ b/crates/uzu/src/forward_pass/state/rope_buffers.rs
@@ -16,8 +16,8 @@ impl<B: Backend> RopeBuffers<B> {
     pub fn new(
         context: &B::Context,
         model_shape: &ModelShape,
+        rope_dim: usize,
     ) -> Self {
-        let rope_dim = model_shape.rope_dim();
         let rope_max_sequence_length = model_shape.context_length();
 
         Self {

--- a/crates/uzu/src/forward_pass/state/shared_buffers.rs
+++ b/crates/uzu/src/forward_pass/state/shared_buffers.rs
@@ -22,9 +22,15 @@ impl<B: Backend> SharedBuffers<B> {
         decoder_config: &DecoderConfig,
         model_shape: &ModelShape,
     ) -> Self {
-        let global_rope = decoder_config.global_rope_config.is_some().then(|| RopeBuffers::new(context, model_shape));
+        let global_rope = decoder_config
+            .global_rope_config
+            .is_some()
+            .then(|| RopeBuffers::new(context, model_shape, model_shape.global_rope_dim()));
 
-        let local_rope = decoder_config.local_rope_config.is_some().then(|| RopeBuffers::new(context, model_shape));
+        let local_rope = decoder_config
+            .local_rope_config
+            .is_some()
+            .then(|| RopeBuffers::new(context, model_shape, model_shape.local_rope_dim()));
 
         let attention_sinks = decoder_config.layer_config.attention_config().is_some_and(|c| c.has_sinks).then(|| {
             let num_heads = decoder_config.num_heads;

--- a/crates/uzu/src/forward_pass/state/state.rs
+++ b/crates/uzu/src/forward_pass/state/state.rs
@@ -563,6 +563,20 @@ impl<B: Backend> ForwardPassState<B> {
                 .and_then(|aux| aux.moe_block_alloc.clone())
                 .expect("MoE block_alloc not initialized"),
 
+            // PLE arrays
+            ArrayId::PleEmbeddings => {
+                self.llm_aux.as_ref().and_then(|aux| aux.ple_embeddings.clone()).expect("PLE embeddings not allocated")
+            },
+            ArrayId::PleProjection => {
+                self.llm_aux.as_ref().and_then(|aux| aux.ple_projection.clone()).expect("PLE projection not allocated")
+            },
+            ArrayId::PlePerLayerInputs => {
+                self.llm_aux.as_ref().and_then(|aux| aux.ple_combined.clone()).expect("PLE combined not allocated")
+            },
+            ArrayId::PleGate => {
+                self.llm_aux.as_ref().and_then(|aux| aux.ple_gate.clone()).expect("PLE gate not allocated")
+            },
+
             // Classifier-specific arrays
             ArrayId::ClassifierPooling => self.classifier_state().pooling.clone(),
             ArrayId::ClassifierPredictionHeadDense => self.classifier_state().dense.clone(),

--- a/crates/uzu/src/forward_pass/traces.rs
+++ b/crates/uzu/src/forward_pass/traces.rs
@@ -29,6 +29,8 @@ fn create_layer_results<B: Backend>(
 pub struct LayerActivationTrace<B: Backend> {
     pub inputs: Array<B>,
     pub pre_attention_norm: Array<B>,
+    pub qkv_projection: Array<B>,
+    pub qk_norm: Array<B>,
     pub attention: Array<B>,
     pub post_attention_norm: Array<B>,
     pub mlp_inputs: Array<B>,
@@ -45,12 +47,15 @@ impl<B: Backend> LayerActivationTrace<B> {
         suffix_length: usize,
     ) -> Self {
         let main_shape = model_shape.main_shape(suffix_length);
+        let qkv_shape = model_shape.qkv_shape(suffix_length);
         let activation_data_type = model_shape.activation_data_type();
         let main = |label| create_trace_array(context, &main_shape, activation_data_type, label);
 
         Self {
             inputs: main("layer_activation_trace_inputs"),
             pre_attention_norm: main("layer_activation_trace_pre_attention_norm"),
+            qkv_projection: create_trace_array(context, &qkv_shape, activation_data_type, "layer_trace_qkv_projection"),
+            qk_norm: create_trace_array(context, &qkv_shape, activation_data_type, "layer_trace_qk_norm"),
             attention: main("layer_activation_trace_attention"),
             post_attention_norm: main("layer_activation_trace_post_attention_norm"),
             mlp_inputs: main("layer_activation_trace_mlp_inputs"),

--- a/crates/uzu/tests/unit/config/attention_test.rs
+++ b/crates/uzu/tests/unit/config/attention_test.rs
@@ -79,6 +79,7 @@ fn test_attention_config() {
         has_gate: false,
         gate_projection_config: None,
         partial_rope_dim: None,
+        value_norm_config: None,
     };
 
     let deserialized_config: AttentionConfig = from_str(config_str).unwrap();

--- a/crates/uzu/tests/unit/config/attention_test.rs
+++ b/crates/uzu/tests/unit/config/attention_test.rs
@@ -80,6 +80,7 @@ fn test_attention_config() {
         gate_projection_config: None,
         partial_rope_dim: None,
         value_norm_config: None,
+        normalize_values: false,
     };
 
     let deserialized_config: AttentionConfig = from_str(config_str).unwrap();

--- a/crates/uzu/tests/unit/config/decoder_layer_test.rs
+++ b/crates/uzu/tests/unit/config/decoder_layer_test.rs
@@ -140,6 +140,7 @@ fn test_decoder_layer_config() {
             gate_projection_config: None,
             partial_rope_dim: None,
             value_norm_config: None,
+            normalize_values: false,
         }),
         mlp_config: MLPConfig::Dense(mlp::DenseMLPConfig {
             linear_config: LinearConfig::QLoRA {

--- a/crates/uzu/tests/unit/config/decoder_layer_test.rs
+++ b/crates/uzu/tests/unit/config/decoder_layer_test.rs
@@ -91,6 +91,7 @@ fn test_decoder_layer_config() {
             upcast_mode: UpcastMode::OnlyNormalization,
             subtract_mean: false,
             use_bias: false,
+            has_scale: true,
         },
         pre_mlp_norm_config: NormalizationConfig {
             scale_precision: ConfigDataType::BFloat16,
@@ -100,6 +101,7 @@ fn test_decoder_layer_config() {
             upcast_mode: UpcastMode::OnlyNormalization,
             subtract_mean: false,
             use_bias: false,
+            has_scale: true,
         },
         mixer_config: MixerConfig::Attention(AttentionConfig {
             qkv_projection_config: LinearConfig::QLoRA {
@@ -137,6 +139,7 @@ fn test_decoder_layer_config() {
             has_gate: false,
             gate_projection_config: None,
             partial_rope_dim: None,
+            value_norm_config: None,
         }),
         mlp_config: MLPConfig::Dense(mlp::DenseMLPConfig {
             linear_config: LinearConfig::QLoRA {
@@ -158,6 +161,7 @@ fn test_decoder_layer_config() {
         }),
         post_attention_norm_config: None,
         post_mlp_norm_config: None,
+        has_layer_scalar: false,
     };
 
     let deserialized_config: DecoderLayerConfig = from_str(config_str).unwrap();

--- a/crates/uzu/tests/unit/config/decoder_test.rs
+++ b/crates/uzu/tests/unit/config/decoder_test.rs
@@ -154,6 +154,7 @@ fn test_decoder_config() {
                 upcast_mode: UpcastMode::OnlyNormalization,
                 subtract_mean: false,
                 use_bias: false,
+                has_scale: true,
             },
             pre_mlp_norm_config: NormalizationConfig {
                 scale_precision: ConfigDataType::BFloat16,
@@ -163,6 +164,7 @@ fn test_decoder_config() {
                 upcast_mode: UpcastMode::OnlyNormalization,
                 subtract_mean: false,
                 use_bias: false,
+                has_scale: true,
             },
             mixer_config: MixerConfig::Attention(AttentionConfig {
                 qkv_projection_config: LinearConfig::QLoRA {
@@ -200,6 +202,7 @@ fn test_decoder_config() {
                 has_gate: false,
                 gate_projection_config: None,
                 partial_rope_dim: None,
+                value_norm_config: None,
             }),
             mlp_config: MLPConfig::Dense(DenseMLPConfig {
                 linear_config: LinearConfig::QLoRA {
@@ -221,6 +224,7 @@ fn test_decoder_config() {
             }),
             post_attention_norm_config: None,
             post_mlp_norm_config: None,
+            has_layer_scalar: false,
         },
         output_norm_config: NormalizationConfig {
             scale_precision: ConfigDataType::BFloat16,
@@ -230,6 +234,7 @@ fn test_decoder_config() {
             upcast_mode: UpcastMode::OnlyNormalization,
             subtract_mean: false,
             use_bias: false,
+            has_scale: true,
         },
         layer_configs: None,
         vocab_size: 128256,
@@ -241,8 +246,16 @@ fn test_decoder_config() {
         attention_scale: None,
         num_layers: 16,
         sliding_window_sizes: None,
+        hidden_dims: None,
         layer_types: None,
         context_length: 8192,
+        kv_shared_layer_sources: None,
+        ple_dim: None,
+        ple_embed_scale: None,
+        ple_projection_scale: None,
+        ple_combination_scale: None,
+        ple_linear_config: None,
+        ple_norm_config: None,
     };
 
     let deserialized_config: DecoderConfig = from_str(config_str).unwrap();

--- a/crates/uzu/tests/unit/config/decoder_test.rs
+++ b/crates/uzu/tests/unit/config/decoder_test.rs
@@ -203,6 +203,7 @@ fn test_decoder_config() {
                 gate_projection_config: None,
                 partial_rope_dim: None,
                 value_norm_config: None,
+                normalize_values: false,
             }),
             mlp_config: MLPConfig::Dense(DenseMLPConfig {
                 linear_config: LinearConfig::QLoRA {

--- a/crates/uzu/tests/unit/config/normalization/normalization_config_test.rs
+++ b/crates/uzu/tests/unit/config/normalization/normalization_config_test.rs
@@ -22,6 +22,7 @@ fn test_normalization_config() {
         upcast_mode: UpcastMode::OnlyNormalization,
         subtract_mean: false,
         use_bias: false,
+        has_scale: true,
     };
 
     let deserialized_config: NormalizationConfig = from_str(config_str).unwrap();

--- a/crates/uzu/tests/unit/config/transformer_layer_test.rs
+++ b/crates/uzu/tests/unit/config/transformer_layer_test.rs
@@ -148,6 +148,7 @@ fn test_transformer_layer_config() {
             gate_projection_config: None,
             partial_rope_dim: None,
             value_norm_config: None,
+            normalize_values: false,
         }),
         mlp_config: MLPConfig::Dense(mlp::DenseMLPConfig {
             linear_config: LinearConfig::QLoRA {
@@ -169,6 +170,9 @@ fn test_transformer_layer_config() {
         }),
         post_attention_norm_config: None,
         post_mlp_norm_config: None,
+        hidden_dim: None,
+        kv_source_layer: None,
+        ple_config: None,
     };
 
     let deserialized_config: TransformerLayerConfig = from_str(config_str).unwrap();

--- a/crates/uzu/tests/unit/config/transformer_layer_test.rs
+++ b/crates/uzu/tests/unit/config/transformer_layer_test.rs
@@ -99,6 +99,7 @@ fn test_transformer_layer_config() {
             upcast_mode: UpcastMode::OnlyNormalization,
             subtract_mean: false,
             use_bias: false,
+            has_scale: true,
         }),
         pre_mlp_norm_config: NormalizationConfig {
             scale_precision: ConfigDataType::BFloat16,
@@ -108,6 +109,7 @@ fn test_transformer_layer_config() {
             upcast_mode: UpcastMode::OnlyNormalization,
             subtract_mean: false,
             use_bias: false,
+            has_scale: true,
         },
         mixer_config: MixerConfig::Attention(AttentionConfig {
             qkv_projection_config: LinearConfig::QLoRA {
@@ -145,6 +147,7 @@ fn test_transformer_layer_config() {
             has_gate: false,
             gate_projection_config: None,
             partial_rope_dim: None,
+            value_norm_config: None,
         }),
         mlp_config: MLPConfig::Dense(mlp::DenseMLPConfig {
             linear_config: LinearConfig::QLoRA {

--- a/crates/uzu/tests/unit/kernel/attention/attention_single_pass_test.rs
+++ b/crates/uzu/tests/unit/kernel/attention/attention_single_pass_test.rs
@@ -190,6 +190,12 @@ fn test_head_dim_128<T: ArrayElement + Float + Debug + Display>() {
     test_internal(&input, &expected);
 }
 
+fn test_head_dim_512<T: ArrayElement + Float + Debug + Display>() {
+    let input = get_input::<T>(1, 1, 8, 2, 512, true);
+    let expected = get_output::<T, Cpu>(&input);
+    test_internal(&input, &expected);
+}
+
 // Basic tests
 #[test]
 fn test_basic_f32() {
@@ -252,4 +258,20 @@ fn test_head_dim_128_f16() {
 #[test]
 fn test_head_dim_128_bf16() {
     test_head_dim_128::<bf16>();
+}
+
+// Head dim 512
+#[test]
+fn test_head_dim_512_f32() {
+    test_head_dim_512::<f32>();
+}
+
+#[test]
+fn test_head_dim_512_f16() {
+    test_head_dim_512::<f16>();
+}
+
+#[test]
+fn test_head_dim_512_bf16() {
+    test_head_dim_512::<bf16>();
 }

--- a/crates/uzu/tests/unit/kernel/attention/attention_two_pass_test.rs
+++ b/crates/uzu/tests/unit/kernel/attention/attention_two_pass_test.rs
@@ -286,6 +286,12 @@ fn test_first_pass_head_dim_128<T: ArrayElement + Float + Debug + Display>() {
     test_first_pass_internal(&input, &expected);
 }
 
+fn test_first_pass_head_dim_512<T: ArrayElement + Float + Debug + Display>() {
+    let input = get_first_pass_input::<T>(1, 1, 8, 2, 512, true);
+    let expected = get_first_pass_output::<T, Cpu>(&input);
+    test_first_pass_internal(&input, &expected);
+}
+
 // --- Second pass tests ---
 
 fn test_second_pass_internal<T: ArrayElement + Float + Debug + Display>(
@@ -323,6 +329,12 @@ fn test_second_pass_basic<T: ArrayElement + Float + Debug + Display>() {
 
 fn test_second_pass_head_dim_128<T: ArrayElement + Float + Debug + Display>() {
     let input = get_second_pass_input(4, 2, 128);
+    let expected = get_second_pass_output::<T, Cpu>(&input);
+    test_second_pass_internal::<T>(&input, &expected);
+}
+
+fn test_second_pass_head_dim_512<T: ArrayElement + Float + Debug + Display>() {
+    let input = get_second_pass_input(1, 2, 512);
     let expected = get_second_pass_output::<T, Cpu>(&input);
     test_second_pass_internal::<T>(&input, &expected);
 }
@@ -389,6 +401,21 @@ fn test_first_pass_head_dim_128_bf16() {
     test_first_pass_head_dim_128::<bf16>();
 }
 
+#[test]
+fn test_first_pass_head_dim_512_f32() {
+    test_first_pass_head_dim_512::<f32>();
+}
+
+#[test]
+fn test_first_pass_head_dim_512_f16() {
+    test_first_pass_head_dim_512::<f16>();
+}
+
+#[test]
+fn test_first_pass_head_dim_512_bf16() {
+    test_first_pass_head_dim_512::<bf16>();
+}
+
 // --- Second pass test entries ---
 
 #[test]
@@ -419,4 +446,19 @@ fn test_second_pass_head_dim_128_f16() {
 #[test]
 fn test_second_pass_head_dim_128_bf16() {
     test_second_pass_head_dim_128::<bf16>();
+}
+
+#[test]
+fn test_second_pass_head_dim_512_f32() {
+    test_second_pass_head_dim_512::<f32>();
+}
+
+#[test]
+fn test_second_pass_head_dim_512_f16() {
+    test_second_pass_head_dim_512::<f16>();
+}
+
+#[test]
+fn test_second_pass_head_dim_512_bf16() {
+    test_second_pass_head_dim_512::<bf16>();
 }

--- a/crates/uzu/tests/unit/kernel/element_mul_test.rs
+++ b/crates/uzu/tests/unit/kernel/element_mul_test.rs
@@ -1,0 +1,123 @@
+use std::{
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
+
+use half::{bf16, f16};
+use num_traits::Float;
+use uzu::{
+    ArrayContextExt, ArrayElement,
+    backends::common::{Backend, Context, Encoder, Kernels, kernel::ElementWiseMulStridedKernel},
+};
+
+// ---- Strided ElementWiseMulStrided tests ----
+
+struct StridedInput<T: ArrayElement + Float> {
+    input_a: Box<[T]>,
+    input_b: Box<[T]>,
+    ple_dim: u32,
+    stride: u32,
+    layer_offset: u32,
+    rows: u32,
+}
+
+fn get_strided_test_data<T: ArrayElement + Float>() -> (StridedInput<T>, Vec<T>) {
+    let rows = 4usize;
+    let ple_dim = 64usize;
+    let num_layers = 3usize;
+    let stride = num_layers * ple_dim;
+    let target_layer = 1usize;
+    let layer_offset = target_layer * ple_dim;
+
+    // input_a is contiguous [rows, ple_dim]
+    let mut input_a: Vec<T> = vec![T::zero(); rows * ple_dim];
+    // input_b is strided [rows, num_layers * ple_dim]
+    let mut input_b: Vec<T> = vec![T::zero(); rows * stride];
+    let mut expected: Vec<T> = vec![T::zero(); rows * ple_dim];
+
+    for row in 0..rows {
+        for col in 0..ple_dim {
+            let a_val = T::from(((row * ple_dim + col) as f32).sin() * 10f32).unwrap();
+            input_a[row * ple_dim + col] = a_val;
+
+            // Fill all layers in the strided buffer
+            for layer in 0..num_layers {
+                let b_val = T::from(((row * stride + layer * ple_dim + col) as f32).cos() * 5f32).unwrap();
+                input_b[row * stride + layer * ple_dim + col] = b_val;
+            }
+
+            // Expected uses the target_layer slice
+            let b_val = input_b[row * stride + layer_offset + col];
+            let a_f = a_val.to_f32().unwrap();
+            let b_f = b_val.to_f32().unwrap();
+            expected[row * ple_dim + col] = T::from(a_f * b_f).unwrap();
+        }
+    }
+
+    let input = StridedInput {
+        input_a: input_a.into_boxed_slice(),
+        input_b: input_b.into_boxed_slice(),
+        ple_dim: ple_dim as u32,
+        stride: stride as u32,
+        layer_offset: layer_offset as u32,
+        rows: rows as u32,
+    };
+
+    (input, expected)
+}
+
+fn get_strided_output<T: ArrayElement + Float, B: Backend>(input: &StridedInput<T>) -> Vec<T> {
+    let context = B::Context::new().expect("Failed to create Context");
+
+    let kernel = <<B as Backend>::Kernels as Kernels>::ElementWiseMulStridedKernel::new(&context, T::data_type())
+        .expect("Failed to create ElementWiseMulStridedKernel");
+
+    let a_size = (input.rows * input.ple_dim) as usize;
+    let b_size = (input.rows * input.stride) as usize;
+    let a_array = context.create_array_from(&[a_size], &input.input_a, "");
+    let b_array = context.create_array_from(&[b_size], &input.input_b, "");
+    let out_array = context.create_array_uninitialized(&[a_size], T::data_type(), "");
+
+    let mut encoder = Encoder::new(context.as_ref()).expect("Failed to create encoder");
+    kernel.encode(
+        a_array.buffer().borrow().deref(),
+        b_array.buffer().borrow().deref(),
+        out_array.buffer().borrow_mut().deref_mut(),
+        input.ple_dim,
+        input.stride,
+        input.layer_offset,
+        input.rows,
+        &mut encoder,
+    );
+    encoder.end_encoding().submit().wait_until_completed().unwrap();
+
+    out_array.as_slice().to_vec()
+}
+
+fn test_strided<T: ArrayElement + Float + Debug>() {
+    let (input, expected) = get_strided_test_data::<T>();
+    for_each_backend!(|B| {
+        let output = get_strided_output::<T, B>(&input);
+        assert_eq!(
+            output,
+            expected,
+            "ElementWiseMulStrided results are not equal for backend {}",
+            std::any::type_name::<B>()
+        );
+    });
+}
+
+#[test]
+fn test_strided_f32() {
+    test_strided::<f32>();
+}
+
+#[test]
+fn test_strided_f16() {
+    test_strided::<f16>();
+}
+
+#[test]
+fn test_strided_bf16() {
+    test_strided::<bf16>();
+}

--- a/crates/uzu/tests/unit/kernel/mod.rs
+++ b/crates/uzu/tests/unit/kernel/mod.rs
@@ -7,6 +7,7 @@ mod activation_test;
 mod attention;
 mod audio;
 mod delta_net_test;
+mod element_mul_test;
 mod embedding;
 mod kv_cache_update_test;
 mod layer_norm_test;

--- a/scripts/generate_traces.py
+++ b/scripts/generate_traces.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Generate traces.safetensors for Uzu TraceValidator from HuggingFace Gemma 4.
+
+Captures intermediate activations matching the Uzu trace format:
+- Per-layer inputs, norm outputs, attention, MLP, outputs
+- Model-level output_norm, logits
+- KV cache states
+
+Usage:
+  uv run --with torch --with transformers --with safetensors --with accelerate \
+    scripts/generate_traces.py
+"""
+
+import argparse
+import torch
+from safetensors.torch import save_file
+from transformers import AutoTokenizer, AutoModelForCausalLM
+
+
+def generate_traces(model_name: str, output_path: str, prompt: str):
+    print(f"Loading tokenizer from {model_name}...")
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+
+    print(f"Loading model from {model_name}...")
+    model = AutoModelForCausalLM.from_pretrained(model_name, dtype=torch.bfloat16)
+    model.eval()
+
+    # Gemma 4 is multimodal — text model is at model.model.language_model
+    lm = model.model.language_model
+
+    # Tokenize
+    chat = [{"role": "user", "content": prompt}]
+    formatted = tokenizer.apply_chat_template(chat, tokenize=False, add_generation_prompt=True)
+    inputs = tokenizer(formatted, return_tensors="pt")
+    input_ids = inputs["input_ids"]
+    suffix_length = input_ids.shape[1]
+
+    print(f"Prompt: {repr(formatted[:100])}...")
+    print(f"Token IDs: {input_ids[0].tolist()}")
+    print(f"Suffix length: {suffix_length}")
+
+    traces = {}
+    hooks = []
+
+    # Token info
+    traces["activation_trace.token_ids"] = input_ids[0].to(torch.int32)
+    traces["activation_trace.token_positions"] = torch.arange(suffix_length, dtype=torch.int32)
+
+    num_layers = len(lm.layers)
+    print(f"Model has {num_layers} layers")
+
+    # Storage
+    captured = {}
+
+    def hook_output(name):
+        """Hook that captures the output tensor."""
+        def fn(module, args, output):
+            if isinstance(output, tuple):
+                captured[name] = output[0].detach().clone().float()
+            else:
+                captured[name] = output.detach().clone().float()
+        return fn
+
+    def hook_output_kw(name):
+        """Hook for modules that use kwargs."""
+        def fn(module, args, kwargs, output):
+            if isinstance(output, tuple):
+                captured[name] = output[0].detach().clone().float()
+            else:
+                captured[name] = output.detach().clone().float()
+        return fn
+
+    def hook_input(name):
+        """Hook that captures input hidden_states."""
+        def fn(module, args, kwargs):
+            hs = args[0] if args else kwargs.get('hidden_states')
+            if hs is not None:
+                captured[name] = hs.detach().clone().float()
+        return fn
+
+    # Register hooks per layer
+    for i, layer in enumerate(lm.layers):
+        # Layer input
+        hooks.append(layer.register_forward_pre_hook(hook_input(f"layer.{i}.input"), with_kwargs=True))
+        # Layer output
+        hooks.append(layer.register_forward_hook(hook_output_kw(f"layer.{i}.output"), with_kwargs=True))
+        # Pre-attention norm
+        hooks.append(layer.input_layernorm.register_forward_hook(hook_output(f"layer.{i}.pre_mixer_norm")))
+        # Attention output
+        hooks.append(layer.self_attn.register_forward_hook(hook_output_kw(f"layer.{i}.mixer"), with_kwargs=True))
+        # Post-attention norm
+        if hasattr(layer, 'post_attention_layernorm'):
+            hooks.append(layer.post_attention_layernorm.register_forward_hook(hook_output(f"layer.{i}.post_mixer_norm")))
+        # Pre-MLP norm
+        hooks.append(layer.pre_feedforward_layernorm.register_forward_hook(hook_output(f"layer.{i}.pre_mlp_norm")))
+        # MLP output
+        hooks.append(layer.mlp.register_forward_hook(hook_output_kw(f"layer.{i}.mlp"), with_kwargs=True))
+        # Post-MLP norm
+        if hasattr(layer, 'post_feedforward_layernorm'):
+            hooks.append(layer.post_feedforward_layernorm.register_forward_hook(hook_output(f"layer.{i}.post_mlp_norm")))
+
+        # Attention intermediates (layer 0 only, to keep file size manageable)
+        if i == 0:
+            attn = layer.self_attn
+            hooks.append(attn.q_proj.register_forward_hook(hook_output(f"layer.{i}.q_proj")))
+            hooks.append(attn.k_proj.register_forward_hook(hook_output(f"layer.{i}.k_proj")))
+            hooks.append(attn.v_proj.register_forward_hook(hook_output(f"layer.{i}.v_proj")))
+            hooks.append(attn.q_norm.register_forward_hook(hook_output(f"layer.{i}.q_norm")))
+            hooks.append(attn.k_norm.register_forward_hook(hook_output(f"layer.{i}.k_norm")))
+            hooks.append(attn.v_norm.register_forward_hook(hook_output(f"layer.{i}.v_norm")))
+            hooks.append(attn.o_proj.register_forward_hook(hook_output(f"layer.{i}.o_proj")))
+
+            # PLE intermediates
+            if hasattr(layer, 'per_layer_input_gate'):
+                hooks.append(layer.per_layer_input_gate.register_forward_hook(
+                    hook_output(f"layer.{i}.ple_gate")))
+                hooks.append(layer.per_layer_projection.register_forward_hook(
+                    hook_output(f"layer.{i}.ple_projection")))
+                hooks.append(layer.post_per_layer_input_norm.register_forward_hook(
+                    hook_output(f"layer.{i}.post_ple_norm")))
+
+    # Output norm
+    hooks.append(lm.norm.register_forward_hook(hook_output("output_norm")))
+
+    # Run forward pass
+    print("Running forward pass...")
+    with torch.no_grad():
+        outputs = model(input_ids, use_cache=True)
+
+    logits = outputs.logits.float()
+    print(f"Logits shape: {logits.shape}")
+
+    predicted = logits[0].argmax(dim=-1)
+    print(f"Predicted next token: '{tokenizer.decode(predicted[-1])}' (id={predicted[-1].item()})")
+
+    # Remove hooks
+    for h in hooks:
+        h.remove()
+
+    # Build trace tensors (remove batch dim: [1, seq, dim] -> [seq, dim])
+    if "output_norm" in captured:
+        traces["activation_trace.output_norm"] = captured["output_norm"][0]
+    traces["activation_trace.logits"] = logits[0]
+
+    for i in range(num_layers):
+        prefix = f"activation_trace.layer_results.{i}"
+        ap = f"{prefix}.activation_trace"
+
+        if f"layer.{i}.input" in captured:
+            traces[f"{ap}.inputs"] = captured[f"layer.{i}.input"][0]
+        if f"layer.{i}.pre_mixer_norm" in captured:
+            traces[f"{ap}.pre_mixer_norm"] = captured[f"layer.{i}.pre_mixer_norm"][0]
+        if f"layer.{i}.mixer" in captured:
+            traces[f"{ap}.mixer"] = captured[f"layer.{i}.mixer"][0]
+        if f"layer.{i}.post_mixer_norm" in captured:
+            traces[f"{ap}.post_mixer_norm"] = captured[f"layer.{i}.post_mixer_norm"][0]
+        if f"layer.{i}.pre_mlp_norm" in captured:
+            traces[f"{ap}.pre_mlp_norm"] = captured[f"layer.{i}.pre_mlp_norm"][0]
+        if f"layer.{i}.mlp" in captured:
+            traces[f"{ap}.mlp"] = captured[f"layer.{i}.mlp"][0]
+        if f"layer.{i}.post_mlp_norm" in captured:
+            traces[f"{ap}.post_mlp_norm"] = captured[f"layer.{i}.post_mlp_norm"][0]
+        if f"layer.{i}.output" in captured:
+            traces[f"{prefix}.outputs"] = captured[f"layer.{i}.output"][0]
+
+        for name in ["q_proj", "k_proj", "v_proj", "q_norm", "k_norm", "v_norm", "o_proj",
+                     "ple_gate", "ple_projection", "post_ple_norm"]:
+            key = f"layer.{i}.{name}"
+            if key in captured:
+                traces[f"{ap}.{name}"] = captured[key][0]
+
+    # KV cache (DynamicCache API)
+    past_kv = outputs.past_key_values
+    if past_kv is not None and hasattr(past_kv, 'key_cache'):
+        for i in range(min(num_layers, len(past_kv.key_cache))):
+            traces[f"updated_kv_cache.{i}.keys"] = past_kv.key_cache[i].float().squeeze(0)
+            traces[f"updated_kv_cache.{i}.values"] = past_kv.value_cache[i].float().squeeze(0)
+
+    # Activation tensors should be BF16 to match model precision.
+    # Token IDs/positions stay as int32.
+    final = {}
+    for k, v in traces.items():
+        if v.is_floating_point():
+            final[k] = v.contiguous().to(torch.bfloat16)
+        else:
+            final[k] = v.contiguous()
+
+    print(f"\nSaving {len(final)} tensors to {output_path}")
+    for k in sorted(final.keys())[:20]:
+        print(f"  {k}: {final[k].shape} {final[k].dtype}")
+    if len(final) > 20:
+        print(f"  ... and {len(final) - 20} more")
+
+    save_file(final, output_path)
+    print("Done!")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="google/gemma-4-e2b-it")
+    parser.add_argument("--output", default="models/0.1.8/gemma-4-e2b-4bit/traces.safetensors")
+    parser.add_argument("--prompt", default="What is the capital of France?")
+    args = parser.parse_args()
+    generate_traces(args.model, args.output, args.prompt)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add text-only inference support for Google's Gemma 4 E2B architecture:

- **Per-Layer Embedding (PLE)**: Model-level PLE computation with gated projection, per-layer injection, dedicated ArrayIds and scratch buffers
- **Heterogeneous attention**: Per-layer head_dim (256/512) and num_groups, head_dim=512 Metal+CPU kernel variants, per-layer buffer reshaping
- **KV cache sharing**: Shared layers (15-34) alias KV from source layers via Rc, skip KV update for shared layers
- **Double-wide MLP**: Per-layer hidden_dims, max-based buffer sizing for scratch buffers
- **Per-layer scalar**: Layer-wise scaling factor applied after residual + PLE
- **V-norm**: QK normalization with all-ones value normalization buffer
- **Proportional RoPE**: Per-type (global/local) head_dim for frequency computation
- **Fused norm compatibility**: Explicit residual add before PLE/scalar to work correctly with fused RMSNorm

Requires trymirai/lalamo#197 (model conversion support)

## Benchmark (4-bit quantized, Apple M3 16GB)

| Metric           | uzu    | MLX      | Delta   |
|------------------|--------|----------|---------|
| Prefill (t/s)    | 516.9  | 1039.5   | -50.3%  |
| Generation (t/s) | 38.8   | 57.1     | -32.1%  |


*Prompt 64 tokens, generation 256 tokens, 5 runs. MLX via mlx-lm@main (0.31.2, unreleased). Same quantization config (4-bit, group_size=64, affine). Initial implementation prioritizes correctness; optimization opportunities identified (KV projection waste, buffer reuse).*

## Trace Validation

Full-precision model validated against HuggingFace reference (`scripts/generate_traces.py`):
- **0/1 token violations** (correct argmax prediction)
- Layers 0-14: <1.5% output error (bf16 precision floor)
- Layers 15-34 (shared): <2.5% output error (accumulated bf16 drift)
- Mixer (attention) error: 0.23%-0.99% across all 35 layers

## Scope

Text modality only, consistent with how other multimodal models (Gemma 3) are supported in uzu. Vision/audio encoders can be added incrementally.

## Known Limitations

- **KV projection waste**: Shared layers still compute unused K/V projections (~33% wasted compute, performance-only). Fix: skip K/V projection for shared layers.

## Test Plan

- [x] `cargo +nightly fmt --check` passes
- [x] `CARGO_ENCODED_RUSTFLAGS="-Dwarnings" cargo build` passes (zero warnings)
- [x] `cargo test --package uzu --features tracing --lib` passes (97/97)
- [x] Tracer integration test passes (0 token violations)
- [x] Full-precision model generates coherent text (18.2 t/s)
- [x] 4-bit quantized model generates coherent text (40.7 t/s)
- [x] HEAD_DIM=512 attention kernel tests added (single-pass + two-pass)

## Hardware Note

Developed and tested on Apple M3 with 16GB RAM. Both full-precision (9.1GB) and 4-bit quantized (6.6GB) models load and generate correctly.