### PR TITLE
KV cache blit copy

### DIFF
--- a/crates/backend-uzu/src/backends/common/buffer.rs
+++ b/crates/backend-uzu/src/backends/common/buffer.rs
@@ -1,8 +1,8 @@
-use std::{fmt::Debug, ops::Range};
+use std::{any::Any, fmt::Debug, ops::Range};
 
 use crate::backends::common::Backend;
 
-pub trait Buffer: Debug {
+pub trait Buffer: Any + Debug {
     type Backend: Backend;
 
     fn gpu_ptr(&self) -> usize;

--- a/crates/backend-uzu/src/backends/common/command_buffer.rs
+++ b/crates/backend-uzu/src/backends/common/command_buffer.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use super::{Backend, BufferRangeMut, BufferRangeRef};
+use super::{Backend, Buffer, BufferRangeMut, BufferRangeRef};
 
 pub trait CommandBuffer {
     type Backend: Backend<CommandBuffer = Self>;
@@ -70,11 +70,13 @@ impl AccessFlags {
 pub trait CommandBufferEncoding {
     type CommandBuffer: CommandBuffer<Encoding = Self>;
 
-    fn encode_copy(
+    fn encode_copy<Src, Dst>(
         &mut self,
-        src: BufferRangeRef<'_, <<Self::CommandBuffer as CommandBuffer>::Backend as Backend>::DenseBuffer>,
-        dst: BufferRangeMut<'_, <<Self::CommandBuffer as CommandBuffer>::Backend as Backend>::DenseBuffer>,
-    );
+        src: BufferRangeRef<'_, Src>,
+        dst: BufferRangeMut<'_, Dst>,
+    ) where
+        Src: Buffer<Backend = <Self::CommandBuffer as CommandBuffer>::Backend>,
+        Dst: Buffer<Backend = <Self::CommandBuffer as CommandBuffer>::Backend>;
 
     fn encode_fill(
         &mut self,

--- a/crates/backend-uzu/src/backends/cpu/buffer.rs
+++ b/crates/backend-uzu/src/backends/cpu/buffer.rs
@@ -10,6 +10,6 @@ pub(super) fn cpu_buffer<B: Buffer<Backend = Cpu>>(buffer: &B) -> &UnsafeCell<Pi
     if let Some(buf) = buffer.downcast_ref::<<Cpu as Backend>::DenseBuffer>() {
         buf
     } else {
-        unreachable!("unsupported Metal buffer type")
+        unreachable!("Unsupported Cpu buffer type")
     }
 }

--- a/crates/backend-uzu/src/backends/cpu/buffer.rs
+++ b/crates/backend-uzu/src/backends/cpu/buffer.rs
@@ -1,0 +1,15 @@
+use std::{any::Any, cell::UnsafeCell, pin::Pin};
+
+use crate::backends::{
+    common::{Backend, Buffer},
+    cpu::Cpu,
+};
+
+pub(super) fn cpu_buffer<B: Buffer<Backend = Cpu>>(buffer: &B) -> &UnsafeCell<Pin<Box<[u8]>>> {
+    let buffer = buffer as &dyn Any;
+    if let Some(buf) = buffer.downcast_ref::<<Cpu as Backend>::DenseBuffer>() {
+        buf
+    } else {
+        unreachable!("unsupported Metal buffer type")
+    }
+}

--- a/crates/backend-uzu/src/backends/cpu/command_buffer.rs
+++ b/crates/backend-uzu/src/backends/cpu/command_buffer.rs
@@ -11,10 +11,10 @@ use std::{
 use crate::{
     backends::{
         common::{
-            AccessFlags, Backend, BufferRangeMut, BufferRangeRef, CommandBuffer, CommandBufferCompleted,
+            AccessFlags, Backend, Buffer, BufferRangeMut, BufferRangeRef, CommandBuffer, CommandBufferCompleted,
             CommandBufferEncoding, CommandBufferExecutable, CommandBufferInitial, CommandBufferPending,
         },
-        cpu::{Cpu, error::CpuError},
+        cpu::{Cpu, buffer::cpu_buffer, error::CpuError},
     },
     utils::pointers::{SendPtr, SendPtrMut},
 };
@@ -73,20 +73,24 @@ impl CpuCommandBufferEncoding {
 impl CommandBufferEncoding for CpuCommandBufferEncoding {
     type CommandBuffer = CpuCommandBuffer;
 
-    fn encode_copy(
+    fn encode_copy<Src, Dst>(
         &mut self,
-        src: BufferRangeRef<'_, <Cpu as Backend>::DenseBuffer>,
-        dst: BufferRangeMut<'_, <Cpu as Backend>::DenseBuffer>,
-    ) {
+        src: BufferRangeRef<'_, Src>,
+        dst: BufferRangeMut<'_, Dst>,
+    ) where
+        Src: Buffer<Backend = Cpu>,
+        Dst: Buffer<Backend = Cpu>,
+    {
         let src_range = src.range();
         let dst_range = dst.range();
-        let size = src_range.end - src_range.start;
-        assert_eq!(size, dst_range.end - dst_range.start);
+        assert_eq!(src_range.len(), dst_range.len());
 
-        let src_ptr = SendPtr(unsafe { (&*src.buffer().get()).as_ptr().add(src_range.start) });
-        let dst_ptr = SendPtrMut(unsafe { (&mut *dst.buffer().get()).as_mut_ptr().add(dst_range.start) });
+        let src_buffer = cpu_buffer(src.buffer());
+        let dst_buffer = cpu_buffer(dst.buffer());
+        let src_ptr = SendPtr(unsafe { (&*src_buffer.get()).as_ptr().add(src_range.start) });
+        let dst_ptr = SendPtrMut(unsafe { (&mut *dst_buffer.get()).as_mut_ptr().add(dst_range.start) });
         self.push_command(move || unsafe {
-            std::ptr::copy(src_ptr.as_ptr(), dst_ptr.as_ptr(), size);
+            std::ptr::copy(src_ptr.as_ptr(), dst_ptr.as_ptr(), src_range.len());
         });
     }
 

--- a/crates/backend-uzu/src/backends/cpu/mod.rs
+++ b/crates/backend-uzu/src/backends/cpu/mod.rs
@@ -8,5 +8,6 @@ mod kernel;
 mod sparse;
 
 pub mod argmax;
+mod buffer;
 
 pub use backend::Cpu;

--- a/crates/backend-uzu/src/backends/cpu/mod.rs
+++ b/crates/backend-uzu/src/backends/cpu/mod.rs
@@ -1,4 +1,5 @@
 mod backend;
+mod buffer;
 mod command_buffer;
 mod context;
 mod dense_buffer;
@@ -8,6 +9,5 @@ mod kernel;
 mod sparse;
 
 pub mod argmax;
-mod buffer;
 
 pub use backend::Cpu;

--- a/crates/backend-uzu/src/backends/metal/buffer.rs
+++ b/crates/backend-uzu/src/backends/metal/buffer.rs
@@ -15,6 +15,6 @@ pub(super) fn metal_buffer<B: Buffer<Backend = Metal>>(buffer: &B) -> &Retained<
     } else if let Some(buffer) = buffer.downcast_ref::<MetalSparseBuffer>() {
         buffer.mtl_buffer()
     } else {
-        unreachable!("unsupported Metal buffer type")
+        unreachable!("Unsupported Metal buffer type")
     }
 }

--- a/crates/backend-uzu/src/backends/metal/buffer.rs
+++ b/crates/backend-uzu/src/backends/metal/buffer.rs
@@ -1,0 +1,20 @@
+use std::any::Any;
+
+use metal::MTLBuffer;
+use objc2::{rc::Retained, runtime::ProtocolObject};
+
+use crate::backends::{
+    common::{Backend, Buffer},
+    metal::{Metal, sparse::MetalSparseBuffer},
+};
+
+pub(super) fn metal_buffer<B: Buffer<Backend = Metal>>(buffer: &B) -> &Retained<ProtocolObject<dyn MTLBuffer>> {
+    let buffer = buffer as &dyn Any;
+    if let Some(buffer) = buffer.downcast_ref::<<Metal as Backend>::DenseBuffer>() {
+        buffer
+    } else if let Some(buffer) = buffer.downcast_ref::<MetalSparseBuffer>() {
+        buffer.mtl_buffer()
+    } else {
+        unreachable!("unsupported Metal buffer type")
+    }
+}

--- a/crates/backend-uzu/src/backends/metal/command_buffer.rs
+++ b/crates/backend-uzu/src/backends/metal/command_buffer.rs
@@ -9,10 +9,10 @@ use objc2::{Message, rc::Retained, runtime::ProtocolObject};
 use super::Metal;
 use crate::backends::{
     common::{
-        AccessFlags, Backend, BufferRangeMut, BufferRangeRef, CommandBuffer, CommandBufferCompleted,
+        AccessFlags, Backend, Buffer, BufferRangeMut, BufferRangeRef, CommandBuffer, CommandBufferCompleted,
         CommandBufferEncoding, CommandBufferExecutable, CommandBufferInitial, CommandBufferPending,
     },
-    metal::error::MetalError,
+    metal::{buffer::metal_buffer, error::MetalError},
 };
 
 pub struct MetalCommandBuffer;
@@ -118,17 +118,27 @@ impl Drop for MetalCommandBufferEncoding {
 impl CommandBufferEncoding for MetalCommandBufferEncoding {
     type CommandBuffer = MetalCommandBuffer;
 
-    fn encode_copy(
+    fn encode_copy<Src, Dst>(
         &mut self,
-        src: BufferRangeRef<'_, <Metal as Backend>::DenseBuffer>,
-        dst: BufferRangeMut<'_, <Metal as Backend>::DenseBuffer>,
-    ) {
+        src: BufferRangeRef<'_, Src>,
+        dst: BufferRangeMut<'_, Dst>,
+    ) where
+        Src: Buffer<Backend = Metal>,
+        Dst: Buffer<Backend = Metal>,
+    {
         let src_range = src.range();
         let dst_range = dst.range();
-        let size = src_range.end - src_range.start;
-        assert_eq!(size, dst_range.end - dst_range.start);
+        assert_eq!(src_range.len(), dst_range.len());
 
-        self.ensure_blit().copy_buffer_to_buffer(src.buffer(), src_range.start, dst.buffer(), dst_range.start, size);
+        let src_mtl_buffer = metal_buffer(src.buffer());
+        let dst_mtl_buffer = metal_buffer(dst.buffer());
+        self.ensure_blit().copy_buffer_to_buffer(
+            src_mtl_buffer,
+            src_range.start,
+            dst_mtl_buffer,
+            dst_range.start,
+            src_range.len(),
+        );
     }
 
     fn encode_fill(

--- a/crates/backend-uzu/src/backends/metal/mod.rs
+++ b/crates/backend-uzu/src/backends/metal/mod.rs
@@ -1,4 +1,5 @@
 mod backend;
+mod buffer;
 mod command_buffer;
 mod context;
 mod dense_buffer;

--- a/crates/backend-uzu/src/backends/metal/sparse/sparse_buffer.rs
+++ b/crates/backend-uzu/src/backends/metal/sparse/sparse_buffer.rs
@@ -45,6 +45,10 @@ impl MetalSparseBuffer {
             context,
         })
     }
+
+    pub(crate) fn mtl_buffer(&self) -> &Retained<ProtocolObject<dyn MTLBuffer>> {
+        &self.buffer
+    }
 }
 
 impl Debug for MetalSparseBuffer {

--- a/crates/backend-uzu/src/forward_pass/cache_layers.rs
+++ b/crates/backend-uzu/src/forward_pass/cache_layers.rs
@@ -330,10 +330,14 @@ impl<B: Backend> CacheLayers<B> {
         range: std::ops::Range<usize>,
     ) -> Option<CacheLayersSlice<B>> {
         let mut layers = Vec::with_capacity(self.data.len());
+        let mut encoder: Option<Encoder<B>> = None;
+
         for layer in self.data.iter() {
             match layer {
                 CacheLayer::Transformer(kv) => {
-                    let Some(slice) = kv.slice(context, range.clone()) else {
+                    let mut encoder =
+                        encoder.get_or_insert_with(|| Encoder::new(context).expect("Failed to create Encoder"));
+                    let Some(slice) = kv.slice(context, &mut encoder, range.clone()) else {
                         return None;
                     };
                     layers.push(CacheLayerSlice::Transformer(slice));
@@ -342,6 +346,10 @@ impl<B: Backend> CacheLayers<B> {
                 CacheLayer::ShortConv(_) => layers.push(CacheLayerSlice::ShortConv),
                 CacheLayer::DeltaNet(_) => layers.push(CacheLayerSlice::DeltaNet),
             }
+        }
+
+        if let Some(encoder) = encoder {
+            encoder.end_encoding().submit().wait_until_completed().expect("Failed to end and wait encoder");
         }
 
         Some(CacheLayersSlice {
@@ -355,15 +363,23 @@ impl<B: Backend> CacheLayers<B> {
         slice: &CacheLayersSlice<B>,
         range: Option<std::ops::Range<usize>>,
     ) {
+        let mut encoder: Option<Encoder<B>> = None;
+
         for (layer, snapshot) in self.data.iter_mut().zip(slice.layers.iter()) {
             match (layer, snapshot) {
                 (CacheLayer::Transformer(kv), CacheLayerSlice::Transformer(s)) => {
-                    kv.apply_slice(context, &s, range.clone());
+                    let mut encoder =
+                        encoder.get_or_insert_with(|| Encoder::new(context).expect("Failed to create Encoder"));
+                    kv.apply_slice(&mut encoder, &s, range.clone());
                 },
                 (CacheLayer::StateSpace(_), CacheLayerSlice::StateSpace) => {},
                 (CacheLayer::ShortConv(_), CacheLayerSlice::ShortConv) => {},
                 _ => {},
             }
+        }
+
+        if let Some(encoder) = encoder {
+            encoder.end_encoding().submit().wait_until_completed().expect("Failed to end and wait encoder");
         }
     }
 
@@ -386,13 +402,22 @@ impl<B: Backend> CacheLayers<B> {
     ) {
         assert_eq!(source.data.len(), self.data.len(), "cache layer count mismatch");
 
+        // Key/value arrays stay alive until after encoder.submit().wait_until_completed() returns, then explicitly drops them.
+        // This prevents the slice buffers from being freed while the GPU is still reading from them during windowed cache cloning.
+        let mut pending_slices: Vec<KVSlice<B>> = Vec::new();
+        let mut encoder: Option<Encoder<B>> = None;
+
         for (source_layer, destination_layer) in source.data.iter().zip(self.data.iter_mut()) {
             match (source_layer, destination_layer) {
                 (CacheLayer::Transformer(source), CacheLayer::Transformer(destination)) => {
                     let copy_rows = source.prefix_segment_length();
                     if copy_rows > 0 && matches!(source.state, KVCacheLayerState::Windowed { .. }) {
-                        let slice = source.slice(context, 0..copy_rows).expect("Failed to slice KV cache layer");
-                        destination.apply_slice(context, &slice, None);
+                        let encoder =
+                            encoder.get_or_insert_with(|| Encoder::new(context).expect("Failed to create Encoder"));
+                        let slice =
+                            source.slice(context, encoder, 0..copy_rows).expect("Failed to slice KV cache layer");
+                        destination.apply_slice(encoder, &slice, None);
+                        pending_slices.push(slice);
                     }
                     destination.state = source.state.clone();
                 },
@@ -404,6 +429,11 @@ impl<B: Backend> CacheLayers<B> {
                 _ => panic!("cache layer type mismatch while copying cache layers"),
             }
         }
+
+        if let Some(encoder) = encoder {
+            encoder.end_encoding().submit().wait_until_completed().expect("Failed to end and wait encoder");
+        }
+        drop(pending_slices);
     }
 
     fn encode_copy_data_from(

--- a/crates/backend-uzu/src/forward_pass/cache_layers.rs
+++ b/crates/backend-uzu/src/forward_pass/cache_layers.rs
@@ -351,13 +351,14 @@ impl<B: Backend> CacheLayers<B> {
 
     pub fn apply_slice(
         &mut self,
+        context: &B::Context,
         slice: &CacheLayersSlice<B>,
         range: Option<std::ops::Range<usize>>,
     ) {
         for (layer, snapshot) in self.data.iter_mut().zip(slice.layers.iter()) {
             match (layer, snapshot) {
                 (CacheLayer::Transformer(kv), CacheLayerSlice::Transformer(s)) => {
-                    kv.apply_slice(&s, range.clone());
+                    kv.apply_slice(context, &s, range.clone());
                 },
                 (CacheLayer::StateSpace(_), CacheLayerSlice::StateSpace) => {},
                 (CacheLayer::ShortConv(_), CacheLayerSlice::ShortConv) => {},
@@ -391,7 +392,7 @@ impl<B: Backend> CacheLayers<B> {
                     let copy_rows = source.prefix_segment_length();
                     if copy_rows > 0 && matches!(source.state, KVCacheLayerState::Windowed { .. }) {
                         let slice = source.slice(context, 0..copy_rows).expect("Failed to slice KV cache layer");
-                        destination.apply_slice(&slice, None);
+                        destination.apply_slice(context, &slice, None);
                     }
                     destination.state = source.state.clone();
                 },

--- a/crates/backend-uzu/src/forward_pass/kv_cache_layer.rs
+++ b/crates/backend-uzu/src/forward_pass/kv_cache_layer.rs
@@ -1,8 +1,10 @@
+use std::ops::Range;
+
 use crate::{
     DataType,
     array::{Array, ArrayContextExt, size_for_shape},
     backends::common::{
-        Allocation, Backend, Encoder, allocation_as_bytes, allocation_as_bytes_mut,
+        Allocation, Backend, Encoder,
         kernel::kv_cache_update::{KVCacheUpdate, KVLayerData},
     },
 };
@@ -47,24 +49,6 @@ pub struct KVCacheLayer<B: Backend> {
     pub values: Allocation<B>,
     pub shape: [usize; 3],
     pub data_type: DataType,
-}
-
-fn copy_rows(
-    source_keys_bytes: &[u8],
-    source_values_bytes: &[u8],
-    destination_keys_bytes: &mut [u8],
-    destination_values_bytes: &mut [u8],
-    row_size: usize,
-    row_pairs: impl IntoIterator<Item = (usize, usize)>,
-) {
-    for (source_row, destination_row) in row_pairs {
-        let source_offset = source_row * row_size;
-        let destination_offset = destination_row * row_size;
-        destination_keys_bytes[destination_offset..destination_offset + row_size]
-            .copy_from_slice(&source_keys_bytes[source_offset..source_offset + row_size]);
-        destination_values_bytes[destination_offset..destination_offset + row_size]
-            .copy_from_slice(&source_values_bytes[source_offset..source_offset + row_size]);
-    }
 }
 
 impl<B: Backend> KVCacheLayer<B> {
@@ -214,7 +198,7 @@ impl<B: Backend> KVCacheLayer<B> {
     pub fn slice(
         &self,
         context: &B::Context,
-        range: std::ops::Range<usize>,
+        range: Range<usize>,
     ) -> Option<KVSlice<B>> {
         match self.state {
             KVCacheLayerState::Full {
@@ -235,12 +219,6 @@ impl<B: Backend> KVCacheLayer<B> {
                 let dtype = self.data_type;
                 let row_size = size_for_shape(&[1, num_groups, head_dim], dtype);
 
-                let slice_shape = [len, num_groups, head_dim];
-                let mut slice_keys = context.create_array_uninitialized(&slice_shape, dtype);
-                let mut slice_values = context.create_array_uninitialized(&slice_shape, dtype);
-                let source_keys_bytes = allocation_as_bytes(&self.keys);
-                let source_values_bytes = allocation_as_bytes(&self.values);
-
                 let slots: Vec<usize> = (range.start..range.end)
                     .enumerate()
                     .map(|(offset, _)| {
@@ -252,17 +230,19 @@ impl<B: Backend> KVCacheLayer<B> {
                         }
                     })
                     .collect();
+                let row_pairs = slots.iter().enumerate().map(|(dst_row, &src_row)| (src_row, dst_row));
 
-                let destination_keys_bytes = slice_keys.as_bytes_mut();
-                let destination_values_bytes = slice_values.as_bytes_mut();
-
-                copy_rows(
-                    source_keys_bytes,
-                    source_values_bytes,
-                    destination_keys_bytes,
-                    destination_values_bytes,
+                let slice_shape = [len, num_groups, head_dim];
+                let mut dst_keys = context.create_array_uninitialized(&slice_shape, dtype);
+                let mut dst_values = context.create_array_uninitialized(&slice_shape, dtype);
+                Self::copy_rows(
+                    context,
+                    &self.keys,
+                    dst_keys.allocation_mut(),
+                    &self.values,
+                    dst_values.allocation_mut(),
                     row_size,
-                    slots.iter().enumerate().map(|(destination_row, &source_row)| (source_row, destination_row)),
+                    row_pairs,
                 );
 
                 Some(KVSlice::Window {
@@ -270,8 +250,8 @@ impl<B: Backend> KVCacheLayer<B> {
                     base_ring_offset: ring_offset,
                     base_ring_length: ring_length,
                     slots,
-                    keys: slice_keys,
-                    values: slice_values,
+                    keys: dst_keys,
+                    values: dst_values,
                 })
             },
         }
@@ -279,8 +259,9 @@ impl<B: Backend> KVCacheLayer<B> {
 
     pub fn apply_slice(
         &mut self,
+        context: &B::Context,
         slice: &KVSlice<B>,
-        range: Option<std::ops::Range<usize>>,
+        range: Option<Range<usize>>,
     ) {
         match (slice, &mut self.state) {
             (
@@ -316,68 +297,89 @@ impl<B: Backend> KVCacheLayer<B> {
                 *w_len = *window_length;
                 let [_, num_groups, head_dim] = self.shape;
                 let row_size = size_for_shape(&[1, num_groups, head_dim], self.data_type);
-                let source_keys_bytes = keys.as_bytes();
-                let source_values_bytes = values.as_bytes();
-                let destination_keys_bytes = allocation_as_bytes_mut(&mut self.keys);
-                let destination_values_bytes = allocation_as_bytes_mut(&mut self.values);
-                match range {
+
+                let row_pairs: Option<Box<dyn Iterator<Item = (usize, usize)>>> = match range {
                     None => {
                         *ring_offset = *base_ring_offset;
                         *ring_length = *base_ring_length;
-
-                        copy_rows(
-                            source_keys_bytes,
-                            source_values_bytes,
-                            destination_keys_bytes,
-                            destination_values_bytes,
-                            row_size,
-                            slots
-                                .iter()
-                                .enumerate()
-                                .map(|(source_row, &destination_row)| (source_row, destination_row)),
-                        );
+                        let pairs = slots.iter().enumerate().map(|(src_row, &dst_row)| (src_row, dst_row));
+                        Some(Box::new(pairs))
                     },
                     Some(r) => {
                         let len = r.end.saturating_sub(r.start);
                         if len == 0 {
-                            return;
-                        }
-
-                        let accepted = r.start;
-                        let base_len = *base_ring_length;
-                        let w = *window_length;
-
-                        let (new_offset, new_len) = if base_len < w {
-                            let after = base_len.saturating_add(accepted);
-                            if after <= w {
-                                (*base_ring_offset, after)
-                            } else {
-                                let overflow = after - w;
-                                ((base_ring_offset + overflow) % w, w)
-                            }
+                            None
                         } else {
-                            ((base_ring_offset + accepted) % w, w)
-                        };
+                            let accepted = r.start;
+                            let base_len = *base_ring_length;
+                            let w = *window_length;
 
-                        *ring_offset = new_offset;
-                        *ring_length = new_len;
+                            let (new_offset, new_len) = if base_len < w {
+                                let after = base_len.saturating_add(accepted);
+                                if after <= w {
+                                    (*base_ring_offset, after)
+                                } else {
+                                    let overflow = after - w;
+                                    ((base_ring_offset + overflow) % w, w)
+                                }
+                            } else {
+                                ((base_ring_offset + accepted) % w, w)
+                            };
 
-                        copy_rows(
-                            source_keys_bytes,
-                            source_values_bytes,
-                            destination_keys_bytes,
-                            destination_values_bytes,
-                            row_size,
-                            slots[r.clone()]
-                                .iter()
-                                .enumerate()
-                                .map(|(index, &destination_row)| (r.start + index, destination_row)),
-                        );
+                            *ring_offset = new_offset;
+                            *ring_length = new_len;
+
+                            let pairs =
+                                slots[r.clone()].iter().enumerate().map(move |(i, &dst_row)| (r.start + i, dst_row));
+                            Some(Box::new(pairs))
+                        }
                     },
-                }
+                };
+                let Some(row_pairs) = row_pairs else {
+                    return;
+                };
+
+                Self::copy_rows(
+                    context,
+                    keys.allocation(),
+                    &mut self.keys,
+                    values.allocation(),
+                    &mut self.values,
+                    row_size,
+                    row_pairs,
+                );
             },
             _ => {},
         }
+    }
+
+    fn copy_rows(
+        context: &B::Context,
+        src_keys: &Allocation<B>,
+        dst_keys: &mut Allocation<B>,
+        src_values: &Allocation<B>,
+        dst_values: &mut Allocation<B>,
+        row_size: usize,
+        row_pairs: impl IntoIterator<Item = (usize, usize)>,
+    ) {
+        let mut encoder = Encoder::new(context).expect("Failed to create Encoder");
+        for (src_row, dst_row) in row_pairs {
+            let src_offset = src_row * row_size;
+            let dst_offset = dst_row * row_size;
+            encoder.encode_copy(
+                src_keys,
+                src_offset..src_offset + row_size,
+                dst_keys,
+                dst_offset..dst_offset + row_size,
+            );
+            encoder.encode_copy(
+                src_values,
+                src_offset..src_offset + row_size,
+                dst_values,
+                dst_offset..dst_offset + row_size,
+            );
+        }
+        encoder.end_encoding().submit().wait_until_completed().expect("Failed to copy rows");
     }
 }
 

--- a/crates/backend-uzu/src/forward_pass/kv_cache_layer.rs
+++ b/crates/backend-uzu/src/forward_pass/kv_cache_layer.rs
@@ -198,6 +198,7 @@ impl<B: Backend> KVCacheLayer<B> {
     pub fn slice(
         &self,
         context: &B::Context,
+        encoder: &mut Encoder<B>,
         range: Range<usize>,
     ) -> Option<KVSlice<B>> {
         match self.state {
@@ -236,7 +237,7 @@ impl<B: Backend> KVCacheLayer<B> {
                 let mut dst_keys = context.create_array_uninitialized(&slice_shape, dtype);
                 let mut dst_values = context.create_array_uninitialized(&slice_shape, dtype);
                 Self::copy_rows(
-                    context,
+                    encoder,
                     &self.keys,
                     dst_keys.allocation_mut(),
                     &self.values,
@@ -259,7 +260,7 @@ impl<B: Backend> KVCacheLayer<B> {
 
     pub fn apply_slice(
         &mut self,
-        context: &B::Context,
+        encoder: &mut Encoder<B>,
         slice: &KVSlice<B>,
         range: Option<Range<usize>>,
     ) {
@@ -340,7 +341,7 @@ impl<B: Backend> KVCacheLayer<B> {
                 };
 
                 Self::copy_rows(
-                    context,
+                    encoder,
                     keys.allocation(),
                     &mut self.keys,
                     values.allocation(),
@@ -354,7 +355,7 @@ impl<B: Backend> KVCacheLayer<B> {
     }
 
     fn copy_rows(
-        context: &B::Context,
+        encoder: &mut Encoder<B>,
         src_keys: &Allocation<B>,
         dst_keys: &mut Allocation<B>,
         src_values: &Allocation<B>,
@@ -362,7 +363,6 @@ impl<B: Backend> KVCacheLayer<B> {
         row_size: usize,
         row_pairs: impl IntoIterator<Item = (usize, usize)>,
     ) {
-        let mut encoder = Encoder::new(context).expect("Failed to create Encoder");
         for (src_row, dst_row) in row_pairs {
             let src_offset = src_row * row_size;
             let dst_offset = dst_row * row_size;
@@ -379,7 +379,6 @@ impl<B: Backend> KVCacheLayer<B> {
                 dst_offset..dst_offset + row_size,
             );
         }
-        encoder.end_encoding().submit().wait_until_completed().expect("Failed to copy rows");
     }
 }
 

--- a/crates/backend-uzu/src/language_model/language_model_generator.rs
+++ b/crates/backend-uzu/src/language_model/language_model_generator.rs
@@ -637,7 +637,7 @@ impl<B: Backend> LanguageModelGeneratorTrait for LanguageModelGenerator<B> {
         range: Range<usize>,
     ) {
         let slice = slice.downcast_ref::<CacheLayersSlice<B>>().unwrap();
-        self.context.cache_layers.borrow_mut().apply_slice(slice, Some(range));
+        self.context.cache_layers.borrow_mut().apply_slice(&self.context.context, slice, Some(range));
     }
 
     fn build_llm_context(&self) -> Box<dyn Any> {

--- a/crates/backend-uzu/tests/unit/forward_pass/kv_cache_state_test.rs
+++ b/crates/backend-uzu/tests/unit/forward_pass/kv_cache_state_test.rs
@@ -311,7 +311,7 @@ fn kv_cache_slice_apply_contiguous_window() {
     overwrite_allocation(&mut layer.keys, &[(0, -1.0), (1, -2.0)]);
     overwrite_allocation(&mut layer.values, &[(0, -3.0), (1, -4.0)]);
 
-    layer.apply_slice(&slice, None);
+    layer.apply_slice(&context, &slice, None);
 
     let keys_after: Vec<f32> = allocation_to_vec(&layer.keys);
     let values_after: Vec<f32> = allocation_to_vec(&layer.values);
@@ -342,7 +342,7 @@ fn kv_cache_slice_apply_wrap_window() {
     overwrite_allocation(&mut layer.keys, &[(2, -11.0), (3, -12.0)]);
     overwrite_allocation(&mut layer.values, &[(2, -13.0), (3, -14.0)]);
 
-    layer.apply_slice(&slice, None);
+    layer.apply_slice(&context, &slice, None);
 
     let keys_after: Vec<f32> = allocation_to_vec(&layer.keys);
     let values_after: Vec<f32> = allocation_to_vec(&layer.values);
@@ -375,7 +375,7 @@ fn kv_cache_slice_apply_full_restores_metadata() {
         *prefix_len = 1;
     }
 
-    layer.apply_slice(&slice, None);
+    layer.apply_slice(&context, &slice, None);
 
     if let KVCacheLayerState::Full {
         prefix_len,

--- a/crates/backend-uzu/tests/unit/forward_pass/kv_cache_state_test.rs
+++ b/crates/backend-uzu/tests/unit/forward_pass/kv_cache_state_test.rs
@@ -306,12 +306,17 @@ fn kv_cache_slice_apply_contiguous_window() {
     );
     let (initial_keys, initial_values) = fill_arrays(&mut layer);
 
-    let slice = layer.slice(&context, 0..2).expect("slice should exist");
+    let mut encoder = Encoder::<Metal>::new(&context).expect("Failed to create encoder");
+    let slice = layer.slice(&context, &mut encoder, 0..2).expect("slice should exist");
+    encoder.end_encoding().submit().wait_until_completed().expect("Failed to end and wait encoder");
+
     // Mutate the captured slots.
     overwrite_allocation(&mut layer.keys, &[(0, -1.0), (1, -2.0)]);
     overwrite_allocation(&mut layer.values, &[(0, -3.0), (1, -4.0)]);
 
-    layer.apply_slice(&context, &slice, None);
+    let mut encoder = Encoder::<Metal>::new(&context).expect("Failed to create encoder");
+    layer.apply_slice(&mut encoder, &slice, None);
+    encoder.end_encoding().submit().wait_until_completed().expect("Failed to end and wait encoder");
 
     let keys_after: Vec<f32> = allocation_to_vec(&layer.keys);
     let values_after: Vec<f32> = allocation_to_vec(&layer.values);
@@ -337,12 +342,17 @@ fn kv_cache_slice_apply_wrap_window() {
     );
     let (initial_keys, initial_values) = fill_arrays(&mut layer);
 
-    let slice = layer.slice(&context, 2..4).expect("slice should exist");
+    let mut encoder = Encoder::<Metal>::new(&context).expect("Failed to create encoder");
+    let slice = layer.slice(&context, &mut encoder, 2..4).expect("slice should exist");
+    encoder.end_encoding().submit().wait_until_completed().expect("Failed to end and wait encoder");
+
     // Captured slots are expected to wrap; mutate them.
     overwrite_allocation(&mut layer.keys, &[(2, -11.0), (3, -12.0)]);
     overwrite_allocation(&mut layer.values, &[(2, -13.0), (3, -14.0)]);
 
-    layer.apply_slice(&context, &slice, None);
+    let mut encoder = Encoder::<Metal>::new(&context).expect("Failed to create encoder");
+    layer.apply_slice(&mut encoder, &slice, None);
+    encoder.end_encoding().submit().wait_until_completed().expect("Failed to end and wait encoder");
 
     let keys_after: Vec<f32> = allocation_to_vec(&layer.keys);
     let values_after: Vec<f32> = allocation_to_vec(&layer.values);
@@ -365,7 +375,9 @@ fn kv_cache_slice_apply_full_restores_metadata() {
         0,
     );
 
-    let slice = layer.slice(&context, 0..2).expect("full slice exists");
+    let mut encoder = Encoder::<Metal>::new(&context).expect("Failed to create encoder");
+    let slice = layer.slice(&context, &mut encoder, 0..2).expect("full slice exists");
+    encoder.end_encoding().submit().wait_until_completed().expect("Failed to end and wait encoder");
 
     // Mutate metadata.
     if let KVCacheLayerState::Full {
@@ -375,7 +387,9 @@ fn kv_cache_slice_apply_full_restores_metadata() {
         *prefix_len = 1;
     }
 
-    layer.apply_slice(&context, &slice, None);
+    let mut encoder = Encoder::<Metal>::new(&context).expect("Failed to create encoder");
+    layer.apply_slice(&mut encoder, &slice, None);
+    encoder.end_encoding().submit().wait_until_completed().expect("Failed to end and wait encoder");
 
     if let KVCacheLayerState::Full {
         prefix_len,


### PR DESCRIPTION
* Generalize `CommandBufferEncoding::encode_copy()`: now it supports any `Buffer`
* Use blit encoder to copy values in `kv_cache_layers.rs`