### PR TITLE
Fix Linux CPU-only download-manager build

### DIFF
--- a/crates/download-manager/src/backends/common/backend.rs
+++ b/crates/download-manager/src/backends/common/backend.rs
@@ -10,6 +10,7 @@ use crate::{
 
 pub enum InitialTaskAttachment<B: Backend> {
     None,
+    #[cfg_attr(not(target_vendor = "apple"), allow(dead_code))]
     Downloading {
         active_task: B::ActiveTask,
         initial_downloaded_bytes: u64,

--- a/crates/download-manager/src/backends/mod.rs
+++ b/crates/download-manager/src/backends/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(target_vendor = "apple")]
 pub mod apple;
 pub mod common;
 pub mod universal;

--- a/crates/download-manager/src/file_download_manager.rs
+++ b/crates/download-manager/src/file_download_manager.rs
@@ -5,8 +5,10 @@ use tokio_stream::wrappers::BroadcastStream as TokioBroadcastStream;
 
 use crate::{
     DownloadError, DownloadId, FileCheck, FileDownloadEvent, FileDownloadTask,
-    backends::{apple::AppleDownloadManager, universal::UniversalDownloadManager},
+    backends::universal::UniversalDownloadManager,
 };
+#[cfg(target_vendor = "apple")]
+use crate::backends::apple::AppleDownloadManager;
 
 pub type DownloadEvent = (DownloadId, FileDownloadEvent);
 pub type DownloadEventSender = TokioBroadcastSender<DownloadEvent>;

--- a/crates/download-manager/src/file_download_manager.rs
+++ b/crates/download-manager/src/file_download_manager.rs
@@ -3,12 +3,12 @@ use std::{path::Path, sync::Arc};
 use tokio::{runtime::Handle as TokioHandle, sync::broadcast::Sender as TokioBroadcastSender};
 use tokio_stream::wrappers::BroadcastStream as TokioBroadcastStream;
 
+#[cfg(target_vendor = "apple")]
+use crate::backends::apple::AppleDownloadManager;
 use crate::{
     DownloadError, DownloadId, FileCheck, FileDownloadEvent, FileDownloadTask,
     backends::universal::UniversalDownloadManager,
 };
-#[cfg(target_vendor = "apple")]
-use crate::backends::apple::AppleDownloadManager;
 
 pub type DownloadEvent = (DownloadId, FileDownloadEvent);
 pub type DownloadEventSender = TokioBroadcastSender<DownloadEvent>;


### PR DESCRIPTION
## What

Fix Linux CPU-only builds by compiling the Apple download backend only on Apple targets.

## Why

`download-manager` exposed Apple-specific modules/imports on Linux even though Apple dependencies are target-gated. This breaks CPU-only Linux checks.

## Validation

- `cargo check -p uzu --no-default-features --features backend-cpu`
- `cargo check -p cli --no-default-features --features backend-cpu,capability-cli`
- `cargo test -p backend-uzu --no-default-features --lib`
- `cargo run --release -p uzu --example quick_start --no-default-features --features backend-cpu`