### PR TITLE
Run ci on wip prs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    types: [ opened, reopened, ready_for_review, synchronize ]
   workflow_dispatch:
 
 concurrency:
@@ -53,7 +52,6 @@ jobs:
   tests:
     name: ${{ matrix.backend }} ${{ matrix.tracing && ' (tracing)' || '' }}
     runs-on: [ self-hosted, macos, mac, arm64 ]
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
 
     strategy:
       matrix:


### PR DESCRIPTION
A small number of wasted ci runs is not worth the noise of "ready to review" prs that are just marked as such to run ci