### PR TITLE
[codex] Add reduced-width MLP compaction tooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,8 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 name = "benchmarks"
 version = "0.1.8"
 dependencies = [
+ "anyhow",
+ "clap",
  "half",
  "libc",
  "mach2",
@@ -317,6 +319,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sysinfo",
+ "tokenizers",
  "uzu",
 ]
 

--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -3,9 +3,16 @@ name = "benchmarks"
 version.workspace = true
 edition.workspace = true
 
+[features]
+default = ["metal-backend"]
+tracing = ["uzu/tracing"]
+metal-backend = ["uzu/metal"]
+
 [dependencies]
+anyhow.workspace = true
+clap.workspace = true
 metal.workspace = true
-uzu.workspace = true
+uzu = { path = "../uzu", version = "0.1.8", default-features = false }
 serde.workspace = true
 serde_json.workspace = true
 sysinfo.workspace = true
@@ -13,3 +20,4 @@ libc.workspace = true
 mach2.workspace = true
 half.workspace = true
 objc2.workspace = true
+tokenizers.workspace = true

--- a/crates/benchmarks/src/bin/dump_prefill_mlp_trace.rs
+++ b/crates/benchmarks/src/bin/dump_prefill_mlp_trace.rs
@@ -1,0 +1,161 @@
+#[cfg(not(feature = "tracing"))]
+compile_error!("dump_prefill_mlp_trace requires `--features tracing`");
+
+use std::{
+    fs::{self, File},
+    io::{BufReader, Write},
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Result, anyhow, bail};
+use benchmarks::runner::types::Task;
+use clap::Parser;
+use serde::Serialize;
+use tokenizers::Tokenizer;
+#[cfg(feature = "metal-backend")]
+use uzu::backends::metal::Metal;
+use uzu::{
+    backends::{common::Backend, cpu::Cpu},
+    config::ModelMetadata,
+    language_model::{LanguageModelGenerator, language_model_generator::PrefillTraceDump},
+    session::{
+        config::DecodingConfig,
+        helpers::{InputProcessor, InputProcessorDefault},
+        parameter::{ContextLength, PrefillStepSize},
+        types::Input,
+    },
+};
+
+#[derive(Parser)]
+struct Args {
+    model: PathBuf,
+    task: PathBuf,
+    output_dir: PathBuf,
+    #[arg(long)]
+    prefill_step_size: Option<usize>,
+}
+
+#[derive(Serialize)]
+struct LayerManifest {
+    layer_index: usize,
+    rows: usize,
+    cols: usize,
+    pre_mlp_norm_file: String,
+    mlp_file: String,
+}
+
+#[derive(Serialize)]
+struct TraceManifest {
+    identifier: String,
+    input_tokens: usize,
+    logits_rows: usize,
+    logits_cols: usize,
+    logits_file: String,
+    layers: Vec<LayerManifest>,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let task = load_task(&args.task)?;
+    match std::env::var("UZU_BACKEND").map(|value| value.to_ascii_lowercase()) {
+        Ok(value) if value == "cpu" => run::<Cpu>(&args.model, &task, args.prefill_step_size, &args.output_dir),
+        #[cfg(feature = "metal-backend")]
+        Ok(value) if value == "metal" => run::<Metal>(&args.model, &task, args.prefill_step_size, &args.output_dir),
+        #[cfg(not(feature = "metal-backend"))]
+        Ok(value) if value == "metal" => bail!("metal backend was not built; rebuild with `--features metal-backend`"),
+        Ok(value) => bail!("Unsupported backend: {value}"),
+        #[cfg(feature = "metal-backend")]
+        Err(_) => run::<Metal>(&args.model, &task, args.prefill_step_size, &args.output_dir),
+        #[cfg(not(feature = "metal-backend"))]
+        Err(_) => run::<Cpu>(&args.model, &task, args.prefill_step_size, &args.output_dir),
+    }
+}
+
+fn load_task(path: &Path) -> Result<Task> {
+    Ok(serde_json::from_reader(BufReader::new(File::open(path)?))?)
+}
+
+fn run<B: Backend>(
+    model_path: &Path,
+    task: &Task,
+    prefill_step_size: Option<usize>,
+    output_dir: &Path,
+) -> Result<()>
+where
+    B::Error: std::error::Error + Send + Sync + 'static,
+{
+    let metadata: ModelMetadata = serde_json::from_reader(BufReader::new(File::open(model_path.join("config.json"))?))?;
+    let lm_config = metadata.model_config.as_language_model().ok_or_else(|| anyhow!("language model config"))?;
+    let input_processor = InputProcessorDefault::new(lm_config.message_processor_config.clone());
+    let prompt = input_processor
+        .process(&Input::Messages(task.messages.clone()), false, task.tokens_limit > 0)
+        .map_err(|err| anyhow!("input processor: {err}"))?;
+    let tokenizer = Tokenizer::from_file(model_path.join("tokenizer.json")).map_err(|_| anyhow!("tokenizer"))?;
+    let tokens = tokenizer
+        .encode(prompt.as_str(), false)
+        .map_err(|_| anyhow!("encode prompt"))?
+        .get_ids()
+        .iter()
+        .map(|&token| token as u64)
+        .collect::<Vec<_>>();
+    assert!(!tokens.is_empty(), "prompt must produce at least one token");
+
+    let mut decoding_config = DecodingConfig::default().with_context_length(ContextLength::Custom(tokens.len() + 1));
+    if let Some(prefill_step_size) = prefill_step_size {
+        decoding_config = decoding_config.with_prefill_step_size(PrefillStepSize::Custom(prefill_step_size));
+    }
+
+    let mut generator =
+        LanguageModelGenerator::<B>::new(model_path, decoding_config).map_err(|err| anyhow!("generator: {err}"))?;
+    let traces = generator.probe_prefill_trace_dump(tokens.clone()).map_err(|err| anyhow!("prefill trace: {err}"))?;
+    write_trace_dump(output_dir, &task.identifier, tokens.len(), &traces)
+}
+
+fn write_trace_dump(
+    output_dir: &Path,
+    identifier: &str,
+    input_tokens: usize,
+    traces: &PrefillTraceDump,
+) -> Result<()> {
+    fs::create_dir_all(output_dir)?;
+    let layers = traces
+        .layers
+        .iter()
+        .map(|trace| {
+            let pre_mlp_norm_file = format!("layer_{:02}_pre_mlp_norm.f32", trace.layer_index);
+            let mlp_file = format!("layer_{:02}_mlp.f32", trace.layer_index);
+            write_f32_file(&output_dir.join(&pre_mlp_norm_file), &trace.pre_mlp_norm)?;
+            write_f32_file(&output_dir.join(&mlp_file), &trace.mlp)?;
+            Ok(LayerManifest {
+                layer_index: trace.layer_index,
+                rows: trace.rows,
+                cols: trace.cols,
+                pre_mlp_norm_file,
+                mlp_file,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let logits_file = "logits.f32".to_string();
+    write_f32_file(&output_dir.join(&logits_file), &traces.logits.logits)?;
+    let manifest = TraceManifest {
+        identifier: identifier.to_string(),
+        input_tokens,
+        logits_rows: traces.logits.rows,
+        logits_cols: traces.logits.cols,
+        logits_file,
+        layers,
+    };
+    serde_json::to_writer_pretty(File::create(output_dir.join("manifest.json"))?, &manifest)?;
+    Ok(())
+}
+
+fn write_f32_file(
+    path: &Path,
+    values: &[f32],
+) -> Result<()> {
+    let mut file = File::create(path)?;
+    for value in values {
+        file.write_all(&value.to_le_bytes())?;
+    }
+    Ok(())
+}

--- a/crates/benchmarks/src/bin/prefill_probe.rs
+++ b/crates/benchmarks/src/bin/prefill_probe.rs
@@ -1,0 +1,153 @@
+use std::{
+    fs::File,
+    io::BufReader,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Result, anyhow, bail};
+use benchmarks::runner::{Runner, types::Task};
+use clap::Parser;
+use serde::Serialize;
+use tokenizers::Tokenizer;
+#[cfg(feature = "metal-backend")]
+use uzu::backends::metal::Metal;
+use uzu::{
+    backends::{common::Backend, cpu::Cpu},
+    config::ModelMetadata,
+    language_model::LanguageModelGenerator,
+    session::{
+        config::DecodingConfig,
+        helpers::{InputProcessor, InputProcessorDefault},
+        parameter::{ContextLength, PrefillStepSize, SamplingMethod},
+        types::Input,
+    },
+};
+
+#[derive(Parser)]
+struct Args {
+    model: PathBuf,
+    task: PathBuf,
+    output: PathBuf,
+    #[arg(long)]
+    prefill_step_size: Option<usize>,
+}
+
+#[derive(Serialize)]
+struct ProbeResult {
+    identifier: String,
+    memory_used: Option<u64>,
+    time_to_first_token: f64,
+    prompt_tokens_per_second: f64,
+    generate_tokens_per_second: Option<f64>,
+    text: String,
+    input_tokens: usize,
+    prefill_top_token: u64,
+    prefill_logits: Vec<f32>,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let task = load_task(&args.task)?;
+    let result = match std::env::var("UZU_BACKEND").map(|value| value.to_ascii_lowercase()) {
+        Ok(value) if value == "cpu" => run::<Cpu>(&args.model, &task, args.prefill_step_size)?,
+        #[cfg(feature = "metal-backend")]
+        Ok(value) if value == "metal" => run::<Metal>(&args.model, &task, args.prefill_step_size)?,
+        #[cfg(not(feature = "metal-backend"))]
+        Ok(value) if value == "metal" => bail!("metal backend was not built; rebuild with `--features metal-backend`"),
+        Ok(value) => bail!("Unsupported backend: {value}"),
+        #[cfg(feature = "metal-backend")]
+        Err(_) => run::<Metal>(&args.model, &task, args.prefill_step_size)?,
+        #[cfg(not(feature = "metal-backend"))]
+        Err(_) => run::<Cpu>(&args.model, &task, args.prefill_step_size)?,
+    };
+    serde_json::to_writer_pretty(File::create(&args.output)?, &result)?;
+    Ok(())
+}
+
+fn load_task(path: &Path) -> Result<Task> {
+    Ok(serde_json::from_reader(BufReader::new(File::open(path)?))?)
+}
+
+fn run<B: Backend>(
+    model_path: &Path,
+    task: &Task,
+    prefill_step_size: Option<usize>,
+) -> Result<ProbeResult>
+where
+    B::Error: std::error::Error + Send + Sync + 'static,
+{
+    let runner = Runner::new(task.clone(), model_path.display().to_string(), prefill_step_size);
+    let perf = runner.run(None::<fn(f64)>).map_err(|err| anyhow!("runner failed: {err}"))?;
+    let perf = perf.into_iter().collect::<Vec<_>>();
+    assert!(!perf.is_empty(), "prefill probe expects at least one result");
+    let first = perf.first().expect("missing first result");
+    assert!(
+        perf.iter().all(|result| result.text == first.text),
+        "prefill probe expects deterministic text across runs"
+    );
+    let time_to_first_token = perf.iter().map(|result| result.time_to_first_token).sum::<f64>() / perf.len() as f64;
+    let prompt_tokens_per_second =
+        perf.iter().map(|result| result.prompt_tokens_per_second).sum::<f64>() / perf.len() as f64;
+    let generate_tokens_per_second = if perf.iter().all(|result| result.generate_tokens_per_second.is_some()) {
+        Some(
+            perf.iter().map(|result| result.generate_tokens_per_second.expect("checked above")).sum::<f64>()
+                / perf.len() as f64,
+        )
+    } else {
+        None
+    };
+    let prefill_logits = extract_sampled_prefill_logits::<B>(model_path, task, prefill_step_size)?;
+    let prefill_top_token = prefill_logits
+        .iter()
+        .enumerate()
+        .max_by(|lhs, rhs| lhs.1.partial_cmp(rhs.1).expect("logits must be finite"))
+        .map(|(index, _)| index as u64)
+        .expect("logits must be non-empty");
+
+    Ok(ProbeResult {
+        identifier: task.identifier.clone(),
+        memory_used: first.memory_used,
+        time_to_first_token,
+        prompt_tokens_per_second,
+        generate_tokens_per_second,
+        text: first.text.clone(),
+        input_tokens: first.tokens_count_input as usize,
+        prefill_top_token,
+        prefill_logits,
+    })
+}
+
+fn extract_sampled_prefill_logits<B: Backend>(
+    model_path: &Path,
+    task: &Task,
+    prefill_step_size: Option<usize>,
+) -> Result<Vec<f32>>
+where
+    B::Error: std::error::Error + Send + Sync + 'static,
+{
+    let metadata: ModelMetadata = serde_json::from_reader(BufReader::new(File::open(model_path.join("config.json"))?))?;
+    let lm_config = metadata.model_config.as_language_model().ok_or_else(|| anyhow!("language model config"))?;
+    let input_processor = InputProcessorDefault::new(lm_config.message_processor_config.clone());
+    let prompt = input_processor
+        .process(&Input::Messages(task.messages.clone()), false, task.tokens_limit > 0)
+        .map_err(|err| anyhow!("input processor: {err}"))?;
+    let tokenizer = Tokenizer::from_file(model_path.join("tokenizer.json")).map_err(|_| anyhow!("tokenizer"))?;
+    let tokens = tokenizer
+        .encode(prompt.as_str(), false)
+        .map_err(|_| anyhow!("encode prompt"))?
+        .get_ids()
+        .iter()
+        .map(|&token| token as u64)
+        .collect::<Vec<_>>();
+    assert!(!tokens.is_empty(), "prompt must produce at least one token");
+
+    let mut decoding_config = DecodingConfig::default()
+        .with_context_length(ContextLength::Custom(tokens.len() + task.tokens_limit as usize + 1));
+    if let Some(prefill_step_size) = prefill_step_size {
+        decoding_config = decoding_config.with_prefill_step_size(PrefillStepSize::Custom(prefill_step_size));
+    }
+
+    let mut generator =
+        LanguageModelGenerator::<B>::new(model_path, decoding_config).map_err(|err| anyhow!("generator: {err}"))?;
+    generator.probe_prefill_logits(tokens, SamplingMethod::Greedy).map_err(|err| anyhow!("prefill probe: {err}"))
+}

--- a/crates/uzu/src/encodable_block/classifier_layer.rs
+++ b/crates/uzu/src/encodable_block/classifier_layer.rs
@@ -301,7 +301,7 @@ impl<B: Backend> ClassifierLayer<B> {
             state.encode_copy_array(command_buffer, ArrayId::Main, layer_traces.borrow().pre_mlp_norm.clone());
         }
 
-        self.mlp.encode(state, command_buffer)?;
+        self.mlp.encode(state, parameters, command_buffer)?;
         #[cfg(feature = "tracing")]
         if let Some(ref layer_traces) = layer_traces {
             state.encode_copy_array(command_buffer, ArrayId::Main, layer_traces.borrow().mlp.clone());

--- a/crates/uzu/src/encodable_block/layer/executables.rs
+++ b/crates/uzu/src/encodable_block/layer/executables.rs
@@ -330,7 +330,7 @@ impl<B: Backend> LayerExecutables<B> {
             state.encode_copy_array(command_buffer, ArrayId::Main, layer_traces.borrow().pre_mlp_norm.clone());
         }
 
-        self.mlp.encode(state, command_buffer)?;
+        self.mlp.encode(state, parameters, command_buffer)?;
         #[cfg(feature = "tracing")]
         if let Some(ref layer_traces) = layer_traces {
             state.encode_copy_array(command_buffer, ArrayId::Main, layer_traces.borrow().mlp.clone());

--- a/crates/uzu/src/encodable_block/linear/full_precision.rs
+++ b/crates/uzu/src/encodable_block/linear/full_precision.rs
@@ -4,11 +4,13 @@ use std::{
     rc::Rc,
 };
 
+use half::{bf16, f16};
 use thiserror::Error;
 
 use super::Linear;
 use crate::{
-    DataType,
+    ArrayElement, DataType,
+    array::ArrayContextExt,
     backends::common::{
         Backend, CommandBuffer,
         kernel::matmul::{FullPrecisionMatmulArguments, FullPrecisionMatmulKernel, MatmulError, MatmulKernels},
@@ -123,6 +125,173 @@ impl<B: Backend> FullPrecisionLinear<B> {
             output_array_id,
         })
     }
+
+    pub fn new_selected_rows(
+        context: &B::Context,
+        precision: DataType,
+        input_dim: usize,
+        output_dim: usize,
+        selected_rows: &[usize],
+        parameter_tree: &ParameterTree<B::Context>,
+        input_array_id: ArrayId,
+        output_array_id: ArrayId,
+    ) -> Result<Self, FullPrecisionLinearError<B>> {
+        let weights = parameter_tree.leaf_array("weights").map_err(FullPrecisionLinearError::ParameterError)?;
+        let weights_shape = weights.shape().to_vec();
+        if weights_shape != [output_dim, input_dim] {
+            return Err(FullPrecisionLinearError::InvalidWeightsShape {
+                got: weights_shape.into_boxed_slice(),
+                expected_output_dim: output_dim,
+                expected_input_dim: input_dim,
+            });
+        }
+        if weights.data_type() != precision {
+            return Err(FullPrecisionLinearError::InvalidWeightsDataType {
+                expected: precision,
+                got: weights.data_type(),
+            });
+        }
+
+        let weights_buffer = compact_rows_buffer(context, &weights, selected_rows, input_dim, "selected_rows_weights");
+        let bias_buffer = match parameter_tree.leaf_array("biases") {
+            Ok(biases) => Some(compact_rows_buffer(context, &biases, selected_rows, 1, "selected_rows_biases")),
+            Err(_) => None,
+        };
+        let kernel = <B::Kernels as MatmulKernels>::FullPrecisionMatmulKernel::new(context, precision)?;
+
+        Ok(Self {
+            kernel: RefCell::new(kernel),
+            bias_buffer,
+            weights_buffer,
+            input_dim,
+            output_dim: selected_rows.len(),
+            input_array_id,
+            output_array_id,
+        })
+    }
+
+    pub fn new_selected_columns(
+        context: &B::Context,
+        precision: DataType,
+        input_dim: usize,
+        output_dim: usize,
+        selected_columns: &[usize],
+        parameter_tree: &ParameterTree<B::Context>,
+        input_array_id: ArrayId,
+        output_array_id: ArrayId,
+    ) -> Result<Self, FullPrecisionLinearError<B>> {
+        let weights = parameter_tree.leaf_array("weights").map_err(FullPrecisionLinearError::ParameterError)?;
+        let weights_shape = weights.shape().to_vec();
+        if weights_shape != [output_dim, input_dim] {
+            return Err(FullPrecisionLinearError::InvalidWeightsShape {
+                got: weights_shape.into_boxed_slice(),
+                expected_output_dim: output_dim,
+                expected_input_dim: input_dim,
+            });
+        }
+        if weights.data_type() != precision {
+            return Err(FullPrecisionLinearError::InvalidWeightsDataType {
+                expected: precision,
+                got: weights.data_type(),
+            });
+        }
+
+        let weights_buffer = compact_columns_buffer(
+            context,
+            &weights,
+            selected_columns,
+            output_dim,
+            input_dim,
+            "selected_columns_weights",
+        );
+        let bias_buffer = match parameter_tree.leaf_array("biases") {
+            Ok(biases) => Some(biases.buffer()),
+            Err(_) => None,
+        };
+        let kernel = <B::Kernels as MatmulKernels>::FullPrecisionMatmulKernel::new(context, precision)?;
+
+        Ok(Self {
+            kernel: RefCell::new(kernel),
+            bias_buffer,
+            weights_buffer,
+            input_dim: selected_columns.len(),
+            output_dim,
+            input_array_id,
+            output_array_id,
+        })
+    }
+}
+
+fn compact_rows_buffer<B: Backend>(
+    context: &B::Context,
+    source: &crate::array::Array<B>,
+    selected_rows: &[usize],
+    input_dim: usize,
+    label: &str,
+) -> Rc<RefCell<B::Buffer>> {
+    match source.data_type() {
+        DataType::BF16 => compact_rows_buffer_t::<B, bf16>(context, source, selected_rows, input_dim, label),
+        DataType::F16 => compact_rows_buffer_t::<B, f16>(context, source, selected_rows, input_dim, label),
+        DataType::F32 => compact_rows_buffer_t::<B, f32>(context, source, selected_rows, input_dim, label),
+        dtype => panic!("Unsupported dtype for selected full-precision rows: {dtype:?}"),
+    }
+}
+
+fn compact_rows_buffer_t<B: Backend, T: ArrayElement + Copy>(
+    context: &B::Context,
+    source: &crate::array::Array<B>,
+    selected_rows: &[usize],
+    input_dim: usize,
+    label: &str,
+) -> Rc<RefCell<B::Buffer>> {
+    let values = source.as_slice::<T>();
+    let mut compact = Vec::with_capacity(selected_rows.len() * input_dim);
+    for &row in selected_rows {
+        let start = row * input_dim;
+        compact.extend_from_slice(&values[start..start + input_dim]);
+    }
+    context.create_array_from(&[selected_rows.len(), input_dim], &compact, label).buffer()
+}
+
+fn compact_columns_buffer<B: Backend>(
+    context: &B::Context,
+    source: &crate::array::Array<B>,
+    selected_columns: &[usize],
+    output_dim: usize,
+    input_dim: usize,
+    label: &str,
+) -> Rc<RefCell<B::Buffer>> {
+    match source.data_type() {
+        DataType::BF16 => {
+            compact_columns_buffer_t::<B, bf16>(context, source, selected_columns, output_dim, input_dim, label)
+        },
+        DataType::F16 => {
+            compact_columns_buffer_t::<B, f16>(context, source, selected_columns, output_dim, input_dim, label)
+        },
+        DataType::F32 => {
+            compact_columns_buffer_t::<B, f32>(context, source, selected_columns, output_dim, input_dim, label)
+        },
+        dtype => panic!("Unsupported dtype for selected full-precision columns: {dtype:?}"),
+    }
+}
+
+fn compact_columns_buffer_t<B: Backend, T: ArrayElement + Copy>(
+    context: &B::Context,
+    source: &crate::array::Array<B>,
+    selected_columns: &[usize],
+    output_dim: usize,
+    input_dim: usize,
+    label: &str,
+) -> Rc<RefCell<B::Buffer>> {
+    let values = source.as_slice::<T>();
+    let mut compact = Vec::with_capacity(output_dim * selected_columns.len());
+    for row in 0..output_dim {
+        let row_offset = row * input_dim;
+        for &column in selected_columns {
+            compact.push(values[row_offset + column]);
+        }
+    }
+    context.create_array_from(&[output_dim, selected_columns.len()], &compact, label).buffer()
 }
 
 impl<B: Backend> Linear<B> for FullPrecisionLinear<B> {

--- a/crates/uzu/src/encodable_block/mlp/dense.rs
+++ b/crates/uzu/src/encodable_block/mlp/dense.rs
@@ -5,6 +5,7 @@ use std::ops::{Deref, DerefMut};
 use super::{super::linear::Linear, Mlp};
 use crate::{
     backends::common::{Backend, CommandBuffer, kernel::mlp_gate_act_mul::MlpGateActMulEncodable},
+    encodable_block::EncodingParameters,
     forward_pass::state::{ArrayId, ForwardPassState},
 };
 
@@ -12,6 +13,9 @@ pub struct DenseMlp<B: Backend> {
     up: Box<dyn Linear<B>>,
     gate: MlpGateActMulEncodable<B>,
     down: Box<dyn Linear<B>>,
+    prefill_reduced_up: Option<Box<dyn Linear<B>>>,
+    prefill_reduced_gate: Option<MlpGateActMulEncodable<B>>,
+    prefill_reduced_down: Option<Box<dyn Linear<B>>>,
 }
 
 impl<B: Backend> DenseMlp<B> {
@@ -19,12 +23,60 @@ impl<B: Backend> DenseMlp<B> {
         up: Box<dyn Linear<B>>,
         gate: MlpGateActMulEncodable<B>,
         down: Box<dyn Linear<B>>,
+        prefill_reduced_up: Option<Box<dyn Linear<B>>>,
+        prefill_reduced_gate: Option<MlpGateActMulEncodable<B>>,
+        prefill_reduced_down: Option<Box<dyn Linear<B>>>,
     ) -> Self {
         Self {
             up,
             gate,
             down,
+            prefill_reduced_up,
+            prefill_reduced_gate,
+            prefill_reduced_down,
         }
+    }
+
+    fn uses_prefill_reduced(
+        &self,
+        state: &ForwardPassState<B>,
+        parameters: &EncodingParameters,
+    ) -> bool {
+        (state.is_prefilling() || state.sampling_start() > 0)
+            && parameters.projection_step.is_none()
+            && self.prefill_reduced_up.is_some()
+            && self.prefill_reduced_gate.is_some()
+            && self.prefill_reduced_down.is_some()
+    }
+
+    fn encode_gate(
+        gate: &MlpGateActMulEncodable<B>,
+        state: &mut ForwardPassState<B>,
+        command_buffer: &mut <B::CommandBuffer as CommandBuffer>::Encoding,
+    ) {
+        let arrays = state.arrays(&[ArrayId::MlpFusedUp, ArrayId::MlpHidden]);
+        let fused = arrays[0].borrow_mut();
+        let hidden = arrays[1].borrow_mut();
+        let batch_size = fused.shape()[0] as i32;
+        let fused_buffer = fused.buffer();
+        let fused_buffer = fused_buffer.borrow();
+        let hidden_buffer = hidden.buffer();
+        let mut hidden_buffer = hidden_buffer.borrow_mut();
+        gate.encode(command_buffer, fused_buffer.deref(), hidden_buffer.deref_mut(), batch_size)
+            .expect("Failed to encode MLP activation/mul kernel");
+    }
+
+    fn encode_with(
+        up: &dyn Linear<B>,
+        gate: &MlpGateActMulEncodable<B>,
+        down: &dyn Linear<B>,
+        state: &mut ForwardPassState<B>,
+        command_buffer: &mut <B::CommandBuffer as CommandBuffer>::Encoding,
+    ) -> Result<(), B::Error> {
+        up.encode(state, command_buffer)?;
+        Self::encode_gate(gate, state, command_buffer);
+        down.encode(state, command_buffer)?;
+        Ok(())
     }
 }
 
@@ -32,30 +84,18 @@ impl<B: Backend> Mlp<B> for DenseMlp<B> {
     fn encode(
         &self,
         state: &mut ForwardPassState<B>,
+        parameters: &EncodingParameters,
         command_buffer: &mut <B::CommandBuffer as CommandBuffer>::Encoding,
     ) -> Result<(), B::Error> {
-        // Up
-        self.up.encode(state, command_buffer)?;
-
-        // Gate act+mul (fused_up -> hidden)
-        let arrays = state.arrays(&[ArrayId::MlpFusedUp, ArrayId::MlpHidden]);
-        let fused = arrays[0].borrow_mut();
-        let hidden = arrays[1].borrow_mut();
-        let m = fused.shape()[0] as i32;
-        let fused_buf_rc = fused.buffer();
-        let fused_buf_borrow = fused_buf_rc.borrow();
-        let hidden_buf_rc = hidden.buffer();
-        let mut hidden_buf_borrow = hidden_buf_rc.borrow_mut();
-        self.gate
-            .encode(command_buffer, fused_buf_borrow.deref(), hidden_buf_borrow.deref_mut(), m)
-            .expect("Failed to encode MLP activation/mul kernel");
-        drop(hidden_buf_borrow);
-        drop(fused_buf_borrow);
-        drop(fused);
-        drop(hidden);
-
-        // Down
-        self.down.encode(state, command_buffer)?;
-        Ok(())
+        if self.uses_prefill_reduced(state, parameters) {
+            return Self::encode_with(
+                self.prefill_reduced_up.as_deref().expect("checked above"),
+                self.prefill_reduced_gate.as_ref().expect("checked above"),
+                self.prefill_reduced_down.as_deref().expect("checked above"),
+                state,
+                command_buffer,
+            );
+        }
+        Self::encode_with(self.up.as_ref(), &self.gate, self.down.as_ref(), state, command_buffer)
     }
 }

--- a/crates/uzu/src/encodable_block/mlp/mod.rs
+++ b/crates/uzu/src/encodable_block/mlp/mod.rs
@@ -1,23 +1,33 @@
 mod dense;
 mod moe;
 
-pub use dense::DenseMlp;
-pub use moe::{MoeBlock, MoeBlockError};
+use std::collections::BTreeMap;
+
+use half::{bf16, f16};
+use serde::Deserialize;
 use thiserror::Error;
 
-use super::linear::{Linear, LinearBlockError};
+pub use dense::DenseMlp;
+pub use moe::{MoeBlock, MoeBlockError};
+
+use super::linear::{FullPrecisionLinear, Linear, LinearBlockError};
 use crate::{
-    DataType,
+    ArrayElement, DataType,
     backends::common::{Backend, CommandBuffer, kernel::mlp_gate_act_mul::MlpGateActMulEncodable},
-    config::MLPConfig,
+    config::{LinearConfig, MLPConfig},
+    encodable_block::EncodingParameters,
     forward_pass::state::{ArrayId, ForwardPassState},
     parameters::{ParameterLoaderError, ParameterTree},
+    utils::env_utils::EnvVar,
 };
+
+const MLP_BLOCK_SIZE: usize = 32;
 
 pub trait Mlp<B: Backend> {
     fn encode(
         &self,
         state: &mut ForwardPassState<B>,
+        parameters: &EncodingParameters,
         command_buffer: &mut <B::CommandBuffer as CommandBuffer>::Encoding,
     ) -> Result<(), B::Error>;
 }
@@ -44,6 +54,63 @@ impl<B: Backend> dyn Mlp<B> {
     ) -> Result<Box<dyn Mlp<B>>, MlpBlockError<B>> {
         if let MLPConfig::Dense(dense_config) = config {
             let data_type: DataType = dense_config.linear_config.activation_precision().into();
+            let label = parameter_tree.path_prefix().expect("Dense MLP should have a parameter path");
+            let selected_blocks = static_block_indices_from_env(&label, hidden_dimension)
+                .map(Ok)
+                .or_else(|| {
+                    static_keep_ratio_from_env()
+                        .map(|keep_ratio| select_static_mlp_blocks(parameter_tree, hidden_dimension, keep_ratio))
+                })
+                .transpose()?;
+
+            let prefill_reduced = selected_blocks
+                .as_deref()
+                .map(|selected_blocks| {
+                    let LinearConfig::FullPrecision {
+                        precision,
+                    } = &dense_config.linear_config
+                    else {
+                        panic!("Reduced-width MLP currently requires full-precision linears");
+                    };
+                    let selected_hidden = selected_hidden_indices(selected_blocks);
+                    let selected_up = selected_up_rows(&selected_hidden, hidden_dimension);
+                    let reduced_hidden_dimension = selected_hidden.len();
+                    let up_projection = FullPrecisionLinear::new_selected_rows(
+                        context,
+                        (*precision).into(),
+                        model_dimension,
+                        2 * hidden_dimension,
+                        &selected_up,
+                        &parameter_tree.subtree("up_projection")?,
+                        ArrayId::Main,
+                        ArrayId::MlpFusedUp,
+                    )
+                    .map_err(LinearBlockError::FullPrecisionLinearError)?;
+                    let gate = MlpGateActMulEncodable::new(
+                        context,
+                        data_type,
+                        dense_config.activation.clone(),
+                        reduced_hidden_dimension,
+                    )
+                    .map_err(MlpBlockError::BackendError)?;
+                    let down_projection = FullPrecisionLinear::new_selected_columns(
+                        context,
+                        (*precision).into(),
+                        hidden_dimension,
+                        model_dimension,
+                        &selected_hidden,
+                        &parameter_tree.subtree("down_projection")?,
+                        ArrayId::MlpHidden,
+                        ArrayId::Main,
+                    )
+                    .map_err(LinearBlockError::FullPrecisionLinearError)?;
+                    Ok::<_, MlpBlockError<B>>((
+                        Box::new(up_projection) as Box<dyn Linear<B>>,
+                        gate,
+                        Box::new(down_projection) as Box<dyn Linear<B>>,
+                    ))
+                })
+                .transpose()?;
 
             let up_projection = <dyn Linear<B>>::new(
                 &dense_config.linear_config,
@@ -55,11 +122,9 @@ impl<B: Backend> dyn Mlp<B> {
                 ArrayId::Main,
                 ArrayId::MlpFusedUp,
             )?;
-
             let gate_activation =
                 MlpGateActMulEncodable::new(context, data_type, dense_config.activation.clone(), hidden_dimension)
                     .map_err(MlpBlockError::BackendError)?;
-
             let down_projection = <dyn Linear<B>>::new(
                 &dense_config.linear_config,
                 false,
@@ -70,8 +135,19 @@ impl<B: Backend> dyn Mlp<B> {
                 ArrayId::MlpHidden,
                 ArrayId::Main,
             )?;
+            let (prefill_reduced_up, prefill_reduced_gate, prefill_reduced_down) = match prefill_reduced {
+                Some((up, gate, down)) => (Some(up), Some(gate), Some(down)),
+                None => (None, None, None),
+            };
 
-            return Ok(Box::new(DenseMlp::new(up_projection, gate_activation, down_projection)));
+            return Ok(Box::new(DenseMlp::new(
+                up_projection,
+                gate_activation,
+                down_projection,
+                prefill_reduced_up,
+                prefill_reduced_gate,
+                prefill_reduced_down,
+            )));
         }
 
         if let MLPConfig::MixtureOfExperts(mixture_of_experts_config) = config {
@@ -81,5 +157,295 @@ impl<B: Backend> dyn Mlp<B> {
         }
 
         unreachable!("Unknown MLP config")
+    }
+}
+
+fn static_keep_ratio_from_env() -> Option<f32> {
+    let value = EnvVar::MlpStaticKeepRatio.value();
+    if value.is_empty() {
+        return None;
+    }
+    let keep_ratio = value.parse::<f32>().expect("UZU_MLP_STATIC_KEEP_RATIO must be a float");
+    assert!((0.0..=1.0).contains(&keep_ratio) && keep_ratio > 0.0, "UZU_MLP_STATIC_KEEP_RATIO must be in (0, 1]");
+    Some(keep_ratio)
+}
+
+fn static_block_indices_from_env(
+    label: &str,
+    hidden_dimension: usize,
+) -> Option<Box<[usize]>> {
+    block_indices_from_layer_json(label, hidden_dimension).or_else(|| {
+        let value = EnvVar::MlpStaticBlocks.value();
+        if value.is_empty() {
+            return None;
+        }
+        Some(parse_block_indices(&value, hidden_dimension / MLP_BLOCK_SIZE, EnvVar::MlpStaticBlocks.key()))
+    })
+}
+
+pub(super) fn block_indices_from_layer_json(
+    label: &str,
+    hidden_dimension: usize,
+) -> Option<Box<[usize]>> {
+    assert_eq!(hidden_dimension % MLP_BLOCK_SIZE, 0, "MLP hidden width must divide block size");
+    let value = EnvVar::MlpBlocksByLayerJson.value();
+    if value.is_empty() {
+        return None;
+    }
+    let blocks = serde_json::from_str::<LayerBlockMap>(&value)
+        .unwrap_or_else(|_| panic!("{} must be valid JSON", EnvVar::MlpBlocksByLayerJson.key()));
+    let layer_index = layer_index_from_label(label).expect("MLP label must include a layer index");
+    let block_count = hidden_dimension / MLP_BLOCK_SIZE;
+    let layer_key = layer_index.to_string();
+    blocks
+        .0
+        .get(&layer_key)
+        .or_else(|| blocks.0.get(label))
+        .map(|selected| parse_block_indices_vec(selected.clone(), block_count, EnvVar::MlpBlocksByLayerJson.key()))
+}
+
+fn layer_index_from_label(label: &str) -> Option<usize> {
+    let parts = label.split('.').collect::<Vec<_>>();
+    parts
+        .windows(2)
+        .find_map(|window| matches!(window, ["layer" | "layers", _]).then(|| window[1].parse::<usize>().ok()))
+        .flatten()
+}
+
+fn parse_block_indices(
+    value: &str,
+    block_count: usize,
+    key: &str,
+) -> Box<[usize]> {
+    parse_block_indices_vec(
+        value
+            .split(',')
+            .map(|item| item.trim().parse::<usize>().unwrap_or_else(|_| panic!("{key} must contain integers")))
+            .collect(),
+        block_count,
+        key,
+    )
+}
+
+fn parse_block_indices_vec(
+    mut selected: Vec<usize>,
+    block_count: usize,
+    key: &str,
+) -> Box<[usize]> {
+    assert!(!selected.is_empty(), "{key} cannot be empty");
+    selected.sort_unstable();
+    selected.dedup();
+    assert!(selected.iter().all(|&block| block < block_count), "{key} must contain valid block indices");
+    selected.into_boxed_slice()
+}
+
+#[derive(Deserialize)]
+struct LayerBlockMap(BTreeMap<String, Vec<usize>>);
+
+fn select_static_mlp_blocks<B: Backend>(
+    parameter_tree: &ParameterTree<B::Context>,
+    hidden_dimension: usize,
+    keep_ratio: f32,
+) -> Result<Box<[usize]>, MlpBlockError<B>> {
+    assert_eq!(hidden_dimension % MLP_BLOCK_SIZE, 0, "MLP hidden width must divide block size");
+    let up_weights = parameter_tree.subtree("up_projection")?.leaf_array("weights")?;
+    let down_weights = parameter_tree.subtree("down_projection")?.leaf_array("weights")?;
+    let block_scores = match up_weights.data_type() {
+        DataType::BF16 => static_block_scores_t::<B, bf16>(&up_weights, &down_weights, hidden_dimension),
+        DataType::F16 => static_block_scores_t::<B, f16>(&up_weights, &down_weights, hidden_dimension),
+        DataType::F32 => static_block_scores_t::<B, f32>(&up_weights, &down_weights, hidden_dimension),
+        dtype => panic!("Unsupported MLP dtype for static reduced-width selector: {dtype:?}"),
+    };
+    let keep_blocks = ((block_scores.len() as f32) * keep_ratio).ceil() as usize;
+    let mut ranked = (0..block_scores.len()).collect::<Vec<_>>();
+    ranked.sort_unstable_by(|&lhs, &rhs| {
+        block_scores[rhs].partial_cmp(&block_scores[lhs]).expect("MLP selector scores must be finite")
+    });
+    let mut selected = ranked.into_iter().take(keep_blocks).collect::<Vec<_>>();
+    selected.sort_unstable();
+    Ok(selected.into_boxed_slice())
+}
+
+fn static_block_scores_t<B: Backend, T: ArrayElement + Copy>(
+    up_weights: &crate::array::Array<B>,
+    down_weights: &crate::array::Array<B>,
+    hidden_dimension: usize,
+) -> Box<[f32]>
+where
+    f32: From<T>,
+{
+    let up = up_weights.as_slice::<T>();
+    let down = down_weights.as_slice::<T>();
+    let input_dim = up_weights.shape()[1];
+    let output_dim = down_weights.shape()[0];
+    let block_count = hidden_dimension / MLP_BLOCK_SIZE;
+    let mut scores = vec![0.0_f32; block_count];
+
+    for (block_index, score) in scores.iter_mut().enumerate() {
+        let block_start = block_index * MLP_BLOCK_SIZE;
+        let mut up_energy = 0.0_f32;
+        let mut gate_energy = 0.0_f32;
+        for row in block_start..block_start + MLP_BLOCK_SIZE {
+            let up_row_start = row * input_dim;
+            let gate_row_start = (hidden_dimension + row) * input_dim;
+            up_energy += up[up_row_start..up_row_start + input_dim]
+                .iter()
+                .map(|value| {
+                    let value = f32::from(*value);
+                    value * value
+                })
+                .sum::<f32>();
+            gate_energy += up[gate_row_start..gate_row_start + input_dim]
+                .iter()
+                .map(|value| {
+                    let value = f32::from(*value);
+                    value * value
+                })
+                .sum::<f32>();
+        }
+
+        let mut down_energy = 0.0_f32;
+        for row in 0..output_dim {
+            let row_start = row * hidden_dimension + block_start;
+            down_energy += down[row_start..row_start + MLP_BLOCK_SIZE]
+                .iter()
+                .map(|value| {
+                    let value = f32::from(*value);
+                    value * value
+                })
+                .sum::<f32>();
+        }
+
+        *score = up_energy * gate_energy * down_energy.sqrt();
+    }
+
+    scores.into_boxed_slice()
+}
+
+fn selected_hidden_indices(selected_blocks: &[usize]) -> Box<[usize]> {
+    selected_blocks
+        .iter()
+        .flat_map(|&block| (block * MLP_BLOCK_SIZE)..((block + 1) * MLP_BLOCK_SIZE))
+        .collect::<Vec<_>>()
+        .into_boxed_slice()
+}
+
+fn selected_up_rows(
+    selected_hidden: &[usize],
+    hidden_dimension: usize,
+) -> Box<[usize]> {
+    selected_hidden
+        .iter()
+        .copied()
+        .chain(selected_hidden.iter().map(|&index| hidden_dimension + index))
+        .collect::<Vec<_>>()
+        .into_boxed_slice()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MLP_BLOCK_SIZE, selected_hidden_indices, selected_up_rows};
+
+    fn silu(x: f32) -> f32 {
+        x / (1.0 + (-x).exp())
+    }
+
+    fn matmul(
+        input: &[f32],
+        rows: usize,
+        cols: usize,
+        weights: &[f32],
+        out_cols: usize,
+    ) -> Vec<f32> {
+        let mut out = vec![0.0; rows * out_cols];
+        for row in 0..rows {
+            for col in 0..out_cols {
+                let mut acc = 0.0;
+                for k in 0..cols {
+                    acc += input[row * cols + k] * weights[col * cols + k];
+                }
+                out[row * out_cols + col] = acc;
+            }
+        }
+        out
+    }
+
+    fn compact_rows(
+        weights: &[f32],
+        input_dim: usize,
+        selected_rows: &[usize],
+    ) -> Vec<f32> {
+        let mut compact = Vec::with_capacity(selected_rows.len() * input_dim);
+        for &row in selected_rows {
+            compact.extend_from_slice(&weights[row * input_dim..(row + 1) * input_dim]);
+        }
+        compact
+    }
+
+    fn compact_columns(
+        weights: &[f32],
+        input_dim: usize,
+        output_dim: usize,
+        selected_columns: &[usize],
+    ) -> Vec<f32> {
+        let mut compact = Vec::with_capacity(output_dim * selected_columns.len());
+        for row in 0..output_dim {
+            for &column in selected_columns {
+                compact.push(weights[row * input_dim + column]);
+            }
+        }
+        compact
+    }
+
+    #[test]
+    fn reduced_width_selection_matches_masked_dense_mlp() {
+        let batch = 2;
+        let input_dim = 3;
+        let hidden_dim = MLP_BLOCK_SIZE * 2;
+        let output_dim = 4;
+        let input = vec![0.5, -0.25, 1.0, -1.0, 0.75, 0.25];
+        let up_weights = (0..(2 * hidden_dim * input_dim)).map(|i| ((i % 7) as f32 - 3.0) * 0.1).collect::<Vec<_>>();
+        let down_weights = (0..(output_dim * hidden_dim)).map(|i| ((i % 11) as f32 - 5.0) * 0.05).collect::<Vec<_>>();
+        let selected_blocks = [1_usize];
+        let selected_hidden = selected_hidden_indices(&selected_blocks);
+        let selected_up = selected_up_rows(&selected_hidden, hidden_dim);
+
+        let fused = matmul(&input, batch, input_dim, &up_weights, 2 * hidden_dim);
+        let mut hidden = vec![0.0; batch * hidden_dim];
+        for row in 0..batch {
+            for j in 0..hidden_dim {
+                hidden[row * hidden_dim + j] =
+                    fused[row * 2 * hidden_dim + j] * silu(fused[row * 2 * hidden_dim + hidden_dim + j]);
+            }
+        }
+        let dense_output = matmul(&hidden, batch, hidden_dim, &down_weights, output_dim);
+
+        let reduced_up = compact_rows(&up_weights, input_dim, &selected_up);
+        let reduced_fused = matmul(&input, batch, input_dim, &reduced_up, selected_up.len());
+        let mut reduced_hidden = vec![0.0; batch * selected_hidden.len()];
+        for row in 0..batch {
+            for (index, _) in selected_hidden.iter().enumerate() {
+                reduced_hidden[row * selected_hidden.len() + index] = reduced_fused[row * selected_up.len() + index]
+                    * silu(reduced_fused[row * selected_up.len() + selected_hidden.len() + index]);
+            }
+        }
+        let reduced_down = compact_columns(&down_weights, hidden_dim, output_dim, &selected_hidden);
+        let reduced_output = matmul(&reduced_hidden, batch, selected_hidden.len(), &reduced_down, output_dim);
+
+        let mut masked_output = vec![0.0; batch * output_dim];
+        for row in 0..batch {
+            for out in 0..output_dim {
+                let mut acc = 0.0;
+                for &column in selected_hidden.iter() {
+                    acc += hidden[row * hidden_dim + column] * down_weights[out * hidden_dim + column];
+                }
+                masked_output[row * output_dim + out] = acc;
+            }
+        }
+
+        for (lhs, rhs) in reduced_output.iter().zip(masked_output.iter()) {
+            assert!((lhs - rhs).abs() < 1e-5, "reduced output mismatch: {lhs} vs {rhs}");
+        }
+        assert!(dense_output.iter().zip(masked_output.iter()).any(|(lhs, rhs)| (lhs - rhs).abs() > 1e-4));
     }
 }

--- a/crates/uzu/src/encodable_block/mlp/moe.rs
+++ b/crates/uzu/src/encodable_block/mlp/moe.rs
@@ -22,7 +22,7 @@ use crate::{
             },
         },
     },
-    encodable_block::mlp::Mlp,
+    encodable_block::{EncodingParameters, mlp::Mlp},
     forward_pass::state::{ArrayId, ForwardPassState},
     parameters::{ParameterLoaderError, ParameterTree},
 };
@@ -192,6 +192,7 @@ impl<B: Backend> Mlp<B> for MoeBlock<B> {
     fn encode(
         &self,
         state: &mut ForwardPassState<B>,
+        _parameters: &EncodingParameters,
         command_buffer: &mut <B::CommandBuffer as CommandBuffer>::Encoding,
     ) -> Result<(), B::Error> {
         let suffix_length = state.active_suffix_length();

--- a/crates/uzu/src/forward_pass/state/state.rs
+++ b/crates/uzu/src/forward_pass/state/state.rs
@@ -731,6 +731,22 @@ impl<B: Backend> ForwardPassState<B> {
         }
     }
 
+    pub fn set_sampling_window(
+        &mut self,
+        sampling_start: usize,
+        sampling_length: usize,
+        is_prefilling: bool,
+    ) {
+        match &mut self.mode {
+            ForwardPassMode::LanguageModelGenerator(state) => {
+                state.sampling_start = sampling_start;
+                state.sampling_length = sampling_length;
+                state.is_prefilling = is_prefilling;
+            },
+            ForwardPassMode::Classifier(_) => unreachable!("sampling window is only available for language models"),
+        }
+    }
+
     pub fn cache_layers(&self) -> Option<&Rc<RefCell<CacheLayers<B>>>> {
         match &self.mode {
             ForwardPassMode::LanguageModelGenerator(state) => Some(&state.cache_layers),

--- a/crates/uzu/src/language_model/language_model_generator.rs
+++ b/crates/uzu/src/language_model/language_model_generator.rs
@@ -6,6 +6,9 @@ use std::{
     time::Instant,
 };
 
+#[cfg(feature = "tracing")]
+use crate::array::Array;
+use half::{bf16, f16};
 use itertools::{Either, Itertools, izip};
 
 use super::{
@@ -16,6 +19,7 @@ use super::{
     rng::PRng,
 };
 use crate::{
+    DataType,
     backends::common::{
         Backend, Buffer, CommandBuffer, CommandBufferEncoding, CommandBufferExecutable, CommandBufferInitial,
         CommandBufferPending, Context,
@@ -25,7 +29,7 @@ use crate::{
     forward_pass::{
         cache_layers::{CacheLayer, CacheLayersSlice},
         kv_cache_layer::{AttentionBiasUpdate, INVALID_POSITION},
-        state::ForwardPassState,
+        state::{ArrayId, ForwardPassState},
     },
     session::{
         config::DecodingConfig,
@@ -60,6 +64,31 @@ struct TaskEncodingKey {
     sampling_len: usize,
     has_bitmask: bool,
     is_prefilling: bool,
+}
+
+#[cfg(feature = "tracing")]
+#[derive(Debug, Clone)]
+pub struct PrefillMlpLayerTrace {
+    pub layer_index: usize,
+    pub rows: usize,
+    pub cols: usize,
+    pub pre_mlp_norm: Vec<f32>,
+    pub mlp: Vec<f32>,
+}
+
+#[cfg(feature = "tracing")]
+#[derive(Debug, Clone)]
+pub struct PrefillLogitsTrace {
+    pub rows: usize,
+    pub cols: usize,
+    pub logits: Vec<f32>,
+}
+
+#[cfg(feature = "tracing")]
+#[derive(Debug, Clone)]
+pub struct PrefillTraceDump {
+    pub layers: Vec<PrefillMlpLayerTrace>,
+    pub logits: PrefillLogitsTrace,
 }
 
 pub struct LanguageModelGenerator<B: Backend> {
@@ -134,196 +163,12 @@ impl<B: Backend> LanguageModelGeneratorTrait for LanguageModelGenerator<B> {
     fn prefill(
         &mut self,
         tokens: Vec<u64>,
-        mut compiled_grammar: Option<&mut CompiledGrammar>,
+        compiled_grammar: Option<&mut CompiledGrammar>,
         sampling_method: SamplingMethod,
         prefix_offset: usize,
         sample_suffix: bool,
     ) -> Result<PrefillResult, Error> {
-        assert!(!tokens.is_empty());
-
-        self.tokens.extend(tokens.clone());
-
-        let tokens_length = tokens.len();
-
-        let prefill_step_size = self.decoding_config.prefill_step_size.resolve(&self.context.model_config);
-        let prefill_steps = tokens_length.div_ceil(prefill_step_size);
-        let prefill_size = prefill_steps * prefill_step_size;
-
-        let speculator = &self.decoding_config.speculator_config.speculator;
-
-        let suffix_length = if sample_suffix {
-            self.decoding_config.generate_suffix_length().saturating_sub(1)
-        } else {
-            prefill_size - tokens_length
-        };
-        let suffix_root = TrieNode::from_speculator(
-            &tokens,
-            &self.context.seed,
-            compiled_grammar.as_deref_mut(),
-            speculator.as_ref(),
-            &TrieCreationConfig::default(),
-            suffix_length + 1,
-        );
-        let flat_trie = suffix_root.linearize();
-
-        let has_grammar = compiled_grammar.is_some();
-
-        let token_ids =
-            tokens.iter().copied().take(tokens_length - 1).chain(flat_trie.token_ids()).chunks(prefill_step_size);
-
-        let token_positions = (prefix_offset..prefix_offset + tokens_length - 1)
-            .chain(flat_trie.token_positions().map(|trie_position| prefix_offset + tokens_length - 1 + trie_position))
-            .chunks(prefill_step_size);
-
-        let single_token_bitmask_size = self.context.model_shape.bitmask_shape(1)[1];
-        let token_bitmasks = repeat_n(None, tokens_length - 1).chain(flat_trie.token_masks()).chunks(prefill_step_size);
-
-        let token_seeds = repeat_n(0, tokens_length - 1).chain(flat_trie.token_seeds()).chunks(prefill_step_size);
-
-        let mut last_state: Option<ForwardPassState<B>> = None;
-        let mut run_times: Vec<f64> = Vec::new();
-
-        // Process each prefill step and update the KV cache.
-        for (step, (step_token_ids, step_token_positions, step_token_bitmasks, step_token_seeds)) in
-            izip!(&token_ids, &token_positions, &token_bitmasks, &token_seeds).enumerate()
-        {
-            let tokens_start_index = step * prefill_step_size;
-            let tokens_end_index = tokens_start_index + prefill_step_size;
-
-            let step_token_ids = step_token_ids.collect::<Box<[u64]>>();
-            let step_token_positions = step_token_positions.collect::<Box<[usize]>>();
-            let step_token_seeds = step_token_seeds.collect::<Box<[u64]>>();
-
-            let active_suffix_length = step_token_positions.len();
-            let is_last_prefill_step = step == prefill_steps - 1;
-            let should_sample_after_step = sample_suffix && is_last_prefill_step;
-
-            // If we sample on the last prefill step, we only need logits/sampling
-            // for tokens that are beyond the prompt prefix (i.e. starting at the
-            // suffix-root token, which is the last prompt token).
-            let (sampling_start, sampling_length) = if should_sample_after_step {
-                let suffix_root_index_in_step = (tokens_length - 1).saturating_sub(tokens_start_index);
-                let sampling_length = active_suffix_length.saturating_sub(suffix_root_index_in_step);
-                debug_assert!(sampling_length > 0, "Expected at least one token to sample on the last prefill step");
-                (suffix_root_index_in_step, sampling_length)
-            } else {
-                (0, 0)
-            };
-
-            let step_token_bitmask: Option<Box<[u32]>> = if has_grammar && sampling_length > 0 {
-                Some(
-                    step_token_bitmasks
-                        .map(|mask| match mask {
-                            Some(mask) => Either::Left(
-                                mask.iter()
-                                    .copied()
-                                    .take(single_token_bitmask_size)
-                                    .chain(repeat_n(0u32, single_token_bitmask_size.saturating_sub(mask.len()))),
-                            ),
-                            None => Either::Right(repeat_n(u32::MAX, single_token_bitmask_size)),
-                        })
-                        .flatten()
-                        .collect::<Box<[u32]>>(),
-                )
-            } else {
-                // Drain the chunk iterator to keep the other chunked iterators aligned.
-                let _ = step_token_bitmasks.count();
-                None
-            };
-
-            let should_capture = self.gpu_capture.should_capture_prefill(step == 0);
-
-            if should_capture {
-                let _ = self.gpu_capture.start_capture(&self.context.context, "prefill");
-            }
-
-            objc2::rc::autoreleasepool(|_pool| {
-                let _ = last_state.take();
-            });
-
-            let task = Task {
-                token_ids: &step_token_ids,
-                token_positions: &step_token_positions,
-                token_bitmask: step_token_bitmask.as_deref(),
-                token_seeds: &step_token_seeds,
-                expected_number_of_new_tokens: step_token_ids.len(),
-                active_suffix_length,
-                sampling_start,
-                sampling_length,
-                is_prefilling: !should_sample_after_step,
-            };
-
-            let (state, run_time) = self.run_model(
-                task,
-                false,
-                self.allow_pre_encode(),
-                sampling_method,
-                self.should_fill_attention_bias(),
-            )?;
-
-            if should_capture {
-                self.gpu_capture.stop_capture(&self.context.context, "prefill").map_err(|_| Error::CaptureFailed)?;
-            }
-
-            // Register the accepted prompt tokens from this step.
-            let step_end_token_index = std::cmp::min(tokens_end_index, tokens_length);
-            let tokens_processed_this_step = step_end_token_index - tokens_start_index;
-
-            if tokens_processed_this_step > 0 {
-                let mut positions_for_step: Vec<usize> =
-                    (tokens_start_index..step_end_token_index).map(|idx| idx + prefix_offset).collect();
-                if step == prefill_steps - 1 && sample_suffix {
-                    // Exclude the last token because it belongs to the suffix for sampling.
-                    positions_for_step.pop();
-                }
-
-                if !positions_for_step.is_empty() {
-                    let accept_indices_for_step: Vec<usize> = (0..positions_for_step.len()).collect();
-                    if !accept_indices_for_step.is_empty() {
-                        self.update_cache_layers(&accept_indices_for_step, None, true)?;
-                    }
-
-                    self.context.cache_layers.borrow_mut().register_accepted_tokens(&positions_for_step);
-
-                    if let Some(&last_idx) = positions_for_step.last() {
-                        self.registered_prefix_len = last_idx + 1;
-                    }
-                }
-            }
-
-            last_state = Some(state);
-            run_times.push(run_time);
-        }
-
-        let mut final_state = last_state.ok_or(Error::PrefillFailed)?;
-        if !sample_suffix {
-            self.sync_prefix();
-            return Ok(PrefillResult {
-                tokens: Vec::new(),
-                forwardpass_durations: run_times,
-            });
-        }
-        let sampled_tokens = self.read_sampling_output(&mut final_state)?;
-
-        let last_suffix_start = prefill_step_size * (prefill_steps - 1);
-        let suffix_root_index = (tokens_length - last_suffix_start) - 1;
-
-        let (accepted_tokens, accepted_token_indices) =
-            flat_trie.accept(&sampled_tokens, compiled_grammar.as_deref_mut());
-
-        self.update_cache_layers(
-            &accepted_token_indices.into_iter().map(|p| suffix_root_index + p).collect::<Box<[usize]>>(),
-            Some(last_suffix_start),
-            false,
-        )?;
-
-        self.tokens.extend(accepted_tokens.clone());
-        self.sync_prefix();
-
-        Ok(PrefillResult {
-            tokens: accepted_tokens,
-            forwardpass_durations: run_times,
-        })
+        Ok(self.prefill_impl(tokens, compiled_grammar, sampling_method, prefix_offset, sample_suffix, false)?.0)
     }
 
     fn generate(
@@ -748,6 +593,265 @@ impl<B: Backend> LanguageModelGenerator<B> {
         Ok(generator)
     }
 
+    pub fn probe_prefill_logits(
+        &mut self,
+        tokens: Vec<u64>,
+        sampling_method: SamplingMethod,
+    ) -> Result<Vec<f32>, Error> {
+        let (_, sampled_logits) = self.prefill_impl(tokens, None, sampling_method, 0, true, true)?;
+        Ok(sampled_logits.expect("sampled prefill logits must be present"))
+    }
+
+    #[cfg(feature = "tracing")]
+    pub fn probe_prefill_mlp_traces(
+        &mut self,
+        tokens: Vec<u64>,
+    ) -> Result<Vec<PrefillMlpLayerTrace>, Error> {
+        Ok(self.probe_prefill_trace_dump(tokens)?.layers)
+    }
+
+    #[cfg(feature = "tracing")]
+    pub fn probe_prefill_trace_dump(
+        &mut self,
+        tokens: Vec<u64>,
+    ) -> Result<PrefillTraceDump, Error> {
+        assert!(!tokens.is_empty(), "prefill trace probe requires at least one token");
+        let prefill_step_size = self.decoding_config.prefill_step_size.resolve(&self.context.model_config);
+        assert!(tokens.len() <= prefill_step_size, "prefill trace probe only supports single-step prompts");
+
+        <Self as LanguageModelGeneratorTrait>::reset_state(self);
+        self.tokens.extend(tokens.iter().copied());
+
+        let token_positions = (0..tokens.len()).collect::<Vec<_>>();
+        let token_seeds = vec![0; tokens.len()];
+        let task = Task {
+            token_ids: &tokens,
+            token_positions: &token_positions,
+            token_bitmask: None,
+            token_seeds: &token_seeds,
+            expected_number_of_new_tokens: tokens.len(),
+            active_suffix_length: tokens.len(),
+            sampling_start: 0,
+            sampling_length: 0,
+            is_prefilling: true,
+        };
+        let (mut state, _) = self.run_model(
+            task,
+            false,
+            self.allow_pre_encode(),
+            SamplingMethod::Greedy,
+            self.should_fill_attention_bias(),
+        )?;
+        self.encode_prefill_trace_logits(&mut state)?;
+        let traces = PrefillTraceDump {
+            layers: self.read_prefill_mlp_traces(&state),
+            logits: self.read_prefill_logits_trace(&state),
+        };
+        <Self as LanguageModelGeneratorTrait>::reset_state(self);
+        Ok(traces)
+    }
+
+    #[cfg(feature = "tracing")]
+    fn encode_prefill_trace_logits(
+        &self,
+        state: &mut ForwardPassState<B>,
+    ) -> Result<(), Error> {
+        state.set_sampling_window(0, state.active_suffix_length(), false);
+        self.run_stage(|command_buffer| {
+            self.context
+                .executables
+                .norm
+                .encode(state, command_buffer)
+                .map_err(|error| Error::EncodeFailed(Box::new(error)))?;
+            let traces = state.traces().clone();
+            state.encode_copy_array(command_buffer, ArrayId::Main, traces.borrow().output_norm.clone());
+            self.context
+                .executables
+                .embed
+                .encode_readout(state, command_buffer)
+                .map_err(|error| Error::EncodeFailed(Box::new(error)))?;
+            let traces = state.traces().clone();
+            state.encode_copy_array(command_buffer, ArrayId::Logits, traces.borrow().logits.clone());
+            Ok(())
+        })
+    }
+
+    fn prefill_impl(
+        &mut self,
+        tokens: Vec<u64>,
+        mut compiled_grammar: Option<&mut CompiledGrammar>,
+        sampling_method: SamplingMethod,
+        prefix_offset: usize,
+        sample_suffix: bool,
+        capture_sampled_logits: bool,
+    ) -> Result<(PrefillResult, Option<Vec<f32>>), Error> {
+        assert!(!tokens.is_empty());
+
+        self.tokens.extend(tokens.clone());
+        let tokens_length = tokens.len();
+        let prefill_step_size = self.decoding_config.prefill_step_size.resolve(&self.context.model_config);
+        let prefill_steps = tokens_length.div_ceil(prefill_step_size);
+        let prefill_size = prefill_steps * prefill_step_size;
+        let speculator = &self.decoding_config.speculator_config.speculator;
+        let suffix_length = if sample_suffix {
+            self.decoding_config.generate_suffix_length().saturating_sub(1)
+        } else {
+            prefill_size - tokens_length
+        };
+        let suffix_root = TrieNode::from_speculator(
+            &tokens,
+            &self.context.seed,
+            compiled_grammar.as_deref_mut(),
+            speculator.as_ref(),
+            &TrieCreationConfig::default(),
+            suffix_length + 1,
+        );
+        let flat_trie = suffix_root.linearize();
+        let has_grammar = compiled_grammar.is_some();
+        let token_ids =
+            tokens.iter().copied().take(tokens_length - 1).chain(flat_trie.token_ids()).chunks(prefill_step_size);
+        let token_positions = (prefix_offset..prefix_offset + tokens_length - 1)
+            .chain(flat_trie.token_positions().map(|trie_position| prefix_offset + tokens_length - 1 + trie_position))
+            .chunks(prefill_step_size);
+        let single_token_bitmask_size = self.context.model_shape.bitmask_shape(1)[1];
+        let token_bitmasks = repeat_n(None, tokens_length - 1).chain(flat_trie.token_masks()).chunks(prefill_step_size);
+        let token_seeds = repeat_n(0, tokens_length - 1).chain(flat_trie.token_seeds()).chunks(prefill_step_size);
+
+        let mut last_state: Option<ForwardPassState<B>> = None;
+        let mut run_times: Vec<f64> = Vec::new();
+
+        for (step, (step_token_ids, step_token_positions, step_token_bitmasks, step_token_seeds)) in
+            izip!(&token_ids, &token_positions, &token_bitmasks, &token_seeds).enumerate()
+        {
+            let tokens_start_index = step * prefill_step_size;
+            let tokens_end_index = tokens_start_index + prefill_step_size;
+            let step_token_ids = step_token_ids.collect::<Box<[u64]>>();
+            let step_token_positions = step_token_positions.collect::<Box<[usize]>>();
+            let step_token_seeds = step_token_seeds.collect::<Box<[u64]>>();
+            let active_suffix_length = step_token_positions.len();
+            let is_last_prefill_step = step == prefill_steps - 1;
+            let should_sample_after_step = sample_suffix && is_last_prefill_step;
+            let (sampling_start, sampling_length) = if should_sample_after_step {
+                let suffix_root_index_in_step = (tokens_length - 1).saturating_sub(tokens_start_index);
+                let sampling_length = active_suffix_length.saturating_sub(suffix_root_index_in_step);
+                debug_assert!(sampling_length > 0, "Expected at least one token to sample on the last prefill step");
+                (suffix_root_index_in_step, sampling_length)
+            } else {
+                (0, 0)
+            };
+
+            let step_token_bitmask: Option<Box<[u32]>> = if has_grammar && sampling_length > 0 {
+                Some(
+                    step_token_bitmasks
+                        .map(|mask| match mask {
+                            Some(mask) => Either::Left(
+                                mask.iter()
+                                    .copied()
+                                    .take(single_token_bitmask_size)
+                                    .chain(repeat_n(0u32, single_token_bitmask_size.saturating_sub(mask.len()))),
+                            ),
+                            None => Either::Right(repeat_n(u32::MAX, single_token_bitmask_size)),
+                        })
+                        .flatten()
+                        .collect::<Box<[u32]>>(),
+                )
+            } else {
+                let _ = step_token_bitmasks.count();
+                None
+            };
+
+            let should_capture = self.gpu_capture.should_capture_prefill(step == 0);
+            if should_capture {
+                let _ = self.gpu_capture.start_capture(&self.context.context, "prefill");
+            }
+
+            objc2::rc::autoreleasepool(|_pool| {
+                let _ = last_state.take();
+            });
+
+            let task = Task {
+                token_ids: &step_token_ids,
+                token_positions: &step_token_positions,
+                token_bitmask: step_token_bitmask.as_deref(),
+                token_seeds: &step_token_seeds,
+                expected_number_of_new_tokens: step_token_ids.len(),
+                active_suffix_length,
+                sampling_start,
+                sampling_length,
+                is_prefilling: !should_sample_after_step,
+            };
+
+            let (state, run_time) = self.run_model(
+                task,
+                false,
+                self.allow_pre_encode(),
+                sampling_method,
+                self.should_fill_attention_bias(),
+            )?;
+
+            if should_capture {
+                self.gpu_capture.stop_capture(&self.context.context, "prefill").map_err(|_| Error::CaptureFailed)?;
+            }
+
+            let step_end_token_index = std::cmp::min(tokens_end_index, tokens_length);
+            let tokens_processed_this_step = step_end_token_index - tokens_start_index;
+            if tokens_processed_this_step > 0 {
+                let mut positions_for_step: Vec<usize> =
+                    (tokens_start_index..step_end_token_index).map(|idx| idx + prefix_offset).collect();
+                if step == prefill_steps - 1 && sample_suffix {
+                    positions_for_step.pop();
+                }
+                if !positions_for_step.is_empty() {
+                    let accept_indices_for_step: Vec<usize> = (0..positions_for_step.len()).collect();
+                    self.update_cache_layers(&accept_indices_for_step, None, true)?;
+                    self.context.cache_layers.borrow_mut().register_accepted_tokens(&positions_for_step);
+                    if let Some(&last_idx) = positions_for_step.last() {
+                        self.registered_prefix_len = last_idx + 1;
+                    }
+                }
+            }
+
+            last_state = Some(state);
+            run_times.push(run_time);
+        }
+
+        let mut final_state = last_state.ok_or(Error::PrefillFailed)?;
+        if !sample_suffix {
+            self.sync_prefix();
+            return Ok((
+                PrefillResult {
+                    tokens: Vec::new(),
+                    forwardpass_durations: run_times,
+                },
+                None,
+            ));
+        }
+
+        let sampled_logits = capture_sampled_logits.then(|| self.read_sampling_logits(&final_state));
+        let sampled_tokens = self.read_sampling_output(&mut final_state)?;
+        let last_suffix_start = prefill_step_size * (prefill_steps - 1);
+        let suffix_root_index = (tokens_length - last_suffix_start) - 1;
+        let (accepted_tokens, accepted_token_indices) =
+            flat_trie.accept(&sampled_tokens, compiled_grammar.as_deref_mut());
+
+        self.update_cache_layers(
+            &accepted_token_indices.into_iter().map(|position| suffix_root_index + position).collect::<Box<[usize]>>(),
+            Some(last_suffix_start),
+            false,
+        )?;
+
+        self.tokens.extend(accepted_tokens.clone());
+        self.sync_prefix();
+
+        Ok((
+            PrefillResult {
+                tokens: accepted_tokens,
+                forwardpass_durations: run_times,
+            },
+            sampled_logits,
+        ))
+    }
+
     fn warmup(
         &mut self,
         suffix_length: usize,
@@ -864,6 +968,25 @@ impl<B: Backend> LanguageModelGenerator<B> {
         })
     }
 
+    fn run_stage(
+        &self,
+        encode: impl FnOnce(&mut <B::CommandBuffer as CommandBuffer>::Encoding) -> Result<(), Error>,
+    ) -> Result<(), Error> {
+        let mut command_buffer = self
+            .context
+            .context
+            .create_command_buffer()
+            .map_err(|e| Error::UnableToCreateCommandBuffer(e.into()))?
+            .start_encoding();
+        encode(&mut command_buffer)?;
+        command_buffer
+            .end_encoding()
+            .submit()
+            .wait_until_completed()
+            .map_err(|e| Error::CommandBufferFailed(Box::new(e)))?;
+        Ok(())
+    }
+
     fn encode_forward_pass(
         &self,
         state: &mut ForwardPassState<B>,
@@ -912,6 +1035,92 @@ impl<B: Backend> LanguageModelGenerator<B> {
         }
 
         Ok(result)
+    }
+
+    fn read_sampling_logits(
+        &self,
+        state: &ForwardPassState<B>,
+    ) -> Vec<f32> {
+        let logits = state.arrays(&[ArrayId::Logits]);
+        let logits = logits[0].borrow();
+        let row_index = state.sampling_start();
+        let vocab_size = logits.shape()[1];
+        match logits.data_type() {
+            DataType::BF16 => logits
+                .as_slice::<bf16>()
+                .chunks_exact(vocab_size)
+                .nth(row_index)
+                .expect("bf16 logits row")
+                .iter()
+                .map(|&value| f32::from(value))
+                .collect(),
+            DataType::F16 => logits
+                .as_slice::<f16>()
+                .chunks_exact(vocab_size)
+                .nth(row_index)
+                .expect("f16 logits row")
+                .iter()
+                .map(|&value| f32::from(value))
+                .collect(),
+            DataType::F32 => {
+                logits.as_slice::<f32>().chunks_exact(vocab_size).nth(row_index).expect("f32 logits row").to_vec()
+            },
+            dtype => panic!("Unsupported logits dtype: {dtype:?}"),
+        }
+    }
+
+    #[cfg(feature = "tracing")]
+    fn read_prefill_mlp_traces(
+        &self,
+        state: &ForwardPassState<B>,
+    ) -> Vec<PrefillMlpLayerTrace> {
+        let traces = state.traces().borrow();
+        traces
+            .layer_results
+            .iter()
+            .enumerate()
+            .map(|(layer_index, layer)| {
+                let layer = layer.borrow();
+                let pre_mlp_norm = layer.pre_mlp_norm.borrow();
+                let mlp = layer.mlp.borrow();
+                let shape = pre_mlp_norm.shape().to_vec();
+                assert_eq!(shape.len(), 2, "expected 2D pre-MLP trace");
+                assert_eq!(mlp.shape(), shape.as_slice(), "MLP trace shape must match pre-MLP trace");
+                PrefillMlpLayerTrace {
+                    layer_index,
+                    rows: shape[0],
+                    cols: shape[1],
+                    pre_mlp_norm: Self::array_to_f32_vec(&pre_mlp_norm),
+                    mlp: Self::array_to_f32_vec(&mlp),
+                }
+            })
+            .collect()
+    }
+
+    #[cfg(feature = "tracing")]
+    fn read_prefill_logits_trace(
+        &self,
+        state: &ForwardPassState<B>,
+    ) -> PrefillLogitsTrace {
+        let traces = state.traces().borrow();
+        let logits = traces.logits.borrow();
+        let shape = logits.shape().to_vec();
+        assert_eq!(shape.len(), 2, "expected 2D logits trace");
+        PrefillLogitsTrace {
+            rows: shape[0],
+            cols: shape[1],
+            logits: Self::array_to_f32_vec(&logits),
+        }
+    }
+
+    #[cfg(feature = "tracing")]
+    fn array_to_f32_vec(array: &Array<B>) -> Vec<f32> {
+        match array.data_type() {
+            DataType::BF16 => array.as_slice::<bf16>().iter().map(|&value| f32::from(value)).collect(),
+            DataType::F16 => array.as_slice::<f16>().iter().map(|&value| f32::from(value)).collect(),
+            DataType::F32 => array.as_slice::<f32>().to_vec(),
+            dtype => panic!("Unsupported trace dtype: {dtype:?}"),
+        }
     }
 
     fn update_cache_layers(

--- a/crates/uzu/src/utils/env_utils.rs
+++ b/crates/uzu/src/utils/env_utils.rs
@@ -2,6 +2,9 @@
 pub enum EnvVar {
     CaptureFirstDecode,
     CaptureFirstPrefill,
+    MlpBlocksByLayerJson,
+    MlpStaticBlocks,
+    MlpStaticKeepRatio,
 }
 
 impl EnvVar {
@@ -9,6 +12,9 @@ impl EnvVar {
         match self {
             EnvVar::CaptureFirstDecode => "UZU_CAPTURE_FIRST_DECODE",
             EnvVar::CaptureFirstPrefill => "UZU_CAPTURE_FIRST_PREFILL",
+            EnvVar::MlpBlocksByLayerJson => "UZU_MLP_BLOCKS_BY_LAYER_JSON",
+            EnvVar::MlpStaticBlocks => "UZU_MLP_STATIC_BLOCKS",
+            EnvVar::MlpStaticKeepRatio => "UZU_MLP_STATIC_KEEP_RATIO",
         }
     }
 

--- a/scripts/mlp_prefill_eval.py
+++ b/scripts/mlp_prefill_eval.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Case:
+    identifier: str
+    system: str
+    user_prefix: str
+
+
+CASES: tuple[Case, ...] = (
+    Case("summary", "Summarize the user's input.", ""),
+    Case("bullets", "Summarize the user's input into exactly 6 bullet points.", ""),
+    Case("claims", "Extract the 8 most important claims from the user's input as a numbered list.", ""),
+    Case("title_abstract", "Write a title and then a 3-sentence abstract for the user's input.", ""),
+    Case("short_summary", "Summarize the user's input in at most 120 words.", ""),
+)
+
+MLP_ENV_KEYS = [
+    "UZU_MLP_BLOCKS_BY_LAYER_JSON",
+    "UZU_MLP_STATIC_BLOCKS",
+    "UZU_MLP_STATIC_KEEP_RATIO",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compare baseline vs reduced-width MLP prefill on perf, KL, and generation.")
+    parser.add_argument("--model", required=True, type=Path)
+    parser.add_argument("--variant-model", type=Path)
+    parser.add_argument("--variant-blocks-json", type=Path)
+    parser.add_argument("--probe-bin", type=Path)
+    parser.add_argument("--prefill-step-size", type=int)
+    parser.add_argument("--runs", default=1, type=int)
+    parser.add_argument("--tokens-limit", default=32, type=int)
+    parser.add_argument("--variant-env", action="append", default=[])
+    return parser.parse_args()
+
+
+def load_article(model_path: Path) -> tuple[str, str]:
+    task = json.loads((model_path / "benchmark_task.json").read_text())
+    user_message = next(message["content"] for message in task["messages"] if message["role"] == "user")
+    return task["repo_id"], user_message
+
+
+def build_task(repo_id: str, article: str, case: Case, tokens_limit: int, runs: int) -> dict:
+    return {
+        "greedy": True,
+        "identifier": case.identifier,
+        "messages": [
+            {"role": "system", "content": case.system},
+            {"role": "user", "content": f"{case.user_prefix}{article}"},
+        ],
+        "number_of_runs": runs,
+        "repo_id": repo_id,
+        "tokens_limit": tokens_limit,
+    }
+
+
+def first_diff_index(lhs: str, rhs: str) -> int | None:
+    for index, (left_char, right_char) in enumerate(zip(lhs, rhs)):
+        if left_char != right_char:
+            return index
+    if len(lhs) != len(rhs):
+        return min(len(lhs), len(rhs))
+    return None
+
+
+def softmax(logits: list[float]) -> list[float]:
+    max_logit = max(logits)
+    exp_values = [math.exp(value - max_logit) for value in logits]
+    total = sum(exp_values)
+    return [value / total for value in exp_values]
+
+
+def kl_divergence(reference_logits: list[float], variant_logits: list[float]) -> float:
+    reference = softmax(reference_logits)
+    variant = softmax(variant_logits)
+    return sum(
+        p * (math.log(p) - math.log(max(q, 1e-30)))
+        for p, q in zip(reference, variant)
+        if p > 0.0
+    )
+
+
+def build_probe(env: dict[str, str], probe_bin: Path | None, cwd: Path) -> Path:
+    if probe_bin is not None:
+        return probe_bin
+    subprocess.run(
+        ["cargo", "build", "-p", "benchmarks", "--bin", "prefill_probe"],
+        check=True,
+        cwd=cwd,
+        env=env,
+        stdout=subprocess.DEVNULL,
+    )
+    return cwd / "target" / "debug" / "prefill_probe"
+
+
+def run_probe(
+    probe_bin: Path,
+    model_path: Path,
+    task: dict,
+    prefill_step_size: int | None,
+    env: dict[str, str],
+    tmpdir: Path,
+) -> dict:
+    task_path = tmpdir / f"{task['identifier']}.json"
+    out_path = tmpdir / f"{task['identifier']}.result.json"
+    task_path.write_text(json.dumps(task))
+    command = [str(probe_bin), str(model_path), str(task_path), str(out_path)]
+    if prefill_step_size is not None:
+        command.extend(["--prefill-step-size", str(prefill_step_size)])
+    subprocess.run(command, check=True, env=env, stdout=subprocess.DEVNULL)
+    return json.loads(out_path.read_text())
+
+
+def baseline_env(base_env: dict[str, str]) -> dict[str, str]:
+    env = dict(base_env)
+    for key in MLP_ENV_KEYS:
+        env.pop(key, None)
+    return env
+
+
+def variant_env(base_env: dict[str, str], overrides: list[str]) -> dict[str, str]:
+    env = dict(base_env)
+    for entry in overrides:
+        key, value = entry.split("=", 1)
+        env[key] = value
+    return env
+
+
+def load_variant_blocks(path: Path | None) -> str | None:
+    if path is None:
+        return None
+    payload = json.loads(path.read_text())
+    return json.dumps(payload, separators=(",", ":"))
+
+
+def main() -> None:
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parents[1]
+    repo_id, article = load_article(args.model)
+
+    base_env = dict(os.environ)
+    probe = build_probe(base_env, args.probe_bin, repo_root)
+    baseline_run_env = baseline_env(base_env)
+    variant_run_env = variant_env(base_env, args.variant_env)
+    variant_model = args.variant_model or args.model
+    variant_blocks = load_variant_blocks(args.variant_blocks_json)
+
+    print(
+        "case\tkl_prefill\targmax_same\texact\tfirst_diff\t"
+        "mem_base\tmem_var\tttft_base\tttft_var\t"
+        "prompt_tps_base\tprompt_tps_var\tgen_tps_base\tgen_tps_var",
+        flush=True,
+    )
+    with tempfile.TemporaryDirectory(prefix="mlp_prefill_eval_") as tmp:
+        tmpdir = Path(tmp)
+        for case in CASES:
+            task = build_task(repo_id, article, case, args.tokens_limit, args.runs)
+            baseline = run_probe(probe, args.model, task, args.prefill_step_size, baseline_run_env, tmpdir)
+            case_variant_env = dict(variant_run_env)
+            if variant_blocks is not None:
+                case_variant_env["UZU_MLP_BLOCKS_BY_LAYER_JSON"] = variant_blocks
+            variant = run_probe(probe, variant_model, task, args.prefill_step_size, case_variant_env, tmpdir)
+            diff = first_diff_index(baseline["text"], variant["text"])
+            print(
+                f"{case.identifier}\t"
+                f"{kl_divergence(baseline['prefill_logits'], variant['prefill_logits']):.6f}\t"
+                f"{int(baseline['prefill_top_token'] == variant['prefill_top_token'])}\t"
+                f"{int(baseline['text'] == variant['text'])}\t"
+                f"{'' if diff is None else diff}\t"
+                f"{0 if baseline['memory_used'] is None else baseline['memory_used']}\t"
+                f"{0 if variant['memory_used'] is None else variant['memory_used']}\t"
+                f"{baseline['time_to_first_token']:.4f}\t{variant['time_to_first_token']:.4f}\t"
+                f"{baseline['prompt_tokens_per_second']:.4f}\t{variant['prompt_tokens_per_second']:.4f}\t"
+                f"{0.0 if baseline['generate_tokens_per_second'] is None else baseline['generate_tokens_per_second']:.4f}\t"
+                f"{0.0 if variant['generate_tokens_per_second'] is None else variant['generate_tokens_per_second']:.4f}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mlp_student_fit.py
+++ b/scripts/mlp_student_fit.py
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+BLOCK_SIZE = 32
+LOGIT_PROBE_TOPK = 128
+LOGIT_PROBE_HIDDEN_DIM = 1024
+LOGIT_PROBE_STEPS = 500
+
+
+@dataclass(frozen=True)
+class LayerFiles:
+    rows: int
+    cols: int
+    pre_mlp_norm_file: str
+    mlp_file: str
+
+
+@dataclass(frozen=True)
+class DenseLogitsFiles:
+    rows: int
+    cols: int
+    logits_file: str
+
+
+@dataclass(frozen=True)
+class SparseLogitsFiles:
+    rows: int
+    cols: int
+    topk: int
+    indices_file: str
+    values_file: str
+
+
+@dataclass
+class LogitProbeData:
+    probe: torch.nn.Module
+    train_targets: torch.Tensor
+    valid_targets: torch.Tensor
+    vocab_size: int
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Fit a narrower gated MLP student on dumped prefill traces.")
+    parser.add_argument("--model", required=True, type=Path)
+    parser.add_argument("--trace-dir", required=True, action="append", type=Path)
+    parser.add_argument("--input-trace-dir", action="append", type=Path)
+    parser.add_argument("--selection-trace-dir", action="append", type=Path)
+    parser.add_argument("--layer", required=True, type=int)
+    parser.add_argument("--keep-ratio", type=float)
+    parser.add_argument("--selected-blocks")
+    parser.add_argument("--steps", default=200, type=int)
+    parser.add_argument("--lr", default=1e-3, type=float)
+    parser.add_argument("--weight-decay", default=0.0, type=float)
+    parser.add_argument("--device", default="auto")
+    parser.add_argument("--selector", default="hidden", choices=["hidden", "output_weighted", "output_geom"])
+    parser.add_argument(
+        "--loss",
+        default="mse",
+        choices=["mse", "relative_mse_cosine", "mse_logit_probe", "logit_kl"],
+    )
+    parser.add_argument("--logit-probe-weight", default=1.0, type=float)
+    parser.add_argument("--output-model-dir", type=Path)
+    return parser.parse_args()
+
+
+def select_device(name: str) -> torch.device:
+    if name != "auto":
+        return torch.device(name)
+    if torch.backends.mps.is_available():
+        return torch.device("mps")
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("cpu")
+
+
+def load_manifest(trace_dir: Path) -> dict[int, LayerFiles]:
+    payload = json.loads((trace_dir / "manifest.json").read_text())
+    return {
+        int(layer["layer_index"]): LayerFiles(
+            rows=int(layer["rows"]),
+            cols=int(layer["cols"]),
+            pre_mlp_norm_file=layer["pre_mlp_norm_file"],
+            mlp_file=layer["mlp_file"],
+        )
+        for layer in payload["layers"]
+    }
+
+
+def load_logits_manifest(trace_dir: Path) -> DenseLogitsFiles | SparseLogitsFiles | None:
+    payload = json.loads((trace_dir / "manifest.json").read_text())
+    if "logits_indices_file" in payload:
+        return SparseLogitsFiles(
+            rows=int(payload["logits_rows"]),
+            cols=int(payload["logits_cols"]),
+            topk=int(payload["logits_topk"]),
+            indices_file=payload["logits_indices_file"],
+            values_file=payload["logits_values_file"],
+        )
+    if "logits_file" not in payload:
+        return None
+    return DenseLogitsFiles(
+        rows=int(payload["logits_rows"]),
+        cols=int(payload["logits_cols"]),
+        logits_file=payload["logits_file"],
+    )
+
+
+def load_trace_matrix(
+    path: Path,
+    rows: int,
+    cols: int,
+) -> torch.Tensor:
+    values = torch.from_file(str(path), shared=False, size=rows * cols, dtype=torch.float32)
+    return values.view(rows, cols).clone()
+
+
+def load_i32_matrix(
+    path: Path,
+    rows: int,
+    cols: int,
+) -> torch.Tensor:
+    values = torch.from_file(str(path), shared=False, size=rows * cols, dtype=torch.int32)
+    return values.view(rows, cols).clone()
+
+
+def load_layer_traces(
+    trace_dirs: list[Path],
+    layer: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    xs: list[torch.Tensor] = []
+    ys: list[torch.Tensor] = []
+    for trace_dir in trace_dirs:
+        layer_files = load_manifest(trace_dir)[layer]
+        xs.append(load_trace_matrix(trace_dir / layer_files.pre_mlp_norm_file, layer_files.rows, layer_files.cols))
+        ys.append(load_trace_matrix(trace_dir / layer_files.mlp_file, layer_files.rows, layer_files.cols))
+    return torch.cat(xs, dim=0), torch.cat(ys, dim=0)
+
+
+def load_logit_targets(trace_dirs: list[Path]) -> torch.Tensor:
+    manifests = [load_logits_manifest(trace_dir) for trace_dir in trace_dirs]
+    assert all(manifest is not None for manifest in manifests), "Missing logits trace"
+    manifests = [manifest for manifest in manifests if manifest is not None]
+    if all(isinstance(manifest, DenseLogitsFiles) for manifest in manifests):
+        assert len(manifests) == len(trace_dirs), "Trace and logits manifests must stay aligned"
+        logits: list[torch.Tensor] = []
+        for trace_dir, logits_files in zip(trace_dirs, manifests):
+            assert isinstance(logits_files, DenseLogitsFiles)
+            logits.append(load_trace_matrix(trace_dir / logits_files.logits_file, logits_files.rows, logits_files.cols))
+        full_logits = torch.cat(logits, dim=0)
+        topk = min(LOGIT_PROBE_TOPK, full_logits.shape[1])
+        vocab_indices = torch.topk(full_logits, k=topk, dim=1).indices.reshape(-1).unique(sorted=True)
+        return full_logits.index_select(1, vocab_indices)
+
+    assert all(isinstance(manifest, SparseLogitsFiles) for manifest in manifests), "Mixed logits formats are unsupported"
+    sparse_entries: list[tuple[torch.Tensor, torch.Tensor, int, int]] = []
+    vocab_indices: list[torch.Tensor] = []
+    for trace_dir in trace_dirs:
+        logits_files = load_logits_manifest(trace_dir)
+        assert isinstance(logits_files, SparseLogitsFiles)
+        indices = load_i32_matrix(trace_dir / logits_files.indices_file, logits_files.rows, logits_files.topk).to(torch.long)
+        values = load_trace_matrix(trace_dir / logits_files.values_file, logits_files.rows, logits_files.topk)
+        sparse_entries.append((indices, values, logits_files.rows, logits_files.cols))
+        vocab_indices.append(indices.reshape(-1))
+    union = torch.cat(vocab_indices).unique(sorted=True)
+    union_lookup = {int(value): index for index, value in enumerate(union.tolist())}
+    targets: list[torch.Tensor] = []
+    for indices, values, rows, _ in sparse_entries:
+        remapped = torch.tensor([union_lookup[int(value)] for value in indices.reshape(-1)], dtype=torch.long).view(rows, -1)
+        target = torch.zeros(rows, union.numel(), dtype=torch.float32)
+        target.scatter_(1, remapped, values)
+        targets.append(target)
+    return torch.cat(targets, dim=0)
+
+
+def load_teacher_weights(
+    model_dir: Path,
+    layer: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    with safe_open(model_dir / "model.safetensors", framework="pt") as tensors:
+        fused = tensors.get_tensor(f"transformer.layers.{layer}.mlp.up_projection.weights").float()
+        down = tensors.get_tensor(f"transformer.layers.{layer}.mlp.down_projection.weights").float()
+    hidden_dim = down.shape[1]
+    up = fused[:hidden_dim]
+    gate = fused[hidden_dim:]
+    return up, gate, down
+
+
+def load_all_tensors(model_dir: Path) -> dict[str, torch.Tensor]:
+    with safe_open(model_dir / "model.safetensors", framework="pt") as tensors:
+        return {key: tensors.get_tensor(key) for key in tensors.keys()}
+
+
+def split_train_validation(values: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    split = max(1, int(values.shape[0] * 0.8))
+    if split >= values.shape[0]:
+        split = values.shape[0] - 1
+    return values[:split], values[split:]
+
+
+def teacher_hidden(
+    x: torch.Tensor,
+    up: torch.Tensor,
+    gate: torch.Tensor,
+) -> torch.Tensor:
+    return F.silu(x @ gate.t()) * (x @ up.t())
+
+
+def select_hidden_indices(
+    x: torch.Tensor,
+    up: torch.Tensor,
+    gate: torch.Tensor,
+    down: torch.Tensor,
+    keep_blocks: int,
+    selector: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    hidden = teacher_hidden(x, up, gate)
+    hidden_scores = hidden.square().mean(dim=0)
+    down_scores = down.square().sum(dim=0)
+    if selector == "hidden":
+        feature_scores = hidden_scores
+    elif selector == "output_weighted":
+        feature_scores = hidden_scores * down_scores
+    elif selector == "output_geom":
+        feature_scores = torch.sqrt(hidden_scores * down_scores)
+    else:
+        raise AssertionError(f"Unknown selector: {selector}")
+    block_scores = feature_scores.view(-1, BLOCK_SIZE).sum(dim=1)
+    blocks = torch.topk(block_scores, keep_blocks, largest=True, sorted=False).indices.sort().values
+    offsets = torch.arange(BLOCK_SIZE, dtype=torch.long)
+    indices = (blocks[:, None] * BLOCK_SIZE + offsets[None, :]).reshape(-1)
+    return blocks, indices
+
+
+class StudentMlp(torch.nn.Module):
+    def __init__(
+        self,
+        up: torch.Tensor,
+        gate: torch.Tensor,
+        down: torch.Tensor,
+    ) -> None:
+        super().__init__()
+        self.up = torch.nn.Parameter(up.clone())
+        self.gate = torch.nn.Parameter(gate.clone())
+        self.down = torch.nn.Parameter(down.clone())
+
+    def forward(
+        self,
+        x: torch.Tensor,
+    ) -> torch.Tensor:
+        hidden = F.silu(x @ self.gate.t()) * (x @ self.up.t())
+        return hidden @ self.down.t()
+
+
+def metrics(
+    prediction: torch.Tensor,
+    target: torch.Tensor,
+) -> dict[str, float]:
+    error = prediction - target
+    mse = error.square().mean().item()
+    relative_mse = mse / max(target.square().mean().item(), 1e-12)
+    cosine = F.cosine_similarity(prediction, target, dim=1).mean().item()
+    return {
+        "mse": mse,
+        "relative_mse": relative_mse,
+        "mean_cosine": cosine,
+    }
+
+
+def relative_mse_loss(
+    prediction: torch.Tensor,
+    target: torch.Tensor,
+) -> torch.Tensor:
+    return F.mse_loss(prediction, target) / target.square().mean().clamp_min(1e-12)
+
+
+def build_logit_probe(
+    train_output: torch.Tensor,
+    train_targets: torch.Tensor,
+    valid_targets: torch.Tensor,
+    device: torch.device,
+) -> LogitProbeData:
+    probe = torch.nn.Sequential(
+        torch.nn.Linear(train_output.shape[1], LOGIT_PROBE_HIDDEN_DIM),
+        torch.nn.SiLU(),
+        torch.nn.Linear(LOGIT_PROBE_HIDDEN_DIM, train_targets.shape[1]),
+    ).to(device)
+    optimizer = torch.optim.AdamW(probe.parameters(), lr=1e-3, weight_decay=0.0)
+    train_output = train_output.to(device)
+    train_targets = train_targets.to(device)
+    for _ in range(LOGIT_PROBE_STEPS):
+        optimizer.zero_grad(set_to_none=True)
+        loss = relative_mse_loss(probe(train_output), train_targets)
+        loss.backward()
+        optimizer.step()
+    for parameter in probe.parameters():
+        parameter.requires_grad_(False)
+    return LogitProbeData(
+        probe=probe,
+        train_targets=train_targets,
+        valid_targets=valid_targets.to(device),
+        vocab_size=int(train_targets.shape[1]),
+    )
+
+
+def training_loss(
+    prediction: torch.Tensor,
+    target: torch.Tensor,
+    loss_name: str,
+    logit_probe: LogitProbeData | None,
+    logit_probe_weight: float,
+) -> torch.Tensor:
+    if loss_name == "mse":
+        return F.mse_loss(prediction, target)
+    if loss_name == "relative_mse_cosine":
+        error = (prediction - target).square().mean(dim=1)
+        scale = target.square().mean(dim=1).clamp_min(1e-12)
+        relative_mse = (error / scale).mean()
+        cosine = 1.0 - F.cosine_similarity(prediction, target, dim=1).mean()
+        return relative_mse + cosine
+    if loss_name == "mse_logit_probe":
+        assert logit_probe is not None
+        hidden_loss = relative_mse_loss(prediction, target)
+        logit_loss = relative_mse_loss(logit_probe.probe(prediction), logit_probe.train_targets)
+        return hidden_loss + logit_probe_weight * logit_loss
+    if loss_name == "logit_kl":
+        raise AssertionError("logit_kl requires dedicated loss handling")
+    raise AssertionError(f"Unknown loss: {loss_name}")
+
+
+def logit_kl_loss(
+    prediction: torch.Tensor,
+    target: torch.Tensor,
+    teacher_logits: torch.Tensor,
+    logit_probe: LogitProbeData,
+    logit_probe_weight: float,
+) -> torch.Tensor:
+    hidden_loss = relative_mse_loss(prediction, target)
+    student_logits = logit_probe.probe(prediction)
+    target_probs = torch.softmax(teacher_logits.to(student_logits.device), dim=1)
+    student_log_probs = torch.log_softmax(student_logits, dim=1)
+    kl = F.kl_div(student_log_probs, target_probs, reduction="batchmean")
+    return hidden_loss + logit_probe_weight * kl
+
+
+def write_model_copy(
+    model_dir: Path,
+    output_dir: Path,
+    layer: int,
+    student: StudentMlp,
+    selected_blocks: torch.Tensor,
+) -> None:
+    source_model_dir = output_dir if (output_dir / "model.safetensors").exists() else model_dir
+    tensors = load_all_tensors(source_model_dir)
+    up_key = f"transformer.layers.{layer}.mlp.up_projection.weights"
+    down_key = f"transformer.layers.{layer}.mlp.down_projection.weights"
+    offsets = torch.arange(BLOCK_SIZE, dtype=torch.long)
+    selected_rows = (selected_blocks[:, None] * BLOCK_SIZE + offsets[None, :]).reshape(-1)
+
+    fused = tensors[up_key].clone()
+    hidden_dim = fused.shape[0] // 2
+    fused[selected_rows] = student.up.detach().cpu().to(fused.dtype)
+    fused[hidden_dim + selected_rows] = student.gate.detach().cpu().to(fused.dtype)
+    tensors[up_key] = fused
+
+    down = tensors[down_key].clone()
+    down[:, selected_rows] = student.down.detach().cpu().to(down.dtype)
+    tensors[down_key] = down
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    save_file(tensors, str(output_dir / "model.safetensors"))
+    blocks_path = output_dir / "selected_blocks.json"
+    blocks_by_layer = {}
+    if blocks_path.exists():
+        blocks_by_layer = json.loads(blocks_path.read_text())
+    blocks_by_layer[str(layer)] = selected_blocks.tolist()
+    blocks_path.write_text(json.dumps(blocks_by_layer, sort_keys=True))
+    for source in model_dir.iterdir():
+        if source.name in {"model.safetensors", "selected_blocks.json"}:
+            continue
+        target = output_dir / source.name
+        if target.exists() or target.is_symlink():
+            if target.is_dir() and not target.is_symlink():
+                shutil.rmtree(target)
+            else:
+                target.unlink()
+        os.symlink(source.resolve(), target)
+
+
+def main() -> None:
+    args = parse_args()
+    assert (args.keep_ratio is None) != (args.selected_blocks is None)
+    device = select_device(args.device)
+    input_trace_dirs = args.trace_dir if args.input_trace_dir is None else args.input_trace_dir
+    x, _ = load_layer_traces(input_trace_dirs, args.layer)
+    _, y = load_layer_traces(args.trace_dir, args.layer)
+    selection_trace_dirs = input_trace_dirs if args.selection_trace_dir is None else args.selection_trace_dir
+    selection_x, _ = load_layer_traces(selection_trace_dirs, args.layer)
+    up, gate, down = load_teacher_weights(args.model, args.layer)
+
+    if args.selected_blocks is None:
+        keep_blocks = max(1, int((down.shape[1] // BLOCK_SIZE) * args.keep_ratio))
+        selected_blocks, indices = select_hidden_indices(selection_x, up, gate, down, keep_blocks, args.selector)
+    else:
+        selected_blocks = torch.tensor(
+            [int(value) for value in args.selected_blocks.split(",") if value],
+            dtype=torch.long,
+        )
+        offsets = torch.arange(BLOCK_SIZE, dtype=torch.long)
+        indices = (selected_blocks[:, None] * BLOCK_SIZE + offsets[None, :]).reshape(-1)
+    base_up = up.index_select(0, indices)
+    base_gate = gate.index_select(0, indices)
+    base_down = down.index_select(1, indices)
+
+    train_x, valid_x = split_train_validation(x)
+    train_y, valid_y = split_train_validation(y)
+    logit_probe = None
+    if args.loss in {"mse_logit_probe", "logit_kl"}:
+        logit_targets = load_logit_targets(args.trace_dir)
+        train_targets, valid_targets = split_train_validation(logit_targets)
+        logit_probe = build_logit_probe(train_y, train_targets, valid_targets, device)
+
+    baseline_train = (teacher_hidden(train_x, base_up, base_gate) @ base_down.t()).float()
+    baseline_valid = (teacher_hidden(valid_x, base_up, base_gate) @ base_down.t()).float()
+
+    student = StudentMlp(base_up.to(device), base_gate.to(device), base_down.to(device))
+    optimizer = torch.optim.AdamW(student.parameters(), lr=args.lr, weight_decay=args.weight_decay)
+    train_x = train_x.to(device)
+    train_y = train_y.to(device)
+    valid_x = valid_x.to(device)
+    valid_y = valid_y.to(device)
+
+    for _ in range(args.steps):
+        optimizer.zero_grad(set_to_none=True)
+        prediction = student(train_x)
+        if args.loss == "logit_kl":
+            assert logit_probe is not None
+            loss = logit_kl_loss(
+                prediction,
+                train_y,
+                logit_probe.train_targets,
+                logit_probe,
+                args.logit_probe_weight,
+            )
+        else:
+            loss = training_loss(prediction, train_y, args.loss, logit_probe, args.logit_probe_weight)
+        loss.backward()
+        optimizer.step()
+
+    with torch.no_grad():
+        fitted_train = student(train_x)
+        fitted_valid = student(valid_x)
+
+    result = {
+        "layer": args.layer,
+        "keep_ratio": selected_blocks.numel() / (down.shape[1] // BLOCK_SIZE),
+        "steps": args.steps,
+        "lr": args.lr,
+        "hidden_dim": int(down.shape[1]),
+        "student_dim": int(indices.numel()),
+        "student_blocks": int(selected_blocks.numel()),
+        "selected_blocks": selected_blocks.tolist(),
+        "selector": args.selector,
+        "loss": args.loss,
+        "logit_probe_weight": args.logit_probe_weight,
+        "input_trace_dirs": [str(path) for path in input_trace_dirs],
+        "target_trace_dirs": [str(path) for path in args.trace_dir],
+        "selection_trace_dirs": [str(path) for path in selection_trace_dirs],
+        "device": str(device),
+        "baseline_train": metrics(baseline_train, train_y.cpu()),
+        "baseline_valid": metrics(baseline_valid, valid_y.cpu()),
+        "fitted_train": metrics(fitted_train.cpu(), train_y.cpu()),
+        "fitted_valid": metrics(fitted_valid.cpu(), valid_y.cpu()),
+    }
+    if logit_probe is not None:
+        with torch.no_grad():
+            result["fitted_train_logits"] = metrics(logit_probe.probe(fitted_train).cpu(), logit_probe.train_targets.cpu())
+            result["fitted_valid_logits"] = metrics(logit_probe.probe(fitted_valid).cpu(), logit_probe.valid_targets.cpu())
+            result["logit_probe_vocab_size"] = logit_probe.vocab_size
+    if args.output_model_dir is not None:
+        write_model_copy(args.model, args.output_model_dir, args.layer, student, selected_blocks)
+        result["output_model_dir"] = str(args.output_model_dir)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mlp_trace_dump.py
+++ b/scripts/mlp_trace_dump.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Case:
+    identifier: str
+    system: str
+    user_prefix: str
+
+
+CASES: tuple[Case, ...] = (
+    Case("summary", "Summarize the user's input.", ""),
+    Case("bullets", "Summarize the user's input into exactly 6 bullet points.", ""),
+    Case("claims", "Extract the 8 most important claims from the user's input as a numbered list.", ""),
+    Case("title_abstract", "Write a title and then a 3-sentence abstract for the user's input.", ""),
+    Case("short_summary", "Summarize the user's input in at most 120 words.", ""),
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Dump prefill MLP traces (with logits) for benchmark prompts.")
+    parser.add_argument("--model", required=True, type=Path)
+    parser.add_argument("--output-root", required=True, type=Path)
+    parser.add_argument("--tokens-limit", default=1024, type=int)
+    parser.add_argument("--prefill-step-size", type=int)
+    parser.add_argument("--backend", default=os.environ.get("UZU_BACKEND", "metal"))
+    parser.add_argument("--cases", nargs="*", choices=[case.identifier for case in CASES])
+    parser.add_argument("--release", action="store_true")
+    parser.add_argument("--cpu-only", action="store_true", help="Run benchmarks without metal backend features.")
+    return parser.parse_args()
+
+
+def load_article(model_dir: Path) -> tuple[str, str]:
+    payload = json.loads((model_dir / "benchmark_task.json").read_text())
+    article = next(message["content"] for message in payload["messages"] if message["role"] == "user")
+    return payload["repo_id"], article
+
+
+def build_task(repo_id: str, article: str, case: Case, tokens_limit: int) -> dict:
+    return {
+        "greedy": True,
+        "identifier": case.identifier,
+        "messages": [
+            {"role": "system", "content": case.system},
+            {"role": "user", "content": f"{case.user_prefix}{article}"},
+        ],
+        "number_of_runs": 1,
+        "repo_id": repo_id,
+        "tokens_limit": tokens_limit,
+    }
+
+
+def run_case(
+    repo_root: Path,
+    model_dir: Path,
+    case_dir: Path,
+    task: dict,
+    backend: str,
+    prefill_step_size: int | None,
+    release: bool,
+    cpu_only: bool,
+) -> None:
+    if case_dir.exists():
+        shutil.rmtree(case_dir)
+    case_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=f"mlp_trace_dump_{task['identifier']}_") as tmp:
+        task_path = Path(tmp) / "task.json"
+        task_path.write_text(json.dumps(task))
+        command = ["cargo", "run"]
+        if release:
+            command.append("--release")
+        if cpu_only:
+            command.append("--no-default-features")
+        command.extend([
+            "-p",
+            "benchmarks",
+            "--bin",
+            "dump_prefill_mlp_trace",
+            "--features",
+            "tracing",
+        ])
+        command.extend([
+            "--",
+            str(model_dir),
+            str(task_path),
+            str(case_dir),
+        ])
+        if prefill_step_size is not None:
+            command.extend(["--prefill-step-size", str(prefill_step_size)])
+        env = dict(os.environ)
+        env["UZU_BACKEND"] = backend
+        subprocess.run(command, check=True, cwd=repo_root, env=env)
+
+
+def main() -> None:
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parents[1]
+    repo_id, article = load_article(args.model)
+    selected_cases = [case for case in CASES if args.cases is None or case.identifier in args.cases]
+    for case in selected_cases:
+        task = build_task(repo_id, article, case, args.tokens_limit)
+        case_dir = args.output_root / case.identifier
+        run_case(
+            repo_root=repo_root,
+            model_dir=args.model,
+            case_dir=case_dir,
+            task=task,
+            backend=args.backend,
+            prefill_step_size=args.prefill_step_size,
+            release=args.release,
+            cpu_only=args.cpu_only,
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

This extracts the reduced-width MLP work into a clean branch without the ASTC, short-conv, or KV-compression experiments.

The PR adds:
- static late-layer MLP block selection and reduced-width prefill execution for dense full-precision MLPs
- selected-row / selected-column compaction helpers for full-precision linear weights
- prefill probing and MLP trace dump benchmark bins
- Python scripts to dump traces, fit reduced-width students, and compare baseline vs variant prefill behavior

## Why

The main goal is to make the MLP compaction work reviewable on its own and keep the runtime plumbing separate from the ASTC and other mixed experiments.

## Impact

- enables static reduced-width MLP prefill experiments behind env-controlled block selection
- adds first-class tooling for trace capture and prefill evaluation
- keeps the scope to dense MLP compaction only

## Validation

- `PATH="$HOME/.cargo/bin:$PATH" cargo +1.93.0-x86_64-apple-darwin build -p benchmarks --bin prefill_probe --bin dump_prefill_mlp_trace --no-default-features --features tracing`
- `PATH="$HOME/.cargo/bin:$PATH" cargo +1.93.0-x86_64-apple-darwin fmt --check`
- `python3 -m py_compile scripts/mlp_prefill_eval.py scripts/mlp_student_fit.py scripts/mlp_trace_dump.py`
- `python3 scripts/mlp_prefill_eval.py --help`
- `python3 scripts/mlp_trace_dump.py --help`
- `python3 scripts/mlp_student_fit.py --help`
