### PR TITLE
Add Vulkan backend scaffold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading 0.8.9",
+]
+
+[[package]]
 name = "askama"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +566,7 @@ name = "backend-uzu"
 version = "0.4.9"
 dependencies = [
  "anyhow",
+ "ash",
  "async-trait",
  "bindgen",
  "bitflags 2.11.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ objc2 = "0.6.4"
 objc2-foundation = "0.3.2"
 objc2-security = "0.3.2"
 metal = { package = "mtl-rs", version = "0.1.12" }
+ash = "0.38"
 block2 = "0.6"
 bytemuck = "1.23"
 bytesize = "2"

--- a/crates/backend-uzu/Cargo.toml
+++ b/crates/backend-uzu/Cargo.toml
@@ -46,6 +46,10 @@ objc2-foundation = { workspace = true, optional = true }
 bytesize = { workspace = true, optional = true }
 metal = { workspace = true, optional = true }
 
+# vulkan on linux requires ash
+[target.'cfg(target_os = "linux")'.dependencies]
+ash = { workspace = true, optional = true }
+
 # grammar on non-wasm requires xgrammar
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 xgrammar = { workspace = true, optional = true }
@@ -102,6 +106,7 @@ metal = [
     "dep:metal",
 ]
 grammar = ["dep:xgrammar"]
+vulkan = ["dep:ash"]
 tracing = []
 
 [[test]]

--- a/crates/backend-uzu/src/backends/mod.rs
+++ b/crates/backend-uzu/src/backends/mod.rs
@@ -3,6 +3,8 @@ pub mod common;
 pub mod cpu;
 #[cfg(metal_backend)]
 pub mod metal;
+#[cfg(all(feature = "vulkan", target_os = "linux"))]
+pub mod vulkan;
 
 macro_rules! select_backend {
     ($expr:expr, $unk:expr) => {{

--- a/crates/backend-uzu/src/backends/vulkan/error.rs
+++ b/crates/backend-uzu/src/backends/vulkan/error.rs
@@ -1,0 +1,7 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum VulkanError {
+    #[error("Vulkan backend is not available")]
+    Unavailable,
+}

--- a/crates/backend-uzu/src/backends/vulkan/mod.rs
+++ b/crates/backend-uzu/src/backends/vulkan/mod.rs
@@ -1,0 +1,3 @@
+mod error;
+
+pub use error::VulkanError;


### PR DESCRIPTION
## What

Add the initial cfg-gated Vulkan backend scaffold under `backend-uzu`.

## Why

This creates a small, compile-checked entry point for follow-up Vulkan backend work without changing existing CPU or Metal behavior.

## Validation

- `cargo +stable check -p backend-uzu --no-default-features`
- `cargo +stable check -p backend-uzu --no-default-features --features vulkan`
- `env CARGO_ENCODED_RUSTFLAGS=-Dwarnings cargo +stable check -p backend-uzu --no-default-features --features vulkan`
- `cargo metadata --locked --format-version=1`
- `cargo +nightly fmt --check`