### PR TITLE
support multidimensional threadgroup in dsl

### DIFF
--- a/crates/backend-uzu/build/metal/ast.rs
+++ b/crates/backend-uzu/build/metal/ast.rs
@@ -308,7 +308,7 @@ fn parse_argument_type(
     }
 
     if c_type.contains("threadgroup") && c_type.contains('*') {
-        let lbracket = source.rfind('[').context("threadgroup missing size bracket")? + 1;
+        let lbracket = source.find('[').context("threadgroup missing size bracket")? + 1;
         let rbracket = source.rfind(']').context("threadgroup missing size bracket")?;
         return Ok(MetalArgumentType::Shared(Some(source[lbracket..rbracket].into())));
     }

--- a/crates/backend-uzu/build/metal/wrapper.rs
+++ b/crates/backend-uzu/build/metal/wrapper.rs
@@ -231,10 +231,11 @@ fn kernel_wrappers(
         let wrapper_arguments = wrapper_arguments.join(", ");
 
         let shared_definitions = kernel.arguments.iter().filter_map(|a| match &a.argument_type {
-            MetalArgumentType::Shared(Some(len)) => {
-                Some(format!("{} {}[{}]", &a.c_type.replace('*', ""), a.name, len.as_ref(),))
+            MetalArgumentType::Shared(dimensions) => {
+                let element_type = a.c_type.split(['*', '&', '(']).next().unwrap_or_default().trim_end();
+                let dimensions = dimensions.as_deref().map(|d| format!("[{d}]")).unwrap_or_default();
+                Some(format!("{element_type} {}{dimensions}", a.name))
             },
-            MetalArgumentType::Shared(None) => Some(format!("{} {}", &a.c_type.replace('&', ""), a.name)),
             _ => None,
         });
 


### PR DESCRIPTION
| Source decl                       | clang `c_type`           |
 |-----------------------------------|--------------------------|
  | `threadgroup T name[N]`           | `threadgroup T *`        |
  | `threadgroup T& name`             | `threadgroup T &`        |
  | `threadgroup T name[A][B]`        | `threadgroup T (*)[B]`   |
  | `threadgroup T name[A][B][C]`     | `threadgroup T (*)[B][C]`|