### PR TITLE
Buffers refactoring

### DIFF
--- a/crates/backend-uzu/src/backends/common/buffer.rs
+++ b/crates/backend-uzu/src/backends/common/buffer.rs
@@ -11,10 +11,6 @@ pub trait Buffer: Any + Debug {
 }
 
 pub trait BufferGpuAddressRangeExt: Buffer {
-    fn gpu_address_range(&self) -> Range<usize> {
-        self.gpu_ptr()..(self.gpu_ptr() + self.size())
-    }
-
     fn gpu_address_subrange(
         &self,
         subrange: Range<usize>,

--- a/crates/backend-uzu/src/backends/common/buffer.rs
+++ b/crates/backend-uzu/src/backends/common/buffer.rs
@@ -5,6 +5,12 @@ use crate::backends::common::Backend;
 pub trait Buffer: Any + Debug {
     type Backend: Backend;
 
+    fn as_bytes_slice_range(
+        &self,
+        context: Option<&<Self::Backend as Backend>::Context>,
+        range: Range<usize>,
+    ) -> Result<&[u8], <Self::Backend as Backend>::Error>;
+
     fn gpu_ptr(&self) -> usize;
 
     fn size(&self) -> usize;

--- a/crates/backend-uzu/src/backends/common/buffer_range.rs
+++ b/crates/backend-uzu/src/backends/common/buffer_range.rs
@@ -5,7 +5,7 @@
 
 use std::ops::Range;
 
-use crate::backends::common::Buffer;
+use crate::backends::common::{Backend, Buffer};
 
 pub struct BufferRangeRef<'a, B: Buffer> {
     buffer: &'a B,
@@ -21,6 +21,13 @@ impl<'a, B: Buffer> BufferRangeRef<'a, B> {
             buffer,
             range,
         }
+    }
+
+    pub fn as_bytes_slice(
+        &self,
+        context: &<<B as Buffer>::Backend as Backend>::Context,
+    ) -> Result<&[u8], <<B as Buffer>::Backend as Backend>::Error> {
+        self.buffer.as_bytes_slice_range(Some(context), self.range.clone())
     }
 
     pub fn buffer(&self) -> &'a B {

--- a/crates/backend-uzu/src/backends/common/command_buffer.rs
+++ b/crates/backend-uzu/src/backends/common/command_buffer.rs
@@ -78,11 +78,12 @@ pub trait CommandBufferEncoding {
         Src: Buffer<Backend = <Self::CommandBuffer as CommandBuffer>::Backend>,
         Dst: Buffer<Backend = <Self::CommandBuffer as CommandBuffer>::Backend>;
 
-    fn encode_fill(
+    fn encode_fill<Dst>(
         &mut self,
-        dst: BufferRangeMut<'_, <<Self::CommandBuffer as CommandBuffer>::Backend as Backend>::DenseBuffer>,
+        dst: BufferRangeMut<'_, Dst>,
         value: u8,
-    );
+    ) where
+        Dst: Buffer<Backend = <Self::CommandBuffer as CommandBuffer>::Backend>;
 
     fn encode_barrier(
         &mut self,

--- a/crates/backend-uzu/src/backends/common/encoder.rs
+++ b/crates/backend-uzu/src/backends/common/encoder.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::backends::common::{
-    AccessFlags, Allocation, AllocationPool, AllocationType, AsBufferRangeMut, AsBufferRangeRef, Backend,
+    AccessFlags, Allocation, AllocationPool, AllocationType, AsBufferRangeMut, AsBufferRangeRef, Backend, Buffer,
     BufferGpuAddressRangeExt, CommandBuffer, CommandBufferCompleted, CommandBufferEncoding, CommandBufferExecutable,
     CommandBufferInitial, CommandBufferPending, Context,
     hazard_tracker::{Access, HazardTracker},
@@ -79,13 +79,18 @@ impl<'encoding, B: Backend> Encoder<'encoding, B> {
         )
     }
 
-    pub fn encode_copy(
+    pub fn encode_copy<Src, Dst>(
         &mut self,
-        src: &Allocation<B>,
+        src: &Src,
         src_range: impl RangeBounds<usize>,
-        dst: &mut Allocation<B>,
+        dst: &mut Dst,
         dst_range: impl RangeBounds<usize>,
-    ) {
+    ) where
+        Src: AsBufferRangeRef,
+        Src::Buffer: Buffer<Backend = B>,
+        Dst: AsBufferRangeMut,
+        Dst::Buffer: Buffer<Backend = B>,
+    {
         let src_buffer_range = src.as_buffer_range_ref();
         let dst_buffer_range = dst.as_buffer_range_mut();
         let src_range = resolve_copy_range(src_range, src_buffer_range.range().len(), "source");
@@ -108,11 +113,14 @@ impl<'encoding, B: Backend> Encoder<'encoding, B> {
         self.command_buffer.encode_copy(src_buffer_range, dst_buffer_range);
     }
 
-    pub fn encode_fill(
+    pub fn encode_fill<Dst>(
         &mut self,
-        dst: &mut Allocation<B>,
+        dst: &mut Dst,
         value: u8,
-    ) {
+    ) where
+        Dst: AsBufferRangeMut,
+        Dst::Buffer: Buffer<Backend = B>,
+    {
         let dst_buffer_range = dst.as_buffer_range_mut();
         assert!(!dst_buffer_range.range().is_empty(), "zero-sized fills are not allowed");
         self.access(&[Access {

--- a/crates/backend-uzu/src/backends/cpu/command_buffer.rs
+++ b/crates/backend-uzu/src/backends/cpu/command_buffer.rs
@@ -11,7 +11,7 @@ use std::{
 use crate::{
     backends::{
         common::{
-            AccessFlags, Backend, Buffer, BufferRangeMut, BufferRangeRef, CommandBuffer, CommandBufferCompleted,
+            AccessFlags, Buffer, BufferRangeMut, BufferRangeRef, CommandBuffer, CommandBufferCompleted,
             CommandBufferEncoding, CommandBufferExecutable, CommandBufferInitial, CommandBufferPending,
         },
         cpu::{BufferDowncastExt, Cpu, error::CpuError},
@@ -96,14 +96,16 @@ impl CommandBufferEncoding for CpuCommandBufferEncoding {
         });
     }
 
-    fn encode_fill(
+    fn encode_fill<Dst>(
         &mut self,
-        dst: BufferRangeMut<'_, <Cpu as Backend>::DenseBuffer>,
+        dst: BufferRangeMut<'_, Dst>,
         value: u8,
-    ) {
+    ) where
+        Dst: Buffer<Backend = Cpu>,
+    {
         let range = dst.range();
         let size = range.end - range.start;
-        let dst = SendPtrMut(unsafe { (&mut *dst.buffer().get()).as_mut_ptr().add(range.start) });
+        let dst = SendPtrMut(unsafe { (&mut *dst.buffer().downcast().get()).as_mut_ptr().add(range.start) });
         self.push_command(move || unsafe {
             dst.as_ptr().write_bytes(value, size);
         });

--- a/crates/backend-uzu/src/backends/cpu/dense_buffer.rs
+++ b/crates/backend-uzu/src/backends/cpu/dense_buffer.rs
@@ -1,10 +1,19 @@
-use std::{cell::UnsafeCell, os::raw::c_void, pin::Pin, ptr::NonNull};
+use std::{cell::UnsafeCell, ops::Range, os::raw::c_void, pin::Pin, ptr::NonNull};
 
 use super::Cpu;
-use crate::backends::common::{Buffer, DenseBuffer};
+use crate::backends::common::{Backend, Buffer, DenseBuffer};
 
 impl Buffer for UnsafeCell<Pin<Box<[u8]>>> {
     type Backend = Cpu;
+
+    fn as_bytes_slice_range(
+        &self,
+        _context: Option<&<Self::Backend as Backend>::Context>,
+        range: Range<usize>,
+    ) -> Result<&[u8], <Self::Backend as Backend>::Error> {
+        let pinned = unsafe { &*self.get() };
+        Ok(&pinned[range])
+    }
 
     fn gpu_ptr(&self) -> usize {
         unsafe { &*self.get() }.as_ptr().addr()

--- a/crates/backend-uzu/src/backends/cpu/sparse/sparse_buffer.rs
+++ b/crates/backend-uzu/src/backends/cpu/sparse/sparse_buffer.rs
@@ -11,6 +11,14 @@ pub struct CpuSparseBuffer {}
 impl Buffer for CpuSparseBuffer {
     type Backend = Cpu;
 
+    fn as_bytes_slice_range(
+        &self,
+        _context: Option<&<Self::Backend as Backend>::Context>,
+        _range: Range<usize>,
+    ) -> Result<&[u8], <Self::Backend as Backend>::Error> {
+        todo!()
+    }
+
     fn gpu_ptr(&self) -> usize {
         todo!()
     }

--- a/crates/backend-uzu/src/backends/metal/command_buffer.rs
+++ b/crates/backend-uzu/src/backends/metal/command_buffer.rs
@@ -9,7 +9,7 @@ use objc2::{Message, rc::Retained, runtime::ProtocolObject};
 use super::{BufferDowncastExt, Metal};
 use crate::backends::{
     common::{
-        AccessFlags, Backend, Buffer, BufferRangeMut, BufferRangeRef, CommandBuffer, CommandBufferCompleted,
+        AccessFlags, Buffer, BufferRangeMut, BufferRangeRef, CommandBuffer, CommandBufferCompleted,
         CommandBufferEncoding, CommandBufferExecutable, CommandBufferInitial, CommandBufferPending,
     },
     metal::error::MetalError,
@@ -139,16 +139,17 @@ impl CommandBufferEncoding for MetalCommandBufferEncoding {
         );
     }
 
-    fn encode_fill(
+    fn encode_fill<Dst>(
         &mut self,
-        dst: BufferRangeMut<'_, <Metal as Backend>::DenseBuffer>,
+        dst: BufferRangeMut<'_, Dst>,
         value: u8,
-    ) {
+    ) where
+        Dst: Buffer<Backend = Metal>,
+    {
         let range = dst.range();
         assert!(range.end > range.start);
         assert!(range.start % 4 == 0 && range.end % 4 == 0);
-
-        self.ensure_blit().fill_buffer_range_value(dst.buffer(), range, value);
+        self.ensure_blit().fill_buffer_range_value(dst.buffer().downcast(), range, value);
     }
 
     fn encode_barrier(

--- a/crates/backend-uzu/src/backends/metal/dense_buffer.rs
+++ b/crates/backend-uzu/src/backends/metal/dense_buffer.rs
@@ -1,13 +1,27 @@
-use std::{os::raw::c_void, ptr::NonNull};
+use std::{ops::Range, os::raw::c_void, ptr::NonNull};
 
 use metal::MTLBuffer;
 use objc2::{rc::Retained, runtime::ProtocolObject};
 
 use super::Metal;
-use crate::backends::common::{Buffer, DenseBuffer};
+use crate::backends::{
+    common::{Backend, Buffer, DenseBuffer},
+    metal::error::MetalError,
+};
 
 impl Buffer for Retained<ProtocolObject<dyn MTLBuffer>> {
     type Backend = Metal;
+
+    fn as_bytes_slice_range(
+        &self,
+        _context: Option<&<Self::Backend as Backend>::Context>,
+        range: Range<usize>,
+    ) -> Result<&[u8], MetalError> {
+        assert!(range.end <= self.length());
+        let start_ptr = unsafe { self.cpu_ptr().add(range.start) };
+        let slice = unsafe { std::slice::from_raw_parts(start_ptr.as_ptr() as *const u8, range.len()) };
+        Ok(slice)
+    }
 
     fn gpu_ptr(&self) -> usize {
         self.gpu_address() as usize

--- a/crates/backend-uzu/src/backends/metal/error.rs
+++ b/crates/backend-uzu/src/backends/metal/error.rs
@@ -24,6 +24,8 @@ pub enum MetalError {
     CannotCreateFunction,
     #[error("Cannot create pipeline state: {0}")]
     CannotCreatePipelineState(String),
+    #[error("Context required")]
+    ContextRequired,
     #[error("Can not allocate buffer with size={0}")]
     SparseBufferAlloc(usize),
     #[error("Can not allocate heap with size={0} and page size={1}")]

--- a/crates/backend-uzu/src/backends/metal/sparse/sparse_buffer.rs
+++ b/crates/backend-uzu/src/backends/metal/sparse/sparse_buffer.rs
@@ -11,7 +11,7 @@ use rangemap::RangeSet;
 
 use crate::{
     backends::{
-        common::{Backend, Buffer, SparseBuffer},
+        common::{Backend, Buffer, Context, DenseBuffer, Encoder, SparseBuffer},
         metal::{Metal, error::MetalError, metal_extensions::SparsePageSizeExt},
     },
     prelude::MetalContext,
@@ -74,6 +74,24 @@ impl Drop for MetalSparseBuffer {
 
 impl Buffer for MetalSparseBuffer {
     type Backend = Metal;
+
+    fn as_bytes_slice_range(
+        &self,
+        context: Option<&<Self::Backend as Backend>::Context>,
+        range: Range<usize>,
+    ) -> Result<&[u8], MetalError> {
+        let context = context.ok_or(MetalError::ContextRequired)?;
+        let dst_buffer_length = range.len();
+        let mut dst_buffer = context.create_buffer(dst_buffer_length)?;
+
+        let mut encoder = Encoder::<Self::Backend>::new(context)?;
+        encoder.encode_copy(self, range, &mut dst_buffer, 0..dst_buffer_length);
+        encoder.end_encoding().submit().wait_until_completed()?;
+
+        let bytes =
+            unsafe { std::slice::from_raw_parts(dst_buffer.cpu_ptr().as_ptr() as *const u8, dst_buffer_length) };
+        Ok(bytes)
+    }
 
     fn gpu_ptr(&self) -> usize {
         self.buffer.gpu_ptr()


### PR DESCRIPTION
* Added `Buffer::as_bytes_slice_range` and `BufferRangeRef::as_bytes_slice `
* Migrate `Encoder::encode_copy` and `Encoder::encode_fill` to take `AsBufferRangeRef`
* Removed redundant `BufferGpuAddressRangeExt ::gpu_address_range`

This changes needed for migrating kv cache to sparse buffers: trace validator and tests needed bytes.
