### PR TITLE
Package dewrapped RHT readout path with uint2 winner and uint4 fallback

### DIFF
--- a/crates/uzu/src/backends/common/kernel/quant_matmul.rs
+++ b/crates/uzu/src/backends/common/kernel/quant_matmul.rs
@@ -120,9 +120,18 @@ impl<B: Backend> QuantizedMatmulKernelEncodable<B> {
 
         let bits = quant_bits(configuration.mode)?;
         let use_mlx_quant = matches!(configuration.quantization_type, QuantizedMatmulType::Mlx);
+        let force_matrix_vector = bits == 2;
 
-        let matrix_vector_family = select_matrix_vector_family(&configuration);
-        let matrix_matrix_family = select_matrix_matrix_family(&configuration, bits);
+        let matrix_vector_family = if force_matrix_vector {
+            MatrixVectorFamily::QmvFast
+        } else {
+            select_matrix_vector_family(&configuration)
+        };
+        let matrix_matrix_family = if force_matrix_vector {
+            MatrixMatrixFamily::QmmAlignedK
+        } else {
+            select_matrix_matrix_family(&configuration, bits)
+        };
         let matrix_vector_key = KernelKey::MatrixVector(matrix_vector_family);
         let matrix_matrix_key = KernelKey::MatrixMatrix(matrix_matrix_family);
 
@@ -138,8 +147,16 @@ impl<B: Backend> QuantizedMatmulKernelEncodable<B> {
                 matrix_vector_family,
             )?,
         );
-        kernels.insert(
-            matrix_matrix_key,
+        let matrix_matrix_kernel = if force_matrix_vector {
+            create_matrix_vector_kernel(
+                context,
+                configuration.data_type,
+                configuration.group_size,
+                bits,
+                use_mlx_quant,
+                matrix_vector_family,
+            )?
+        } else {
             create_matrix_matrix_kernel(
                 context,
                 configuration.data_type,
@@ -147,8 +164,9 @@ impl<B: Backend> QuantizedMatmulKernelEncodable<B> {
                 bits,
                 use_mlx_quant,
                 matrix_matrix_family,
-            )?,
-        );
+            )?
+        };
+        kernels.insert(matrix_matrix_key, matrix_matrix_kernel);
 
         Ok(Self {
             kernels,
@@ -420,7 +438,7 @@ fn validate_configuration<B: Backend>(
         return Err(QuantizedMatmulError::UnsupportedDataType(configuration.data_type));
     }
 
-    if !matches!(configuration.group_size, 32 | 64 | 128) {
+    if !matches!(configuration.group_size, 32 | 64 | 128 | 256 | 512) {
         return Err(QuantizedMatmulError::UnsupportedGroupSize(configuration.group_size));
     }
 
@@ -466,10 +484,11 @@ fn select_matrix_matrix_family(
 
 fn quant_bits<B: Backend>(mode: QuantizationMode) -> Result<usize, QuantizedMatmulError<B>> {
     let bits = match mode {
+        QuantizationMode::UInt2 => 2,
         QuantizationMode::UInt4 => 4,
         QuantizationMode::UInt8 | QuantizationMode::Int8 => 8,
     };
-    if matches!(bits, 4 | 8) {
+    if matches!(bits, 2 | 4 | 8) {
         Ok(bits)
     } else {
         Err(QuantizedMatmulError::UnsupportedBits(bits))

--- a/crates/uzu/src/backends/common/kernel/quant_matmul.rs
+++ b/crates/uzu/src/backends/common/kernel/quant_matmul.rs
@@ -105,12 +105,6 @@ enum MatrixMatrixFamily {
     QmmTransposed64x64,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RuntimeVariant {
-    MatrixVector,
-    MatrixMatrix,
-}
-
 impl<B: Backend> QuantizedMatmulKernelEncodable<B> {
     pub fn new(
         context: &B::Context,
@@ -120,53 +114,33 @@ impl<B: Backend> QuantizedMatmulKernelEncodable<B> {
 
         let bits = quant_bits(configuration.mode)?;
         let use_mlx_quant = matches!(configuration.quantization_type, QuantizedMatmulType::Mlx);
-        let force_matrix_vector = bits == 2;
-
-        let matrix_vector_family = if force_matrix_vector {
-            MatrixVectorFamily::QmvFast
-        } else {
-            select_matrix_vector_family(&configuration)
-        };
-        let matrix_matrix_family = if force_matrix_vector {
-            MatrixMatrixFamily::QmmAlignedK
-        } else {
-            select_matrix_matrix_family(&configuration, bits)
-        };
-        let matrix_vector_key = KernelKey::MatrixVector(matrix_vector_family);
-        let matrix_matrix_key = KernelKey::MatrixMatrix(matrix_matrix_family);
+        let (matrix_vector_key, matrix_matrix_key) = select_kernel_keys(&configuration, bits);
 
         let mut kernels = HashMap::new();
         kernels.insert(
             matrix_vector_key,
-            create_matrix_vector_kernel(
+            create_kernel(
                 context,
                 configuration.data_type,
                 configuration.group_size,
                 bits,
                 use_mlx_quant,
-                matrix_vector_family,
+                matrix_vector_key,
             )?,
         );
-        let matrix_matrix_kernel = if force_matrix_vector {
-            create_matrix_vector_kernel(
-                context,
-                configuration.data_type,
-                configuration.group_size,
-                bits,
-                use_mlx_quant,
-                matrix_vector_family,
-            )?
-        } else {
-            create_matrix_matrix_kernel(
-                context,
-                configuration.data_type,
-                configuration.group_size,
-                bits,
-                use_mlx_quant,
-                matrix_matrix_family,
-            )?
-        };
-        kernels.insert(matrix_matrix_key, matrix_matrix_kernel);
+        if matrix_matrix_key != matrix_vector_key {
+            kernels.insert(
+                matrix_matrix_key,
+                create_kernel(
+                    context,
+                    configuration.data_type,
+                    configuration.group_size,
+                    bits,
+                    use_mlx_quant,
+                    matrix_matrix_key,
+                )?,
+            );
+        }
 
         Ok(Self {
             kernels,
@@ -189,10 +163,7 @@ impl<B: Backend> QuantizedMatmulKernelEncodable<B> {
             });
         }
 
-        let key = match self.select_runtime_variant(arguments.batch) {
-            RuntimeVariant::MatrixVector => self.matrix_vector_key,
-            RuntimeVariant::MatrixMatrix => self.matrix_matrix_key,
-        };
+        let key = self.kernel_key(arguments.batch);
 
         let kernel = self.kernels.get(&key).ok_or(QuantizedMatmulError::MissingKernel(kernel_key_name(key)))?;
         let k = to_i32("input_dim", arguments.input_dim)?;
@@ -291,15 +262,33 @@ impl<B: Backend> QuantizedMatmulKernelEncodable<B> {
         Ok(())
     }
 
-    fn select_runtime_variant(
+    fn kernel_key(
         &self,
         batch: usize,
-    ) -> RuntimeVariant {
+    ) -> KernelKey {
         if batch < 32 || self.output_dim == 1 {
-            RuntimeVariant::MatrixVector
+            self.matrix_vector_key
         } else {
-            RuntimeVariant::MatrixMatrix
+            self.matrix_matrix_key
         }
+    }
+}
+
+fn create_kernel<B: Backend>(
+    context: &B::Context,
+    data_type: DataType,
+    group_size: usize,
+    bits: usize,
+    use_mlx_quant: bool,
+    key: KernelKey,
+) -> Result<EncodableVariant<B>, QuantizedMatmulError<B>> {
+    match key {
+        KernelKey::MatrixVector(family) => {
+            create_matrix_vector_kernel(context, data_type, group_size, bits, use_mlx_quant, family)
+        },
+        KernelKey::MatrixMatrix(family) => {
+            create_matrix_matrix_kernel(context, data_type, group_size, bits, use_mlx_quant, family)
+        },
     }
 }
 
@@ -444,6 +433,21 @@ fn validate_configuration<B: Backend>(
 
     let _ = quant_bits(configuration.mode)?;
     Ok(())
+}
+
+fn select_kernel_keys(
+    configuration: &QuantizedMatmulConfiguration,
+    bits: usize,
+) -> (KernelKey, KernelKey) {
+    if bits == 2 {
+        let shared_key = KernelKey::MatrixVector(MatrixVectorFamily::QmvFast);
+        return (shared_key, shared_key);
+    }
+
+    (
+        KernelKey::MatrixVector(select_matrix_vector_family(configuration)),
+        KernelKey::MatrixMatrix(select_matrix_matrix_family(configuration, bits)),
+    )
 }
 
 fn select_matrix_vector_family(configuration: &QuantizedMatmulConfiguration) -> MatrixVectorFamily {

--- a/crates/uzu/src/backends/cpu/kernel/quant_matmul/qmm.rs
+++ b/crates/uzu/src/backends/cpu/kernel/quant_matmul/qmm.rs
@@ -6,7 +6,7 @@ use crate::ArrayElement;
 
 #[kernel(QuantizedMatmulQmm)]
 #[variants(T, f32, f16, bf16)]
-#[variants(GROUP_SIZE, 32, 64, 128)]
+#[variants(GROUP_SIZE, 32, 64, 128, 256, 512)]
 #[variants(BITS, 4, 8)]
 pub fn quantized_matmul_qmm<T: ArrayElement + Float, const GROUP_SIZE: i32, const BITS: i32>(
     #[allow(unused)] w: *const u32,

--- a/crates/uzu/src/backends/cpu/kernel/quant_matmul/qmm_transposed.rs
+++ b/crates/uzu/src/backends/cpu/kernel/quant_matmul/qmm_transposed.rs
@@ -6,7 +6,7 @@ use crate::ArrayElement;
 
 #[kernel(QuantizedMatmulQmmTransposed)]
 #[variants(T, f32, f16, bf16)]
-#[variants(GROUP_SIZE, 32, 64, 128)]
+#[variants(GROUP_SIZE, 32, 64, 128, 256, 512)]
 #[variants(BITS, 4, 8)]
 pub fn quantized_matmul_qmm_transposed<T: ArrayElement + Float, const GROUP_SIZE: i32, const BITS: i32>(
     #[allow(unused)] w: *const u32,

--- a/crates/uzu/src/backends/cpu/kernel/quant_matmul/qmv.rs
+++ b/crates/uzu/src/backends/cpu/kernel/quant_matmul/qmv.rs
@@ -6,7 +6,7 @@ use crate::ArrayElement;
 
 #[kernel(QuantizedMatmulQmv)]
 #[variants(T, f32, f16, bf16)]
-#[variants(GROUP_SIZE, 32, 64, 128)]
+#[variants(GROUP_SIZE, 32, 64, 128, 256, 512)]
 #[variants(BITS, 4, 8)]
 pub fn quantized_matmul_qmv<T: ArrayElement + Float, const GROUP_SIZE: i32, const BITS: i32>(
     #[allow(unused)] w: *const u32,

--- a/crates/uzu/src/backends/cpu/kernel/quant_matmul/qmv_fast.rs
+++ b/crates/uzu/src/backends/cpu/kernel/quant_matmul/qmv_fast.rs
@@ -6,8 +6,8 @@ use crate::ArrayElement;
 
 #[kernel(QuantizedMatmulQmvFast)]
 #[variants(T, f32, f16, bf16)]
-#[variants(GROUP_SIZE, 32, 64, 128)]
-#[variants(BITS, 4, 8)]
+#[variants(GROUP_SIZE, 32, 64, 128, 256, 512)]
+#[variants(BITS, 2, 4, 8)]
 pub fn quantized_matmul_qmv_fast<T: ArrayElement + Float, const GROUP_SIZE: i32, const BITS: i32>(
     #[allow(unused)] w: *const u32,
     #[allow(unused)] scales: *const T,

--- a/crates/uzu/src/backends/cpu/kernel/quant_matmul/qvm.rs
+++ b/crates/uzu/src/backends/cpu/kernel/quant_matmul/qvm.rs
@@ -6,7 +6,7 @@ use crate::ArrayElement;
 
 #[kernel(QuantizedMatmulQvm)]
 #[variants(T, f32, f16, bf16)]
-#[variants(GROUP_SIZE, 32, 64, 128)]
+#[variants(GROUP_SIZE, 32, 64, 128, 256, 512)]
 #[variants(BITS, 4, 8)]
 pub fn quantized_matmul_qvm<T: ArrayElement + Float, const GROUP_SIZE: i32, const BITS: i32>(
     #[allow(unused)] w: *const u32,

--- a/crates/uzu/src/backends/metal/kernel/quant_matmul/qmm.metal
+++ b/crates/uzu/src/backends/metal/kernel/quant_matmul/qmm.metal
@@ -4,7 +4,7 @@
 
 template <typename T, int GROUP_SIZE, int BITS>
 VARIANTS(T, float, half, bfloat)
-VARIANTS(GROUP_SIZE, 32, 64, 128)
+VARIANTS(GROUP_SIZE, 32, 64, 128, 256, 512)
 VARIANTS(BITS, 4, 8)
 KERNEL(QuantizedMatmulQmm)(
     const device uint32_t* w,

--- a/crates/uzu/src/backends/metal/kernel/quant_matmul/qmm_transposed.metal
+++ b/crates/uzu/src/backends/metal/kernel/quant_matmul/qmm_transposed.metal
@@ -4,7 +4,7 @@
 
 template <typename T, int GROUP_SIZE, int BITS>
 VARIANTS(T, float, half, bfloat)
-VARIANTS(GROUP_SIZE, 32, 64, 128)
+VARIANTS(GROUP_SIZE, 32, 64, 128, 256, 512)
 VARIANTS(BITS, 4, 8)
 KERNEL(QuantizedMatmulQmmTransposed)(
     const device uint32_t* w,

--- a/crates/uzu/src/backends/metal/kernel/quant_matmul/qmv.metal
+++ b/crates/uzu/src/backends/metal/kernel/quant_matmul/qmv.metal
@@ -4,7 +4,7 @@
 
 template <typename T, int GROUP_SIZE, int BITS>
 VARIANTS(T, float, half, bfloat)
-VARIANTS(GROUP_SIZE, 32, 64, 128)
+VARIANTS(GROUP_SIZE, 32, 64, 128, 256, 512)
 VARIANTS(BITS, 4, 8)
 KERNEL(QuantizedMatmulQmv)(
     const device uint32_t* w,

--- a/crates/uzu/src/backends/metal/kernel/quant_matmul/qmv_fast.metal
+++ b/crates/uzu/src/backends/metal/kernel/quant_matmul/qmv_fast.metal
@@ -4,8 +4,8 @@
 
 template <typename T, int GROUP_SIZE, int BITS>
 VARIANTS(T, float, half, bfloat)
-VARIANTS(GROUP_SIZE, 32, 64, 128)
-VARIANTS(BITS, 4, 8)
+VARIANTS(GROUP_SIZE, 32, 64, 128, 256, 512)
+VARIANTS(BITS, 2, 4, 8)
 KERNEL(QuantizedMatmulQmvFast)(
     const device uint32_t* w,
     const device T* scales,

--- a/crates/uzu/src/backends/metal/kernel/quant_matmul/quant_matmul.metal
+++ b/crates/uzu/src/backends/metal/kernel/quant_matmul/quant_matmul.metal
@@ -18,10 +18,18 @@ inline constexpr short get_bytes_per_pack() {
 
 template <typename T, typename U, int values_per_thread, int bits>
 inline U load_vector(const device T* x, thread U* x_thread) {
-  static_assert(bits == 4 || bits == 8, "Only int4 and int8 supported");
+  static_assert(bits == 2 || bits == 4 || bits == 8, "Only int2, int4 and int8 supported");
 
   U sum = 0;
-  if (bits == 4) {
+  if (bits == 2) {
+    for (int i = 0; i < values_per_thread; i += 4) {
+      sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3];
+      x_thread[i] = x[i];
+      x_thread[i + 1] = x[i + 1] / 4.0f;
+      x_thread[i + 2] = x[i + 2] / 16.0f;
+      x_thread[i + 3] = x[i + 3] / 64.0f;
+    }
+  } else if (bits == 4) {
     for (int i = 0; i < values_per_thread; i += 4) {
       sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3];
       x_thread[i] = x[i];
@@ -40,10 +48,26 @@ inline U load_vector(const device T* x, thread U* x_thread) {
 
 template <typename T, typename U, int values_per_thread, int bits>
 inline U load_vector_safe(const device T* x, thread U* x_thread, int N) {
-  static_assert(bits == 4 || bits == 8, "Only int4 and int8 supported");
+  static_assert(bits == 2 || bits == 4 || bits == 8, "Only int2, int4 and int8 supported");
 
   U sum = 0;
-  if (bits == 4) {
+  if (bits == 2) {
+    const U scale_lut[4] = {
+        static_cast<U>(1.0f),
+        static_cast<U>(1.0f / 4.0f),
+        static_cast<U>(1.0f / 16.0f),
+        static_cast<U>(1.0f / 64.0f)
+    };
+
+    for (int i = 0; i < values_per_thread; ++i) {
+      x_thread[i] = 0;
+    }
+    for (int i = 0; i < N; ++i) {
+      U v = x[i];
+      sum += v;
+      x_thread[i] = v * scale_lut[i & 3];
+    }
+  } else if (bits == 4) {
     const U scale_lut[4] = {
         static_cast<U>(1.0f),
         static_cast<U>(1.0f / 16.0f),
@@ -104,10 +128,19 @@ inline U qdot(
     U bias,
     U sum
 ) {
-  static_assert(bits == 4 || bits == 8, "Only int4 and int8 supported");
+  static_assert(bits == 2 || bits == 4 || bits == 8, "Only int2, int4 and int8 supported");
 
   U accum = 0;
-  if (bits == 4) {
+  if (bits == 2) {
+    for (int i = 0; i < values_per_thread; i += 4) {
+      const uint8_t byte = w[i / 4];
+      accum +=
+          (x_thread[i] * (byte & 0x03) +
+           x_thread[i + 1] * (byte & 0x0c) +
+           x_thread[i + 2] * (byte & 0x30) +
+           x_thread[i + 3] * (byte & 0xc0));
+    }
+  } else if (bits == 4) {
     const device uint16_t* ws = (const device uint16_t*)w;
     for (int i = 0; i < (values_per_thread / 4); i++) {
       accum +=
@@ -131,10 +164,34 @@ inline U qdot_zero_point(
     U scale,
     U zero_point
 ) {
-  static_assert(bits == 4 || bits == 8, "Only int4 and int8 supported");
+  static_assert(bits == 2 || bits == 4 || bits == 8, "Only int2, int4 and int8 supported");
 
   U accum = 0;
-  if (bits == 4) {
+  if (bits == 2) {
+    const uint8_t zp0 = static_cast<uint8_t>(zero_point);
+    const uint8_t zp1 = static_cast<uint8_t>(zero_point) << 2;
+    const uint8_t zp2 = static_cast<uint8_t>(zero_point) << 4;
+    const uint8_t zp3 = static_cast<uint8_t>(zero_point) << 6;
+    for (int i = 0; i < (values_per_thread / 4); i++) {
+      uint8_t byte = w[i];
+      accum += x_thread[4 * i] *
+               static_cast<U>(
+                   static_cast<int>(byte & 0x03) - static_cast<int>(zp0)
+               );
+      accum += x_thread[4 * i + 1] *
+               static_cast<U>(
+                   static_cast<int>(byte & 0x0c) - static_cast<int>(zp1)
+               );
+      accum += x_thread[4 * i + 2] *
+               static_cast<U>(
+                   static_cast<int>(byte & 0x30) - static_cast<int>(zp2)
+               );
+      accum += x_thread[4 * i + 3] *
+               static_cast<U>(
+                   static_cast<int>(byte & 0xc0) - static_cast<int>(zp3)
+               );
+    }
+  } else if (bits == 4) {
     const device uint16_t* ws = (const device uint16_t*)w;
     const uint16_t zp0 = static_cast<uint16_t>(zero_point);
     const uint16_t zp1 = static_cast<uint16_t>(zero_point) << 4;

--- a/crates/uzu/src/backends/metal/kernel/quant_matmul/qvm.metal
+++ b/crates/uzu/src/backends/metal/kernel/quant_matmul/qvm.metal
@@ -4,7 +4,7 @@
 
 template <typename T, int GROUP_SIZE, int BITS>
 VARIANTS(T, float, half, bfloat)
-VARIANTS(GROUP_SIZE, 32, 64, 128)
+VARIANTS(GROUP_SIZE, 32, 64, 128, 256, 512)
 VARIANTS(BITS, 4, 8)
 KERNEL(QuantizedMatmulQvm)(
     const device uint32_t* w,

--- a/crates/uzu/src/config/common.rs
+++ b/crates/uzu/src/config/common.rs
@@ -41,6 +41,7 @@ impl From<DataType> for ConfigDataType {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Copy, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum QuantizationMode {
+    UInt2,
     UInt4,
     Int8,
     UInt8,
@@ -49,6 +50,7 @@ pub enum QuantizationMode {
 impl QuantizationMode {
     pub fn packing_divisor(&self) -> usize {
         match self {
+            QuantizationMode::UInt2 => 4,
             QuantizationMode::UInt4 => 2,
             QuantizationMode::Int8 => 1,
             QuantizationMode::UInt8 => 1,
@@ -57,6 +59,7 @@ impl QuantizationMode {
 
     pub fn storage_type(&self) -> DataType {
         match self {
+            QuantizationMode::UInt2 => DataType::U8,
             QuantizationMode::UInt4 => DataType::U8,
             QuantizationMode::Int8 => DataType::I8,
             QuantizationMode::UInt8 => DataType::U8,
@@ -67,6 +70,7 @@ impl QuantizationMode {
 impl From<QuantizationMode> for DataType {
     fn from(val: QuantizationMode) -> Self {
         match val {
+            QuantizationMode::UInt2 => DataType::U2,
             QuantizationMode::UInt4 => DataType::U4,
             QuantizationMode::Int8 => DataType::I8,
             QuantizationMode::UInt8 => DataType::U8,

--- a/crates/uzu/src/config/embedding.rs
+++ b/crates/uzu/src/config/embedding.rs
@@ -50,6 +50,16 @@ pub enum EmbeddingConfig {
         activation_quantization_mode: Option<QuantizationMode>,
         activation_precision: ConfigDataType,
     },
+    #[serde(rename = "MLXQuantizedOutputUntiedEmbeddingConfig")]
+    MLXQuantizedOutputUntied {
+        #[serde(flatten)]
+        common: EmbeddingConfigCommon,
+        group_size: usize,
+        output_group_size: usize,
+        embedding_quantization_mode: QuantizationMode,
+        activation_precision: ConfigDataType,
+        output_quantization_mode: QuantizationMode,
+    },
 }
 
 impl EmbeddingConfig {
@@ -72,6 +82,10 @@ impl EmbeddingConfig {
                 ..
             } => common,
             EmbeddingConfig::MLXSemiQuantizedUntied {
+                common,
+                ..
+            } => common,
+            EmbeddingConfig::MLXQuantizedOutputUntied {
                 common,
                 ..
             } => common,
@@ -138,5 +152,33 @@ mod tests {
 
         let deserialized: EmbeddingConfig = from_str(mlx_quant_untied_str).unwrap();
         assert_eq!(deserialized, mlx_quant_untied);
+
+        let mlx_quant_output_untied_str = r#"
+            {
+                "type": "MLXQuantizedOutputUntiedEmbeddingConfig",
+                "input_scale": null,
+                "logit_soft_cap": null,
+                "group_size": 128,
+                "output_group_size": 512,
+                "embedding_quantization_mode": "uint8",
+                "activation_precision": "bfloat16",
+                "output_quantization_mode": "uint2"
+            }
+        "#;
+
+        let mlx_quant_output_untied = EmbeddingConfig::MLXQuantizedOutputUntied {
+            common: EmbeddingConfigCommon {
+                input_scale: None,
+                logit_soft_cap: None,
+            },
+            group_size: 128,
+            output_group_size: 512,
+            embedding_quantization_mode: QuantizationMode::UInt8,
+            activation_precision: ConfigDataType::BFloat16,
+            output_quantization_mode: QuantizationMode::UInt2,
+        };
+
+        let deserialized: EmbeddingConfig = from_str(mlx_quant_output_untied_str).unwrap();
+        assert_eq!(deserialized, mlx_quant_output_untied);
     }
 }

--- a/crates/uzu/src/config/embedding.rs
+++ b/crates/uzu/src/config/embedding.rs
@@ -68,24 +68,24 @@ impl EmbeddingConfig {
             EmbeddingConfig::Tied {
                 common,
                 ..
-            } => common,
-            EmbeddingConfig::Untied {
+            }
+            | EmbeddingConfig::Untied {
                 common,
                 ..
-            } => common,
-            EmbeddingConfig::MLXQuantizedTied {
+            }
+            | EmbeddingConfig::MLXQuantizedTied {
                 common,
                 ..
-            } => common,
-            EmbeddingConfig::MLXQuantizedUntied {
+            }
+            | EmbeddingConfig::MLXQuantizedUntied {
                 common,
                 ..
-            } => common,
-            EmbeddingConfig::MLXSemiQuantizedUntied {
+            }
+            | EmbeddingConfig::MLXSemiQuantizedUntied {
                 common,
                 ..
-            } => common,
-            EmbeddingConfig::MLXQuantizedOutputUntied {
+            }
+            | EmbeddingConfig::MLXQuantizedOutputUntied {
                 common,
                 ..
             } => common,

--- a/crates/uzu/src/data_type.rs
+++ b/crates/uzu/src/data_type.rs
@@ -11,6 +11,7 @@ pub enum DataType {
     F32,
     F64,
     // Sub-byte integers
+    U2,
     I4,
     U4,
     // Normal integers
@@ -27,6 +28,7 @@ pub enum DataType {
 impl DataType {
     pub const fn size_in_bits(&self) -> usize {
         match self {
+            DataType::U2 => 2,
             DataType::I4 | DataType::U4 => 4,
             DataType::I8 | DataType::U8 => 8,
             DataType::I16 | DataType::U16 => 16,
@@ -45,7 +47,9 @@ impl DataType {
             DataType::BF16 => DLDataTypeCode::kDLBfloat,
             DataType::F16 | DataType::F32 | DataType::F64 => DLDataTypeCode::kDLFloat,
             DataType::I4 | DataType::I8 | DataType::I16 | DataType::I32 | DataType::I64 => DLDataTypeCode::kDLInt,
-            DataType::U4 | DataType::U8 | DataType::U16 | DataType::U32 | DataType::U64 => DLDataTypeCode::kDLUInt,
+            DataType::U2 | DataType::U4 | DataType::U8 | DataType::U16 | DataType::U32 | DataType::U64 => {
+                DLDataTypeCode::kDLUInt
+            },
         }
     }
 }

--- a/crates/uzu/src/encodable_block/embedding.rs
+++ b/crates/uzu/src/encodable_block/embedding.rs
@@ -130,6 +130,53 @@ fn validate_tensor<'file, 'context, 'leaf, B: Backend>(
     Ok(())
 }
 
+fn read_quantized_embedding_tensors<B: Backend>(
+    parameter_tree: &ParameterTree<B::Context>,
+    weights_name: &str,
+    scales_name: &str,
+    biases_name: &str,
+    vocab_size: u32,
+    model_dim: u32,
+    group_size: usize,
+    mode: QuantizationMode,
+    data_type: DataType,
+) -> Result<(B::Buffer, B::Buffer, B::Buffer), EmbeddingError<B>> {
+    let vocab_size = vocab_size as usize;
+    let model_dim = model_dim as usize;
+    let num_groups = model_dim.div_ceil(group_size);
+
+    let weights_leaf = parameter_tree.leaf(weights_name)?;
+    validate_tensor(&weights_leaf, [vocab_size, model_dim / mode.packing_divisor()], mode.storage_type())?;
+    let scales_leaf = parameter_tree.leaf(scales_name)?;
+    validate_tensor(&scales_leaf, [vocab_size, num_groups], data_type)?;
+    let biases_leaf = parameter_tree.leaf(biases_name)?;
+    validate_tensor(&biases_leaf, [vocab_size, num_groups], data_type)?;
+
+    Ok((weights_leaf.read_buffer()?, scales_leaf.read_buffer()?, biases_leaf.read_buffer()?))
+}
+
+fn new_mlx_quantized_readout<B: Backend>(
+    context: &B::Context,
+    data_type: DataType,
+    group_size: usize,
+    model_dim: u32,
+    vocab_size: u32,
+    mode: QuantizationMode,
+) -> Result<QuantizedMatmulKernelEncodable<B>, EmbeddingError<B>> {
+    Ok(QuantizedMatmulKernelEncodable::new(
+        context,
+        QuantizedMatmulConfiguration {
+            data_type,
+            group_size,
+            input_dim: model_dim as usize,
+            output_dim: vocab_size as usize,
+            mode,
+            quantization_type: QuantizedMatmulType::Mlx,
+            weights_transposed: true,
+        },
+    )?)
+}
+
 impl<B: Backend> Embedding<B> {
     pub fn new(
         context: &B::Context,
@@ -268,53 +315,28 @@ impl<B: Backend> Embedding<B> {
                 activation_precision,
             } => {
                 let data_type = (*activation_precision).into();
-
-                let packing_divisor = embedding_quantization_mode.packing_divisor();
-                let storage_data_type = embedding_quantization_mode.storage_type();
-
-                let num_groups = (model_dim as usize).div_ceil(*group_size);
-
-                let input_weights_leaf = parameter_tree.leaf("input_weights")?;
-                validate_tensor(
-                    &input_weights_leaf,
-                    [vocab_size as usize, model_dim as usize / packing_divisor],
-                    storage_data_type,
+                let (input_weights, input_scales, input_biases) = read_quantized_embedding_tensors(
+                    parameter_tree,
+                    "input_weights",
+                    "input_scales",
+                    "input_biases",
+                    vocab_size,
+                    model_dim,
+                    *group_size,
+                    *embedding_quantization_mode,
+                    data_type,
                 )?;
-                let input_scales_leaf = parameter_tree.leaf("input_scales")?;
-                validate_tensor(&input_scales_leaf, [vocab_size as usize, num_groups], data_type)?;
-                let input_biases_leaf = parameter_tree.leaf("input_biases")?;
-                validate_tensor(&input_biases_leaf, [vocab_size as usize, num_groups], data_type)?;
-
-                let output_weights_leaf = parameter_tree.leaf("output_weights")?;
-                validate_tensor(
-                    &output_weights_leaf,
-                    [vocab_size as usize, model_dim as usize / packing_divisor],
-                    storage_data_type,
+                let (output_weights, output_scales, output_biases) = read_quantized_embedding_tensors(
+                    parameter_tree,
+                    "output_weights",
+                    "output_scales",
+                    "output_biases",
+                    vocab_size,
+                    model_dim,
+                    *group_size,
+                    *embedding_quantization_mode,
+                    data_type,
                 )?;
-                let output_scales_leaf = parameter_tree.leaf("output_scales")?;
-                validate_tensor(&output_scales_leaf, [vocab_size as usize, num_groups], data_type)?;
-                let output_biases_leaf = parameter_tree.leaf("output_biases")?;
-                validate_tensor(&output_biases_leaf, [vocab_size as usize, num_groups], data_type)?;
-
-                let input_weights = input_weights_leaf.read_buffer()?;
-                let input_scales = input_scales_leaf.read_buffer()?;
-                let input_biases = input_biases_leaf.read_buffer()?;
-
-                let output_tree = parameter_tree.subtree("output")?;
-                let output_weights_leaf = output_tree.leaf("weights")?;
-                validate_tensor(
-                    &output_weights_leaf,
-                    [vocab_size as usize, model_dim as usize / output_packing_divisor],
-                    output_storage_data_type,
-                )?;
-                let output_scales_leaf = output_tree.leaf("scales")?;
-                validate_tensor(&output_scales_leaf, [vocab_size as usize, output_num_groups], data_type)?;
-                let output_biases_leaf = output_tree.leaf("biases")?;
-                validate_tensor(&output_biases_leaf, [vocab_size as usize, output_num_groups], data_type)?;
-
-                let output_weights = output_weights_leaf.read_buffer()?;
-                let output_scales = output_scales_leaf.read_buffer()?;
-                let output_biases = output_biases_leaf.read_buffer()?;
 
                 let lookup = <B::Kernels as Kernels>::QuantizedEmbeddingLookupKernel::new(
                     context,
@@ -323,17 +345,13 @@ impl<B: Backend> Embedding<B> {
                     quant_mode_to_int(*embedding_quantization_mode),
                 )
                 .map_err(EmbeddingError::BackendError)?;
-                let readout = QuantizedMatmulKernelEncodable::new(
+                let readout = new_mlx_quantized_readout(
                     context,
-                    QuantizedMatmulConfiguration {
-                        data_type,
-                        group_size: *group_size,
-                        input_dim: model_dim as usize,
-                        output_dim: vocab_size as usize,
-                        mode: *embedding_quantization_mode,
-                        quantization_type: QuantizedMatmulType::Mlx,
-                        weights_transposed: true,
-                    },
+                    data_type,
+                    *group_size,
+                    model_dim,
+                    vocab_size,
+                    *embedding_quantization_mode,
                 )?;
 
                 if let Some(activation_quantization_mode) = activation_quantization_mode {
@@ -365,45 +383,30 @@ impl<B: Backend> Embedding<B> {
                 activation_precision,
             } => {
                 let data_type = (*activation_precision).into();
-
-                let packing_divisor = embedding_quantization_mode.packing_divisor();
-                let storage_data_type = embedding_quantization_mode.storage_type();
-
-                let num_groups = (model_dim as usize).div_ceil(*group_size);
-
                 let input_weights_leaf = parameter_tree.leaf("input_weights")?;
                 validate_tensor(&input_weights_leaf, [vocab_size as usize, model_dim as usize], data_type)?;
-
-                let output_weights_leaf = parameter_tree.leaf("output_weights")?;
-                validate_tensor(
-                    &output_weights_leaf,
-                    [vocab_size as usize, model_dim as usize / packing_divisor],
-                    storage_data_type,
-                )?;
-                let output_scales_leaf = parameter_tree.leaf("output_scales")?;
-                validate_tensor(&output_scales_leaf, [vocab_size as usize, num_groups], data_type)?;
-                let output_biases_leaf = parameter_tree.leaf("output_biases")?;
-                validate_tensor(&output_biases_leaf, [vocab_size as usize, num_groups], data_type)?;
-
                 let input_weights = input_weights_leaf.read_buffer()?;
-
-                let output_weights = output_weights_leaf.read_buffer()?;
-                let output_scales = output_scales_leaf.read_buffer()?;
-                let output_biases = output_biases_leaf.read_buffer()?;
+                let (output_weights, output_scales, output_biases) = read_quantized_embedding_tensors(
+                    parameter_tree,
+                    "output_weights",
+                    "output_scales",
+                    "output_biases",
+                    vocab_size,
+                    model_dim,
+                    *group_size,
+                    *embedding_quantization_mode,
+                    data_type,
+                )?;
 
                 let lookup = <B::Kernels as Kernels>::FullPrecisionEmbeddingLookupKernel::new(context, data_type)
                     .map_err(EmbeddingError::BackendError)?;
-                let readout = QuantizedMatmulKernelEncodable::new(
+                let readout = new_mlx_quantized_readout(
                     context,
-                    QuantizedMatmulConfiguration {
-                        data_type,
-                        group_size: *group_size,
-                        input_dim: model_dim as usize,
-                        output_dim: vocab_size as usize,
-                        mode: *embedding_quantization_mode,
-                        quantization_type: QuantizedMatmulType::Mlx,
-                        weights_transposed: true,
-                    },
+                    data_type,
+                    *group_size,
+                    model_dim,
+                    vocab_size,
+                    *embedding_quantization_mode,
                 )?;
 
                 if let Some(activation_quantization_mode) = activation_quantization_mode {
@@ -434,44 +437,30 @@ impl<B: Backend> Embedding<B> {
                 output_quantization_mode,
             } => {
                 let data_type = (*activation_precision).into();
-                let input_packing_divisor = embedding_quantization_mode.packing_divisor();
-                let input_storage_data_type = embedding_quantization_mode.storage_type();
-                let input_num_groups = (model_dim as usize).div_ceil(*group_size);
-
-                let output_packing_divisor = output_quantization_mode.packing_divisor();
-                let output_storage_data_type = output_quantization_mode.storage_type();
-                let output_num_groups = (model_dim as usize).div_ceil(*output_group_size);
-
-                let input_weights_leaf = parameter_tree.leaf("input_weights")?;
-                validate_tensor(
-                    &input_weights_leaf,
-                    [vocab_size as usize, model_dim as usize / input_packing_divisor],
-                    input_storage_data_type,
+                let (input_weights, input_scales, input_biases) = read_quantized_embedding_tensors(
+                    parameter_tree,
+                    "input_weights",
+                    "input_scales",
+                    "input_biases",
+                    vocab_size,
+                    model_dim,
+                    *group_size,
+                    *embedding_quantization_mode,
+                    data_type,
                 )?;
-                let input_scales_leaf = parameter_tree.leaf("input_scales")?;
-                validate_tensor(&input_scales_leaf, [vocab_size as usize, input_num_groups], data_type)?;
-                let input_biases_leaf = parameter_tree.leaf("input_biases")?;
-                validate_tensor(&input_biases_leaf, [vocab_size as usize, input_num_groups], data_type)?;
-
-                let input_weights = input_weights_leaf.read_buffer()?;
-                let input_scales = input_scales_leaf.read_buffer()?;
-                let input_biases = input_biases_leaf.read_buffer()?;
 
                 let output_tree = parameter_tree.subtree("output")?;
-                let output_weights_leaf = output_tree.leaf("weights")?;
-                validate_tensor(
-                    &output_weights_leaf,
-                    [vocab_size as usize, model_dim as usize / output_packing_divisor],
-                    output_storage_data_type,
+                let (output_weights, output_scales, output_biases) = read_quantized_embedding_tensors(
+                    &output_tree,
+                    "weights",
+                    "scales",
+                    "biases",
+                    vocab_size,
+                    model_dim,
+                    *output_group_size,
+                    *output_quantization_mode,
+                    data_type,
                 )?;
-                let output_scales_leaf = output_tree.leaf("scales")?;
-                validate_tensor(&output_scales_leaf, [vocab_size as usize, output_num_groups], data_type)?;
-                let output_biases_leaf = output_tree.leaf("biases")?;
-                validate_tensor(&output_biases_leaf, [vocab_size as usize, output_num_groups], data_type)?;
-
-                let output_weights = output_weights_leaf.read_buffer()?;
-                let output_scales = output_scales_leaf.read_buffer()?;
-                let output_biases = output_biases_leaf.read_buffer()?;
 
                 let lookup = <B::Kernels as Kernels>::QuantizedEmbeddingLookupKernel::new(
                     context,
@@ -480,17 +469,13 @@ impl<B: Backend> Embedding<B> {
                     quant_mode_to_int(*embedding_quantization_mode),
                 )
                 .map_err(EmbeddingError::BackendError)?;
-                let readout = QuantizedMatmulKernelEncodable::new(
+                let readout = new_mlx_quantized_readout(
                     context,
-                    QuantizedMatmulConfiguration {
-                        data_type,
-                        group_size: *output_group_size,
-                        input_dim: model_dim as usize,
-                        output_dim: vocab_size as usize,
-                        mode: *output_quantization_mode,
-                        quantization_type: QuantizedMatmulType::Mlx,
-                        weights_transposed: true,
-                    },
+                    data_type,
+                    *output_group_size,
+                    model_dim,
+                    vocab_size,
+                    *output_quantization_mode,
                 )?;
 
                 EmbeddingTying::Untied {

--- a/crates/uzu/src/encodable_block/embedding.rs
+++ b/crates/uzu/src/encodable_block/embedding.rs
@@ -103,6 +103,7 @@ pub struct Embedding<B: Backend> {
 
 fn quant_mode_to_int(quant_mode: QuantizationMode) -> u32 {
     match quant_mode {
+        QuantizationMode::UInt2 => panic!("uint2 embedding lookup is unsupported"),
         QuantizationMode::UInt4 => 0,
         QuantizationMode::Int8 => 1,
         QuantizationMode::UInt8 => 2,
@@ -299,6 +300,18 @@ impl<B: Backend> Embedding<B> {
                 let input_scales = input_scales_leaf.read_buffer()?;
                 let input_biases = input_biases_leaf.read_buffer()?;
 
+                let output_tree = parameter_tree.subtree("output")?;
+                let output_weights_leaf = output_tree.leaf("weights")?;
+                validate_tensor(
+                    &output_weights_leaf,
+                    [vocab_size as usize, model_dim as usize / output_packing_divisor],
+                    output_storage_data_type,
+                )?;
+                let output_scales_leaf = output_tree.leaf("scales")?;
+                validate_tensor(&output_scales_leaf, [vocab_size as usize, output_num_groups], data_type)?;
+                let output_biases_leaf = output_tree.leaf("biases")?;
+                validate_tensor(&output_biases_leaf, [vocab_size as usize, output_num_groups], data_type)?;
+
                 let output_weights = output_weights_leaf.read_buffer()?;
                 let output_scales = output_scales_leaf.read_buffer()?;
                 let output_biases = output_biases_leaf.read_buffer()?;
@@ -402,6 +415,89 @@ impl<B: Backend> Embedding<B> {
                 EmbeddingTying::Untied {
                     input_ty: UntiedEmbeddingLookupType::FullPrecision {
                         weights: input_weights,
+                        lookup,
+                    },
+                    output_ty: UntiedEmbeddingReadoutType::Quantized {
+                        weights: output_weights,
+                        scales: output_scales,
+                        biases: output_biases,
+                        readout,
+                    },
+                }
+            },
+            EmbeddingConfig::MLXQuantizedOutputUntied {
+                common: _,
+                group_size,
+                output_group_size,
+                embedding_quantization_mode,
+                activation_precision,
+                output_quantization_mode,
+            } => {
+                let data_type = (*activation_precision).into();
+                let input_packing_divisor = embedding_quantization_mode.packing_divisor();
+                let input_storage_data_type = embedding_quantization_mode.storage_type();
+                let input_num_groups = (model_dim as usize).div_ceil(*group_size);
+
+                let output_packing_divisor = output_quantization_mode.packing_divisor();
+                let output_storage_data_type = output_quantization_mode.storage_type();
+                let output_num_groups = (model_dim as usize).div_ceil(*output_group_size);
+
+                let input_weights_leaf = parameter_tree.leaf("input_weights")?;
+                validate_tensor(
+                    &input_weights_leaf,
+                    [vocab_size as usize, model_dim as usize / input_packing_divisor],
+                    input_storage_data_type,
+                )?;
+                let input_scales_leaf = parameter_tree.leaf("input_scales")?;
+                validate_tensor(&input_scales_leaf, [vocab_size as usize, input_num_groups], data_type)?;
+                let input_biases_leaf = parameter_tree.leaf("input_biases")?;
+                validate_tensor(&input_biases_leaf, [vocab_size as usize, input_num_groups], data_type)?;
+
+                let input_weights = input_weights_leaf.read_buffer()?;
+                let input_scales = input_scales_leaf.read_buffer()?;
+                let input_biases = input_biases_leaf.read_buffer()?;
+
+                let output_tree = parameter_tree.subtree("output")?;
+                let output_weights_leaf = output_tree.leaf("weights")?;
+                validate_tensor(
+                    &output_weights_leaf,
+                    [vocab_size as usize, model_dim as usize / output_packing_divisor],
+                    output_storage_data_type,
+                )?;
+                let output_scales_leaf = output_tree.leaf("scales")?;
+                validate_tensor(&output_scales_leaf, [vocab_size as usize, output_num_groups], data_type)?;
+                let output_biases_leaf = output_tree.leaf("biases")?;
+                validate_tensor(&output_biases_leaf, [vocab_size as usize, output_num_groups], data_type)?;
+
+                let output_weights = output_weights_leaf.read_buffer()?;
+                let output_scales = output_scales_leaf.read_buffer()?;
+                let output_biases = output_biases_leaf.read_buffer()?;
+
+                let lookup = <B::Kernels as Kernels>::QuantizedEmbeddingLookupKernel::new(
+                    context,
+                    data_type,
+                    *group_size as u32,
+                    quant_mode_to_int(*embedding_quantization_mode),
+                )
+                .map_err(EmbeddingError::BackendError)?;
+                let readout = QuantizedMatmulKernelEncodable::new(
+                    context,
+                    QuantizedMatmulConfiguration {
+                        data_type,
+                        group_size: *output_group_size,
+                        input_dim: model_dim as usize,
+                        output_dim: vocab_size as usize,
+                        mode: *output_quantization_mode,
+                        quantization_type: QuantizedMatmulType::Mlx,
+                        weights_transposed: true,
+                    },
+                )?;
+
+                EmbeddingTying::Untied {
+                    input_ty: UntiedEmbeddingLookupType::Quantized {
+                        weights: input_weights,
+                        scales: input_scales,
+                        biases: input_biases,
                         lookup,
                     },
                     output_ty: UntiedEmbeddingReadoutType::Quantized {

--- a/scripts/rht_to_quant_model.py
+++ b/scripts/rht_to_quant_model.py
@@ -226,46 +226,6 @@ def base_weight_key_from_inner(weight_key: str) -> str:
     return weight_key.removesuffix(".inner_linear.weights") + ".weights"
 
 
-def config_path_for_weight_key(weight_key: str) -> tuple[str, ...]:
-    parts = weight_key.split(".")
-    assert parts[:3] == ["transformer", "layers", parts[2]]
-    layer_index = parts[2]
-    if parts[3] == "mlp":
-        return ("model_config", "model_config", "transformer_config", "layer_configs", layer_index, "mlp_config", "linear_config")
-    if parts[3] == "mixer":
-        if parts[4] == "in_projection":
-            return (
-                "model_config",
-                "model_config",
-                "transformer_config",
-                "layer_configs",
-                layer_index,
-                "mixer_config",
-                "in_projection_config",
-            )
-        if parts[4] == "out_projection":
-            return (
-                "model_config",
-                "model_config",
-                "transformer_config",
-                "layer_configs",
-                layer_index,
-                "mixer_config",
-                "out_projection_config",
-            )
-        if parts[4] == "qkv_projection":
-            return (
-                "model_config",
-                "model_config",
-                "transformer_config",
-                "layer_configs",
-                layer_index,
-                "mixer_config",
-                "qkv_projection_config",
-            )
-    raise AssertionError(weight_key)
-
-
 def linear_group_size_for_weight_key(weight_key: str, settings: Settings) -> int:
     if ".mlp." in weight_key and settings.mlp_group_size is not None:
         return settings.mlp_group_size
@@ -280,16 +240,6 @@ def linear_group_size_for_config_path(path: tuple[str, ...], settings: Settings)
     if "mixer_config" in path and settings.mixer_group_size is not None:
         return settings.mixer_group_size
     return settings.linear_group_size
-
-
-def set_config_path(root: dict[str, object], path: tuple[str, ...], value: dict[str, object]) -> None:
-    cursor: object = root
-    for part in path[:-1]:
-        cursor = cursor[int(part)] if isinstance(cursor, list) else cursor[part]
-    if isinstance(cursor, list):
-        cursor[int(path[-1])] = value
-    else:
-        cursor[path[-1]] = value
 
 
 def rewrite_rht_config(config: dict[str, object], settings: Settings) -> None:
@@ -314,24 +264,18 @@ def rewrite_rht_config(config: dict[str, object], settings: Settings) -> None:
 def rewrite_embedding_config(config: dict[str, object], settings: Settings) -> None:
     embedding_config = config["model_config"]["model_config"]["embedding_config"]
     assert embedding_config["type"] == "MLXQuantizedTiedEmbeddingConfig"
-    group_size = embedding_config["group_size"]
-    embedding_quantization_mode = embedding_config["embedding_quantization_mode"]
-    activation_precision = embedding_config["activation_precision"]
-    input_scale = embedding_config["input_scale"]
-    logit_soft_cap = embedding_config["logit_soft_cap"]
+    rewritten_embedding_config = {
+        "type": "MLXQuantizedOutputUntiedEmbeddingConfig",
+        "input_scale": embedding_config["input_scale"],
+        "logit_soft_cap": embedding_config["logit_soft_cap"],
+        "group_size": embedding_config["group_size"],
+        "output_group_size": settings.lm_head_group_size,
+        "embedding_quantization_mode": embedding_config["embedding_quantization_mode"],
+        "activation_precision": embedding_config["activation_precision"],
+        "output_quantization_mode": settings.lm_head_mode,
+    }
     embedding_config.clear()
-    embedding_config.update(
-        {
-            "type": "MLXQuantizedOutputUntiedEmbeddingConfig",
-            "input_scale": input_scale,
-            "logit_soft_cap": logit_soft_cap,
-            "group_size": group_size,
-            "output_group_size": settings.lm_head_group_size,
-            "embedding_quantization_mode": embedding_quantization_mode,
-            "activation_precision": activation_precision,
-            "output_quantization_mode": settings.lm_head_mode,
-        }
-    )
+    embedding_config.update(rewritten_embedding_config)
 
 
 def convert_linear(source: safe_open, weight_key: str, settings: Settings) -> ConvertedLinear:

--- a/scripts/rht_to_quant_model.py
+++ b/scripts/rht_to_quant_model.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+RHT_BLOCK_SIZE = 32
+UINT4_MAX = 15.0
+RHT_GROUP_SIZE = 32
+
+
+@dataclass(frozen=True)
+class Settings:
+    source_model: Path
+    output_model: Path
+    linear_group_size: int
+    mlp_group_size: int | None
+    mixer_group_size: int | None
+    lm_head_mode: str
+    lm_head_group_size: int
+
+
+@dataclass(frozen=True)
+class ConvertedLinear:
+    weights: torch.Tensor
+    scales: torch.Tensor
+    zero_points: torch.Tensor
+
+
+@dataclass(frozen=True)
+class ConvertedEmbeddingOutput:
+    weights: torch.Tensor
+    scales: torch.Tensor
+    biases: torch.Tensor
+
+
+def parse_args() -> Settings:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source-model", type=Path, required=True)
+    parser.add_argument("--output-model", type=Path, required=True)
+    parser.add_argument("--linear-group-size", type=int, choices=(32, 64, 128, 256, 512), default=32)
+    parser.add_argument("--mlp-group-size", type=int, choices=(32, 64, 128, 256, 512))
+    parser.add_argument("--mixer-group-size", type=int, choices=(32, 64, 128, 256, 512))
+    parser.add_argument("--lm-head-mode", choices=("uint4", "uint2"), required=True)
+    parser.add_argument("--lm-head-group-size", type=int, choices=(32, 64, 128, 256, 512), required=True)
+    args = parser.parse_args()
+    return Settings(
+        source_model=args.source_model,
+        output_model=args.output_model,
+        linear_group_size=args.linear_group_size,
+        mlp_group_size=args.mlp_group_size,
+        mixer_group_size=args.mixer_group_size,
+        lm_head_mode=args.lm_head_mode,
+        lm_head_group_size=args.lm_head_group_size,
+    )
+
+
+def unpack_uint4(packed: torch.Tensor) -> torch.Tensor:
+    low = packed & 0x0F
+    high = (packed >> 4) & 0x0F
+    return torch.stack((low, high), dim=-1).reshape(*packed.shape[:-1], packed.shape[-1] * 2).to(torch.float32)
+
+
+def pack_uint4(values: torch.Tensor) -> torch.Tensor:
+    assert values.dtype == torch.uint8
+    assert values.shape[-1] % 2 == 0
+    grouped = values.reshape(*values.shape[:-1], values.shape[-1] // 2, 2)
+    return ((grouped[..., 1] << 4) | grouped[..., 0]).contiguous()
+
+
+def unpack_uint2(packed: torch.Tensor) -> torch.Tensor:
+    b0 = packed & 0x03
+    b1 = (packed >> 2) & 0x03
+    b2 = (packed >> 4) & 0x03
+    b3 = (packed >> 6) & 0x03
+    return torch.stack((b0, b1, b2, b3), dim=-1).reshape(*packed.shape[:-1], packed.shape[-1] * 4).to(torch.float32)
+
+
+def pack_uint2(values: torch.Tensor) -> torch.Tensor:
+    assert values.dtype == torch.uint8
+    assert values.shape[-1] % 4 == 0
+    grouped = values.reshape(*values.shape[:-1], values.shape[-1] // 4, 4)
+    return (grouped[..., 0] | (grouped[..., 1] << 2) | (grouped[..., 2] << 4) | (grouped[..., 3] << 6)).contiguous()
+
+
+def dequantize_group_uint4(
+    packed_weights: torch.Tensor,
+    scales: torch.Tensor,
+    packed_zero_points: torch.Tensor,
+    group_size: int,
+) -> torch.Tensor:
+    unpacked_weights = unpack_uint4(packed_weights)
+    unpacked_zero_points = unpack_uint4(packed_zero_points)
+    output_dim, input_dim = unpacked_weights.shape
+    group_count = input_dim // group_size
+    grouped_weights = unpacked_weights.view(output_dim, group_count, group_size)
+    grouped_zero_points = unpacked_zero_points.view(output_dim, group_count, 1)
+    grouped_scales = scales.to(torch.float32).view(output_dim, group_count, 1)
+    return ((grouped_weights - grouped_zero_points) * grouped_scales).view(output_dim, input_dim)
+
+
+def dequantize_mlx_embedding(
+    weights: torch.Tensor,
+    scales: torch.Tensor,
+    biases: torch.Tensor,
+    *,
+    quantization_mode: str,
+    group_size: int,
+) -> torch.Tensor:
+    if quantization_mode == "uint2":
+        unpacked_weights = unpack_uint2(weights)
+    elif quantization_mode == "uint4":
+        unpacked_weights = unpack_uint4(weights)
+    else:
+        assert quantization_mode == "uint8"
+        unpacked_weights = weights.to(torch.float32)
+
+    output_dim, input_dim = unpacked_weights.shape
+    group_count = input_dim // group_size
+    grouped_weights = unpacked_weights.view(output_dim, group_count, group_size)
+    grouped_scales = scales.to(torch.float32).view(output_dim, group_count, 1)
+    grouped_biases = biases.to(torch.float32).view(output_dim, group_count, 1)
+    return (grouped_weights * grouped_scales + grouped_biases).view(output_dim, input_dim)
+
+
+def hadamard_blocks_last_dim(values: torch.Tensor, block_size: int) -> torch.Tensor:
+    assert values.shape[-1] % block_size == 0
+    original_shape = values.shape
+    result = values.reshape(-1, values.shape[-1] // block_size, block_size)
+    step = 1
+    while step < block_size:
+        result = result.reshape(-1, values.shape[-1] // block_size, block_size // (2 * step), 2, step)
+        low = result[..., 0, :]
+        high = result[..., 1, :]
+        result = torch.cat((low + high, low - high), dim=-1)
+        step *= 2
+    return result.reshape(original_shape) / (block_size**0.5)
+
+
+def apply_input_inverse(weights: torch.Tensor, input_factors: torch.Tensor) -> torch.Tensor:
+    return hadamard_blocks_last_dim(weights, RHT_BLOCK_SIZE) * input_factors.to(torch.float32)
+
+
+def apply_output_rotate(weights: torch.Tensor, output_factors: torch.Tensor) -> torch.Tensor:
+    transposed = weights.transpose(0, 1)
+    rotated = hadamard_blocks_last_dim(transposed * output_factors.to(torch.float32), RHT_BLOCK_SIZE)
+    return rotated.transpose(0, 1).contiguous()
+
+
+def unwrap_rht_group_uint4(
+    packed_weights: torch.Tensor,
+    scales: torch.Tensor,
+    packed_zero_points: torch.Tensor,
+    input_factors: torch.Tensor,
+    output_factors: torch.Tensor,
+) -> torch.Tensor:
+    dequantized = dequantize_group_uint4(packed_weights, scales, packed_zero_points, RHT_GROUP_SIZE)
+    return apply_output_rotate(apply_input_inverse(dequantized, input_factors), output_factors).contiguous()
+
+
+def requantize_group_uint4(weights: torch.Tensor, group_size: int) -> ConvertedLinear:
+    assert weights.ndim == 2
+    output_dim, input_dim = weights.shape
+    assert input_dim % group_size == 0
+    group_count = input_dim // group_size
+    grouped = weights.to(torch.float32).view(output_dim, group_count, group_size)
+    min_vals = grouped.amin(dim=-1, keepdim=True)
+    max_vals = grouped.amax(dim=-1, keepdim=True)
+    scales = (max_vals - min_vals) / UINT4_MAX
+    scales = torch.where(scales == 0, torch.ones_like(scales), scales)
+    zero_points = torch.round(-min_vals / scales).clamp(0, UINT4_MAX)
+    quantized = torch.round(grouped / scales + zero_points).clamp(0, UINT4_MAX).to(torch.uint8)
+    return ConvertedLinear(
+        weights=pack_uint4(quantized.view(output_dim, input_dim)),
+        scales=scales.squeeze(-1).to(torch.bfloat16).contiguous(),
+        zero_points=pack_uint4(zero_points.to(torch.uint8).view(output_dim, group_count)),
+    )
+
+
+def requantize_mlx_uint4(weights: torch.Tensor, group_size: int) -> ConvertedEmbeddingOutput:
+    assert weights.ndim == 2
+    output_dim, input_dim = weights.shape
+    assert input_dim % group_size == 0
+    group_count = input_dim // group_size
+    grouped = weights.to(torch.float32).view(output_dim, group_count, group_size)
+    min_vals = grouped.amin(dim=-1, keepdim=True)
+    max_vals = grouped.amax(dim=-1, keepdim=True)
+    scales = (max_vals - min_vals) / UINT4_MAX
+    scales = torch.where(scales == 0, torch.ones_like(scales), scales)
+    quantized = torch.round((grouped - min_vals) / scales).clamp(0, UINT4_MAX).to(torch.uint8)
+    return ConvertedEmbeddingOutput(
+        weights=pack_uint4(quantized.view(output_dim, input_dim)),
+        scales=scales.squeeze(-1).to(torch.bfloat16).contiguous(),
+        biases=min_vals.squeeze(-1).to(torch.bfloat16).contiguous(),
+    )
+
+
+def requantize_mlx_uint2(weights: torch.Tensor, group_size: int) -> ConvertedEmbeddingOutput:
+    assert weights.ndim == 2
+    output_dim, input_dim = weights.shape
+    assert input_dim % group_size == 0
+    group_count = input_dim // group_size
+    grouped = weights.to(torch.float32).view(output_dim, group_count, group_size)
+    min_vals = grouped.amin(dim=-1, keepdim=True)
+    max_vals = grouped.amax(dim=-1, keepdim=True)
+    scales = (max_vals - min_vals) / 3.0
+    scales = torch.where(scales == 0, torch.ones_like(scales), scales)
+    quantized = torch.round((grouped - min_vals) / scales).clamp(0, 3).to(torch.uint8)
+    return ConvertedEmbeddingOutput(
+        weights=pack_uint2(quantized.view(output_dim, input_dim)),
+        scales=scales.squeeze(-1).to(torch.bfloat16).contiguous(),
+        biases=min_vals.squeeze(-1).to(torch.bfloat16).contiguous(),
+    )
+
+
+def base_weight_key_from_inner(weight_key: str) -> str:
+    assert weight_key.endswith(".inner_linear.weights")
+    return weight_key.removesuffix(".inner_linear.weights") + ".weights"
+
+
+def config_path_for_weight_key(weight_key: str) -> tuple[str, ...]:
+    parts = weight_key.split(".")
+    assert parts[:3] == ["transformer", "layers", parts[2]]
+    layer_index = parts[2]
+    if parts[3] == "mlp":
+        return ("model_config", "model_config", "transformer_config", "layer_configs", layer_index, "mlp_config", "linear_config")
+    if parts[3] == "mixer":
+        if parts[4] == "in_projection":
+            return (
+                "model_config",
+                "model_config",
+                "transformer_config",
+                "layer_configs",
+                layer_index,
+                "mixer_config",
+                "in_projection_config",
+            )
+        if parts[4] == "out_projection":
+            return (
+                "model_config",
+                "model_config",
+                "transformer_config",
+                "layer_configs",
+                layer_index,
+                "mixer_config",
+                "out_projection_config",
+            )
+        if parts[4] == "qkv_projection":
+            return (
+                "model_config",
+                "model_config",
+                "transformer_config",
+                "layer_configs",
+                layer_index,
+                "mixer_config",
+                "qkv_projection_config",
+            )
+    raise AssertionError(weight_key)
+
+
+def linear_group_size_for_weight_key(weight_key: str, settings: Settings) -> int:
+    if ".mlp." in weight_key and settings.mlp_group_size is not None:
+        return settings.mlp_group_size
+    if ".mixer." in weight_key and settings.mixer_group_size is not None:
+        return settings.mixer_group_size
+    return settings.linear_group_size
+
+
+def linear_group_size_for_config_path(path: tuple[str, ...], settings: Settings) -> int:
+    if "mlp_config" in path and settings.mlp_group_size is not None:
+        return settings.mlp_group_size
+    if "mixer_config" in path and settings.mixer_group_size is not None:
+        return settings.mixer_group_size
+    return settings.linear_group_size
+
+
+def set_config_path(root: dict[str, object], path: tuple[str, ...], value: dict[str, object]) -> None:
+    cursor: object = root
+    for part in path[:-1]:
+        cursor = cursor[int(part)] if isinstance(cursor, list) else cursor[part]
+    if isinstance(cursor, list):
+        cursor[int(path[-1])] = value
+    else:
+        cursor[path[-1]] = value
+
+
+def rewrite_rht_config(config: dict[str, object], settings: Settings) -> None:
+    def replace(node: object, path: tuple[str, ...] = ()) -> object:
+        if isinstance(node, dict):
+            if node.get("type") == "RHTLinearWrapperConfig":
+                inner = copy.deepcopy(node["inner_config"])
+                assert inner["type"] == "GroupQuantizedLinearConfig"
+                inner["group_size"] = linear_group_size_for_config_path(path, settings)
+                inner["weight_quantization_mode"] = "uint4"
+                return replace(inner, path)
+            return {key: replace(value, path + (key,)) for key, value in node.items()}
+        if isinstance(node, list):
+            return [replace(value, path + (str(index),)) for index, value in enumerate(node)]
+        return node
+
+    replaced = replace(config)
+    config.clear()
+    config.update(replaced)
+
+
+def rewrite_embedding_config(config: dict[str, object], settings: Settings) -> None:
+    embedding_config = config["model_config"]["model_config"]["embedding_config"]
+    assert embedding_config["type"] == "MLXQuantizedTiedEmbeddingConfig"
+    group_size = embedding_config["group_size"]
+    embedding_quantization_mode = embedding_config["embedding_quantization_mode"]
+    activation_precision = embedding_config["activation_precision"]
+    input_scale = embedding_config["input_scale"]
+    logit_soft_cap = embedding_config["logit_soft_cap"]
+    embedding_config.clear()
+    embedding_config.update(
+        {
+            "type": "MLXQuantizedOutputUntiedEmbeddingConfig",
+            "input_scale": input_scale,
+            "logit_soft_cap": logit_soft_cap,
+            "group_size": group_size,
+            "output_group_size": settings.lm_head_group_size,
+            "embedding_quantization_mode": embedding_quantization_mode,
+            "activation_precision": activation_precision,
+            "output_quantization_mode": settings.lm_head_mode,
+        }
+    )
+
+
+def convert_linear(source: safe_open, weight_key: str, settings: Settings) -> ConvertedLinear:
+    prefix = weight_key.removesuffix(".inner_linear.weights")
+    dense = unwrap_rht_group_uint4(
+        source.get_tensor(weight_key),
+        source.get_tensor(f"{prefix}.inner_linear.scales"),
+        source.get_tensor(f"{prefix}.inner_linear.zero_points"),
+        source.get_tensor(f"{prefix}.input_factors"),
+        source.get_tensor(f"{prefix}.output_factors"),
+    )
+    group_size = linear_group_size_for_weight_key(base_weight_key_from_inner(weight_key), settings)
+    return requantize_group_uint4(dense, group_size)
+
+
+def convert_embedding_output(source: safe_open, settings: Settings, config: dict[str, object]) -> ConvertedEmbeddingOutput:
+    embedding_config = config["model_config"]["model_config"]["embedding_config"]
+    dense = dequantize_mlx_embedding(
+        source.get_tensor("embedding.weights"),
+        source.get_tensor("embedding.scales"),
+        source.get_tensor("embedding.biases"),
+        quantization_mode=embedding_config["embedding_quantization_mode"],
+        group_size=embedding_config["group_size"],
+    )
+    if settings.lm_head_mode == "uint2":
+        return requantize_mlx_uint2(dense, settings.lm_head_group_size)
+    assert settings.lm_head_mode == "uint4"
+    return requantize_mlx_uint4(dense, settings.lm_head_group_size)
+
+
+def main() -> None:
+    settings = parse_args()
+    if settings.output_model.exists():
+        shutil.rmtree(settings.output_model)
+    shutil.copytree(settings.source_model, settings.output_model)
+
+    with open(settings.source_model / "config.json") as f:
+        config = json.load(f)
+
+    with safe_open(settings.source_model / "model.safetensors", framework="pt") as source:
+        keys = list(source.keys())
+        wrapped_weight_keys = sorted(key for key in keys if key.endswith(".inner_linear.weights"))
+        rewrite_rht_config(config, settings)
+        rewrite_embedding_config(config, settings)
+
+        converted_tensors: dict[str, torch.Tensor] = {}
+        converted_prefixes: set[str] = set()
+
+        for index, weight_key in enumerate(wrapped_weight_keys, start=1):
+            base_weight_key = base_weight_key_from_inner(weight_key)
+            print(f"[{index}/{len(wrapped_weight_keys)}] {base_weight_key}", flush=True)
+            converted = convert_linear(source, weight_key, settings)
+            base_prefix = base_weight_key.removesuffix(".weights")
+            converted_prefixes.add(base_prefix)
+            converted_tensors[f"{base_prefix}.weights"] = converted.weights
+            converted_tensors[f"{base_prefix}.scales"] = converted.scales
+            converted_tensors[f"{base_prefix}.zero_points"] = converted.zero_points
+            bias_key = f"{weight_key.removesuffix('.weights')}.biases"
+            if bias_key in keys:
+                converted_tensors[f"{base_prefix}.biases"] = source.get_tensor(bias_key)
+
+        print(f"[lm_head] {settings.lm_head_mode} gs={settings.lm_head_group_size}", flush=True)
+        converted_embedding = convert_embedding_output(source, settings, config)
+        converted_tensors["embedding.input_weights"] = source.get_tensor("embedding.weights")
+        converted_tensors["embedding.input_scales"] = source.get_tensor("embedding.scales")
+        converted_tensors["embedding.input_biases"] = source.get_tensor("embedding.biases")
+        converted_tensors["embedding.output.weights"] = converted_embedding.weights
+        converted_tensors["embedding.output.scales"] = converted_embedding.scales
+        converted_tensors["embedding.output.biases"] = converted_embedding.biases
+
+        for key in keys:
+            if ".inner_linear." in key or key.endswith(".input_factors") or key.endswith(".output_factors"):
+                continue
+            if key.startswith("embedding."):
+                continue
+            if key.rsplit(".", 1)[0] in converted_prefixes:
+                continue
+            converted_tensors[key] = source.get_tensor(key)
+
+    with open(settings.output_model / "config.json", "w") as f:
+        json.dump(config, f, indent=2)
+        f.write("\n")
+    save_file(converted_tensors, str(settings.output_model / "model.safetensors"))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rht_to_quant_model.py
+++ b/scripts/rht_to_quant_model.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import argparse
-import copy
 import json
 import shutil
 from dataclasses import dataclass
@@ -26,20 +25,6 @@ class Settings:
     mixer_group_size: int | None
     lm_head_mode: str
     lm_head_group_size: int
-
-
-@dataclass(frozen=True)
-class ConvertedLinear:
-    weights: torch.Tensor
-    scales: torch.Tensor
-    zero_points: torch.Tensor
-
-
-@dataclass(frozen=True)
-class ConvertedEmbeddingOutput:
-    weights: torch.Tensor
-    scales: torch.Tensor
-    biases: torch.Tensor
 
 
 def parse_args() -> Settings:
@@ -145,16 +130,6 @@ def hadamard_blocks_last_dim(values: torch.Tensor, block_size: int) -> torch.Ten
     return result.reshape(original_shape) / (block_size**0.5)
 
 
-def apply_input_inverse(weights: torch.Tensor, input_factors: torch.Tensor) -> torch.Tensor:
-    return hadamard_blocks_last_dim(weights, RHT_BLOCK_SIZE) * input_factors.to(torch.float32)
-
-
-def apply_output_rotate(weights: torch.Tensor, output_factors: torch.Tensor) -> torch.Tensor:
-    transposed = weights.transpose(0, 1)
-    rotated = hadamard_blocks_last_dim(transposed * output_factors.to(torch.float32), RHT_BLOCK_SIZE)
-    return rotated.transpose(0, 1).contiguous()
-
-
 def unwrap_rht_group_uint4(
     packed_weights: torch.Tensor,
     scales: torch.Tensor,
@@ -162,11 +137,14 @@ def unwrap_rht_group_uint4(
     input_factors: torch.Tensor,
     output_factors: torch.Tensor,
 ) -> torch.Tensor:
-    dequantized = dequantize_group_uint4(packed_weights, scales, packed_zero_points, RHT_GROUP_SIZE)
-    return apply_output_rotate(apply_input_inverse(dequantized, input_factors), output_factors).contiguous()
+    weights = dequantize_group_uint4(packed_weights, scales, packed_zero_points, RHT_GROUP_SIZE)
+    weights = hadamard_blocks_last_dim(weights, RHT_BLOCK_SIZE) * input_factors.to(torch.float32)
+    weights = weights.transpose(0, 1)
+    weights = hadamard_blocks_last_dim(weights * output_factors.to(torch.float32), RHT_BLOCK_SIZE)
+    return weights.transpose(0, 1).contiguous()
 
 
-def requantize_group_uint4(weights: torch.Tensor, group_size: int) -> ConvertedLinear:
+def requantize_group_uint4(weights: torch.Tensor, group_size: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     assert weights.ndim == 2
     output_dim, input_dim = weights.shape
     assert input_dim % group_size == 0
@@ -178,14 +156,14 @@ def requantize_group_uint4(weights: torch.Tensor, group_size: int) -> ConvertedL
     scales = torch.where(scales == 0, torch.ones_like(scales), scales)
     zero_points = torch.round(-min_vals / scales).clamp(0, UINT4_MAX)
     quantized = torch.round(grouped / scales + zero_points).clamp(0, UINT4_MAX).to(torch.uint8)
-    return ConvertedLinear(
-        weights=pack_uint4(quantized.view(output_dim, input_dim)),
-        scales=scales.squeeze(-1).to(torch.bfloat16).contiguous(),
-        zero_points=pack_uint4(zero_points.to(torch.uint8).view(output_dim, group_count)),
+    return (
+        pack_uint4(quantized.view(output_dim, input_dim)),
+        scales.squeeze(-1).to(torch.bfloat16).contiguous(),
+        pack_uint4(zero_points.to(torch.uint8).view(output_dim, group_count)),
     )
 
 
-def requantize_mlx_uint4(weights: torch.Tensor, group_size: int) -> ConvertedEmbeddingOutput:
+def requantize_mlx_uint4(weights: torch.Tensor, group_size: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     assert weights.ndim == 2
     output_dim, input_dim = weights.shape
     assert input_dim % group_size == 0
@@ -196,14 +174,14 @@ def requantize_mlx_uint4(weights: torch.Tensor, group_size: int) -> ConvertedEmb
     scales = (max_vals - min_vals) / UINT4_MAX
     scales = torch.where(scales == 0, torch.ones_like(scales), scales)
     quantized = torch.round((grouped - min_vals) / scales).clamp(0, UINT4_MAX).to(torch.uint8)
-    return ConvertedEmbeddingOutput(
-        weights=pack_uint4(quantized.view(output_dim, input_dim)),
-        scales=scales.squeeze(-1).to(torch.bfloat16).contiguous(),
-        biases=min_vals.squeeze(-1).to(torch.bfloat16).contiguous(),
+    return (
+        pack_uint4(quantized.view(output_dim, input_dim)),
+        scales.squeeze(-1).to(torch.bfloat16).contiguous(),
+        min_vals.squeeze(-1).to(torch.bfloat16).contiguous(),
     )
 
 
-def requantize_mlx_uint2(weights: torch.Tensor, group_size: int) -> ConvertedEmbeddingOutput:
+def requantize_mlx_uint2(weights: torch.Tensor, group_size: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     assert weights.ndim == 2
     output_dim, input_dim = weights.shape
     assert input_dim % group_size == 0
@@ -214,30 +192,17 @@ def requantize_mlx_uint2(weights: torch.Tensor, group_size: int) -> ConvertedEmb
     scales = (max_vals - min_vals) / 3.0
     scales = torch.where(scales == 0, torch.ones_like(scales), scales)
     quantized = torch.round((grouped - min_vals) / scales).clamp(0, 3).to(torch.uint8)
-    return ConvertedEmbeddingOutput(
-        weights=pack_uint2(quantized.view(output_dim, input_dim)),
-        scales=scales.squeeze(-1).to(torch.bfloat16).contiguous(),
-        biases=min_vals.squeeze(-1).to(torch.bfloat16).contiguous(),
+    return (
+        pack_uint2(quantized.view(output_dim, input_dim)),
+        scales.squeeze(-1).to(torch.bfloat16).contiguous(),
+        min_vals.squeeze(-1).to(torch.bfloat16).contiguous(),
     )
 
 
-def base_weight_key_from_inner(weight_key: str) -> str:
-    assert weight_key.endswith(".inner_linear.weights")
-    return weight_key.removesuffix(".inner_linear.weights") + ".weights"
-
-
-def linear_group_size_for_weight_key(weight_key: str, settings: Settings) -> int:
-    if ".mlp." in weight_key and settings.mlp_group_size is not None:
+def linear_group_size(settings: Settings, *, is_mlp: bool, is_mixer: bool) -> int:
+    if is_mlp and settings.mlp_group_size is not None:
         return settings.mlp_group_size
-    if ".mixer." in weight_key and settings.mixer_group_size is not None:
-        return settings.mixer_group_size
-    return settings.linear_group_size
-
-
-def linear_group_size_for_config_path(path: tuple[str, ...], settings: Settings) -> int:
-    if "mlp_config" in path and settings.mlp_group_size is not None:
-        return settings.mlp_group_size
-    if "mixer_config" in path and settings.mixer_group_size is not None:
+    if is_mixer and settings.mixer_group_size is not None:
         return settings.mixer_group_size
     return settings.linear_group_size
 
@@ -246,17 +211,23 @@ def rewrite_rht_config(config: dict[str, object], settings: Settings) -> None:
     def replace(node: object, path: tuple[str, ...] = ()) -> object:
         if isinstance(node, dict):
             if node.get("type") == "RHTLinearWrapperConfig":
-                inner = copy.deepcopy(node["inner_config"])
+                inner = replace(node["inner_config"], path)
+                assert isinstance(inner, dict)
                 assert inner["type"] == "GroupQuantizedLinearConfig"
-                inner["group_size"] = linear_group_size_for_config_path(path, settings)
+                inner["group_size"] = linear_group_size(
+                    settings,
+                    is_mlp="mlp_config" in path,
+                    is_mixer="mixer_config" in path,
+                )
                 inner["weight_quantization_mode"] = "uint4"
-                return replace(inner, path)
+                return inner
             return {key: replace(value, path + (key,)) for key, value in node.items()}
         if isinstance(node, list):
             return [replace(value, path + (str(index),)) for index, value in enumerate(node)]
         return node
 
     replaced = replace(config)
+    assert isinstance(replaced, dict)
     config.clear()
     config.update(replaced)
 
@@ -278,20 +249,29 @@ def rewrite_embedding_config(config: dict[str, object], settings: Settings) -> N
     embedding_config.update(rewritten_embedding_config)
 
 
-def convert_linear(source: safe_open, weight_key: str, settings: Settings) -> ConvertedLinear:
-    prefix = weight_key.removesuffix(".inner_linear.weights")
+def convert_linear(source: safe_open, weight_key: str, settings: Settings) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    assert weight_key.endswith(".inner_linear.weights")
+    base_prefix = weight_key.removesuffix(".inner_linear.weights")
     dense = unwrap_rht_group_uint4(
         source.get_tensor(weight_key),
-        source.get_tensor(f"{prefix}.inner_linear.scales"),
-        source.get_tensor(f"{prefix}.inner_linear.zero_points"),
-        source.get_tensor(f"{prefix}.input_factors"),
-        source.get_tensor(f"{prefix}.output_factors"),
+        source.get_tensor(f"{base_prefix}.inner_linear.scales"),
+        source.get_tensor(f"{base_prefix}.inner_linear.zero_points"),
+        source.get_tensor(f"{base_prefix}.input_factors"),
+        source.get_tensor(f"{base_prefix}.output_factors"),
     )
-    group_size = linear_group_size_for_weight_key(base_weight_key_from_inner(weight_key), settings)
+    group_size = linear_group_size(
+        settings,
+        is_mlp=".mlp." in weight_key,
+        is_mixer=".mixer." in weight_key,
+    )
     return requantize_group_uint4(dense, group_size)
 
 
-def convert_embedding_output(source: safe_open, settings: Settings, config: dict[str, object]) -> ConvertedEmbeddingOutput:
+def convert_embedding_output(
+    source: safe_open,
+    settings: Settings,
+    config: dict[str, object],
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     embedding_config = config["model_config"]["model_config"]["embedding_config"]
     dense = dequantize_mlx_embedding(
         source.get_tensor("embedding.weights"),
@@ -325,26 +305,26 @@ def main() -> None:
         converted_prefixes: set[str] = set()
 
         for index, weight_key in enumerate(wrapped_weight_keys, start=1):
-            base_weight_key = base_weight_key_from_inner(weight_key)
-            print(f"[{index}/{len(wrapped_weight_keys)}] {base_weight_key}", flush=True)
-            converted = convert_linear(source, weight_key, settings)
-            base_prefix = base_weight_key.removesuffix(".weights")
+            assert weight_key.endswith(".inner_linear.weights")
+            base_prefix = weight_key.removesuffix(".inner_linear.weights")
+            print(f"[{index}/{len(wrapped_weight_keys)}] {base_prefix}.weights", flush=True)
+            converted_weights, converted_scales, converted_zero_points = convert_linear(source, weight_key, settings)
             converted_prefixes.add(base_prefix)
-            converted_tensors[f"{base_prefix}.weights"] = converted.weights
-            converted_tensors[f"{base_prefix}.scales"] = converted.scales
-            converted_tensors[f"{base_prefix}.zero_points"] = converted.zero_points
-            bias_key = f"{weight_key.removesuffix('.weights')}.biases"
+            converted_tensors[f"{base_prefix}.weights"] = converted_weights
+            converted_tensors[f"{base_prefix}.scales"] = converted_scales
+            converted_tensors[f"{base_prefix}.zero_points"] = converted_zero_points
+            bias_key = f"{base_prefix}.inner_linear.biases"
             if bias_key in keys:
                 converted_tensors[f"{base_prefix}.biases"] = source.get_tensor(bias_key)
 
         print(f"[lm_head] {settings.lm_head_mode} gs={settings.lm_head_group_size}", flush=True)
-        converted_embedding = convert_embedding_output(source, settings, config)
+        output_weights, output_scales, output_biases = convert_embedding_output(source, settings, config)
         converted_tensors["embedding.input_weights"] = source.get_tensor("embedding.weights")
         converted_tensors["embedding.input_scales"] = source.get_tensor("embedding.scales")
         converted_tensors["embedding.input_biases"] = source.get_tensor("embedding.biases")
-        converted_tensors["embedding.output.weights"] = converted_embedding.weights
-        converted_tensors["embedding.output.scales"] = converted_embedding.scales
-        converted_tensors["embedding.output.biases"] = converted_embedding.biases
+        converted_tensors["embedding.output.weights"] = output_weights
+        converted_tensors["embedding.output.scales"] = output_scales
+        converted_tensors["embedding.output.biases"] = output_biases
 
         for key in keys:
             if ".inner_linear." in key or key.endswith(".input_factors") or key.endswith(".output_factors"):


### PR DESCRIPTION
## Summary

This packages the dewrapped RHT conversion/readout path that survived the throughput search.

Final packaged paths:

- winner: `mlp256 + mixer64 + lm_head uint2 gs512`
- fallback: `mlp256 + mixer64 + lm_head uint4 gs512`

This branch adds the minimal runtime/config changes plus a small conversion script to generate those models from the existing RHT checkpoint.

## What changed

- added `uint2` quantization mode support for the quantized matmul path
- added `MLXQuantizedOutputUntiedEmbeddingConfig`
- added untied quantized output-head loading under `embedding.output.*`
- added `scripts/rht_to_quant_model.py` to:
  - unwrap RHT linears
  - requantize body linears to group-uint4 with subtree-specific group sizes
  - emit untied `lm_head` as either MLX `uint2` or MLX `uint4`

## Throughput result that survived

Best production-credible path:

- body `mlp256 + mixer64`
- `lm_head` raw MLX `uint2 gs512`

Matched results from the research run:

- fixed-length 64-token no-stop:
  - `u4 gs512`: `395.07 t/s`
  - `u2 gs512`: `412.61 t/s`
  - delta: `+4.44%`
- sampled benchmark:
  - `u4 gs512`: `362.79 t/s`
  - `u2 gs512`: `378.23 t/s`
  - delta: `+4.25%`

Safer fallback:

- body `mlp256 + mixer64`
- `lm_head uint4 gs512`

## ASTC: where it won and where it failed

ASTC showed an apparent win early, but only against the older tied `uint8` output path.

Early ASTC-vs-old-path numbers:

- `4x4`: `+6.16%`
- `5x5`: `+7.46%`
- `6x6`: `+7.48%`

That did not survive matched reruns against the dewrapped packed-quant baselines.

Once compared apples-to-apples against matched packed quant paths, ASTC lost. The hot-loop reason was consistent with the code shape:

- ASTC path paid texture fetch + inner-loop reduction work in `crates/uzu/src/backends/metal/kernel/astc_linear.metal:119`
- packed quant stayed on the tuned buffer-streaming path in `crates/uzu/src/backends/metal/kernel/quant_matmul/quant_matmul.metal:1435`

ASTC is therefore not in the final packaged implementation.

## Dead branches not shipped

- ASTC readout
- codebook2 readout
- raw body `u2`
- prefix-mixed readout
- correction/sparse correction paths
- zero-point/symmetric side paths

## Validation

- the new conversion script reproduces the benchmarked winner and fallback models exactly
- workspace test execution is currently blocked by the existing `xgrammar-rs` `_CharT` generation failure before `uzu` tests complete
