### PR TITLE
Export Uzu traces as safetensors

### DIFF
--- a/crates/backend-uzu/Cargo.toml
+++ b/crates/backend-uzu/Cargo.toml
@@ -65,6 +65,7 @@ rstest.workspace = true
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = { workspace = true, default-features = true }
 proptest = { workspace = true, default-features = true }
+tempfile.workspace = true
 
 [build-dependencies]
 anyhow.workspace = true

--- a/crates/backend-uzu/Cargo.toml
+++ b/crates/backend-uzu/Cargo.toml
@@ -66,6 +66,7 @@ rstest.workspace = true
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = { workspace = true, default-features = true }
 proptest = { workspace = true, default-features = true }
+tempfile.workspace = true
 
 [build-dependencies]
 anyhow.workspace = true

--- a/crates/backend-uzu/src/forward_pass/cache_layers.rs
+++ b/crates/backend-uzu/src/forward_pass/cache_layers.rs
@@ -302,14 +302,26 @@ impl<B: Backend> CacheLayers<B> {
     }
 
     pub fn iter_layers(&self) -> impl Iterator<Item = (usize, &CacheLayer<B>)> {
-        self.bindings.iter().enumerate().filter_map(|(index, binding)| match binding {
+        self.bindings.iter().enumerate().map(|(index, binding)| match binding {
             LayerCacheBinding::Owned {
                 entry,
-            } => Some((index, &self.entries[entry.index])),
+            } => (index, &self.entries[entry.index]),
             LayerCacheBinding::Shared {
-                ..
-            } => None,
+                source,
+            } => (index, &self.entries[source.index]),
         })
+    }
+
+    pub fn commit_short_conv_suffix_states(
+        &mut self,
+        commit_index: usize,
+        encoder: &mut Encoder<B>,
+    ) {
+        for layer in self.entries.iter_mut() {
+            if let Some(layer) = layer.as_short_conv_mut() {
+                layer.commit_from_suffix_state_if_valid(commit_index, encoder);
+            }
+        }
     }
 
     pub fn clear(
@@ -670,6 +682,97 @@ impl<B: Backend> CacheLayers<B> {
         };
         cloned.copy_from(self, context);
         cloned
+    }
+}
+
+#[cfg(test)]
+mod short_conv_suffix_state_tests {
+    use std::cell::Cell;
+
+    use crate::{
+        array::ArrayContextExt,
+        backends::{
+            common::{Backend, Context, Encoder},
+            cpu::Cpu,
+        },
+        data_type::DataType,
+        forward_pass::{
+            cache_layers::{CacheEntryIndex, CacheLayer, CacheLayers, LayerCacheBinding},
+            short_conv_layer::ShortConvLayer,
+        },
+    };
+
+    #[test]
+    fn test_commit_short_conv_suffix_states_commits_selected_suffix_row() {
+        let context = <Cpu as Backend>::Context::new().expect("create CPU context");
+        let conv_state = context.create_array_zeros(&[2, 2], DataType::F32).into_allocation();
+        let suffix_state = context
+            .create_array_from(&[3, 2, 2], &[1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0])
+            .into_allocation();
+        let short_conv = ShortConvLayer {
+            conv_state,
+            conv_shape: [2, 2],
+            suffix_state,
+            suffix_shape: [3, 2, 2],
+            data_type: DataType::F32,
+            suffix_state_valid_start: Cell::new(1),
+            suffix_state_valid_len: Cell::new(2),
+        };
+        let mut cache_layers = CacheLayers {
+            max_suffix_length: 3,
+            max_prefix_length: 0,
+            entries: Box::new([CacheLayer::ShortConv(short_conv)]),
+            bindings: Box::new([LayerCacheBinding::Owned {
+                entry: CacheEntryIndex {
+                    index: 0,
+                },
+            }]),
+        };
+        let mut encoder = Encoder::<Cpu>::new(context.as_ref()).expect("create encoder");
+
+        cache_layers.commit_short_conv_suffix_states(2, &mut encoder);
+        encoder.end_encoding().submit().wait_until_completed().expect("commit short conv suffix state");
+
+        let (_, layer) = cache_layers.iter_layers().next().expect("short conv layer");
+        assert_eq!(
+            layer.as_short_conv().expect("short conv layer").conv_state.copyout::<f32>(),
+            &[9.0, 10.0, 11.0, 12.0]
+        );
+    }
+
+    #[test]
+    fn test_iter_layers_includes_shared_bindings() {
+        let context = <Cpu as Backend>::Context::new().expect("create CPU context");
+        let short_conv = ShortConvLayer {
+            conv_state: context.create_array_zeros(&[2, 2], DataType::F32).into_allocation(),
+            conv_shape: [2, 2],
+            suffix_state: context.create_array_zeros(&[1, 2, 2], DataType::F32).into_allocation(),
+            suffix_shape: [1, 2, 2],
+            data_type: DataType::F32,
+            suffix_state_valid_start: Cell::new(0),
+            suffix_state_valid_len: Cell::new(0),
+        };
+        let cache_layers = CacheLayers {
+            max_suffix_length: 1,
+            max_prefix_length: 0,
+            entries: Box::new([CacheLayer::ShortConv(short_conv)]),
+            bindings: Box::new([
+                LayerCacheBinding::Owned {
+                    entry: CacheEntryIndex {
+                        index: 0,
+                    },
+                },
+                LayerCacheBinding::Shared {
+                    source: CacheEntryIndex {
+                        index: 0,
+                    },
+                },
+            ]),
+        };
+
+        let layer_indices = cache_layers.iter_layers().map(|(index, _)| index).collect::<Vec<_>>();
+
+        assert_eq!(layer_indices, &[0, 1]);
     }
 }
 

--- a/crates/backend-uzu/src/lib.rs
+++ b/crates/backend-uzu/src/lib.rs
@@ -34,7 +34,7 @@ pub use utils::{TOOLCHAIN_VERSION, VERSION};
 pub mod _private {
     pub use crate::{
         classifier::Classifier,
-        config::model::AnyModelConfig,
+        config::{model::AnyModelConfig, token_codec::AnyTokenCodecConfig, transformer_layer::TransformerLayerConfig},
         encodable_block::{DecoderDecodeInput, Sampling},
         forward_pass::{
             cache_layers::CacheLayers, kv_cache_layer::KVCacheLayer, token_inputs::TokenInputs, traces::ActivationTrace,

--- a/crates/backend-uzu/src/lib.rs
+++ b/crates/backend-uzu/src/lib.rs
@@ -26,22 +26,20 @@ pub use audio::{NanoCodecFsqRuntime, NanoCodecFsqRuntimeConfig};
 pub use backends::common::{AllocationAccessError, allocation_copy_from_slice, allocation_to_vec};
 pub use data_type::{ArrayElement, DataType};
 pub use language_model::gumbel::{gumbel_float, revidx};
-pub use parameters::{ParameterLoader, read_safetensors_metadata};
+pub use parameters::{
+    Dtype, ParameterLoader, SafeTensorData, read_safetensors_metadata, write_safetensors,
+    write_safetensors_with_metadata,
+};
 pub use utils::{TOOLCHAIN_VERSION, VERSION};
 
 #[cfg(feature = "tracing")]
 pub mod _private {
     pub use crate::{
         classifier::Classifier,
-        config::{ModelConfig, ModelMetadata, ModelType},
+        config::{ModelConfig, ModelMetadata, ModelType, TransformerLayerConfig},
         encodable_block::{DecoderDecodeInput, Sampling},
-        forward_pass::{
-            cache_layers::CacheLayers, kv_cache_layer::KVCacheLayer, token_inputs::TokenInputs, traces::ActivationTrace,
-        },
-        language_model::{
-            language_model_generator_context::LanguageModelGeneratorContext,
-            sampler::{ArgmaxSampler, LogitsSampler},
-        },
+        forward_pass::{cache_layers::CacheLayers, token_inputs::TokenInputs, traces::ActivationTrace},
+        language_model::language_model_generator_context::LanguageModelGeneratorContext,
         parameters::ParameterTree,
     };
 }

--- a/crates/backend-uzu/src/parameters/mod.rs
+++ b/crates/backend-uzu/src/parameters/mod.rs
@@ -4,4 +4,7 @@ mod safetensors_metadata;
 // Re-export the safetensors header reader so other modules (e.g. decoder
 // runner) can estimate parameter memory before creating a Context.
 pub use loader::{ParameterLeaf, ParameterLoader, ParameterLoaderError, ParameterTree};
-pub use safetensors_metadata::{HeaderLoadingError, read_metadata as read_safetensors_metadata};
+pub use safetensors_metadata::{
+    Dtype, HashMetadata, HeaderLoadingError, SafeTensorData, read_metadata as read_safetensors_metadata,
+    write_safetensors, write_safetensors_with_metadata,
+};

--- a/crates/backend-uzu/src/parameters/mod.rs
+++ b/crates/backend-uzu/src/parameters/mod.rs
@@ -4,4 +4,7 @@ mod safetensors_metadata;
 // Re-export the safetensors header reader so other modules (e.g. decoder
 // runner) can estimate parameter memory before creating a Context.
 pub use loader::{ParameterLeaf, ParameterLoader, ParameterLoaderError, ParameterTree};
-pub use safetensors_metadata::{HeaderLoadingError, read_metadata as read_safetensors_metadata};
+pub use safetensors_metadata::{
+    Dtype, HeaderLoadingError, SafeTensorData, read_metadata as read_safetensors_metadata, write_safetensors,
+    write_safetensors_with_metadata,
+};

--- a/crates/backend-uzu/src/parameters/safetensors_metadata.rs
+++ b/crates/backend-uzu/src/parameters/safetensors_metadata.rs
@@ -1,6 +1,12 @@
 // This code is based on the safetensors implementation: https://docs.rs/safetensors/latest/src/safetensors/tensor.rs.html
 
-use std::{collections::HashMap, fs::File, str::Utf8Error};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, BTreeSet, HashMap},
+    fs::File,
+    io::{self, Write},
+    str::Utf8Error,
+};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -98,12 +104,37 @@ impl Dtype {
             Self::F32 => DataType::F32,
             Self::I8 => DataType::I8,
             Self::U8 => DataType::U8,
+            Self::I16 => DataType::I16,
+            Self::U16 => DataType::U16,
             Self::I32 => DataType::I32,
             Self::U32 => DataType::U32,
+            Self::F64 => DataType::F64,
             Self::I64 => DataType::I64,
             Self::U64 => DataType::U64,
             dtype => return Err(HeaderLoadingError::UnsupportedDtype(dtype)),
         })
+    }
+}
+
+impl TryFrom<DataType> for Dtype {
+    type Error = DataType;
+
+    fn try_from(dtype: DataType) -> Result<Self, Self::Error> {
+        match dtype {
+            DataType::F16 => Ok(Dtype::F16),
+            DataType::BF16 => Ok(Dtype::BF16),
+            DataType::F32 => Ok(Dtype::F32),
+            DataType::I8 => Ok(Dtype::I8),
+            DataType::U8 => Ok(Dtype::U8),
+            DataType::I16 => Ok(Dtype::I16),
+            DataType::U16 => Ok(Dtype::U16),
+            DataType::I32 => Ok(Dtype::I32),
+            DataType::U32 => Ok(Dtype::U32),
+            DataType::F64 => Ok(Dtype::F64),
+            DataType::I64 => Ok(Dtype::I64),
+            DataType::U64 => Ok(Dtype::U64),
+            DataType::I4 | DataType::U4 => Err(dtype),
+        }
     }
 }
 
@@ -124,4 +155,87 @@ pub fn read_metadata(file: &File) -> Result<(usize, HashMetadata), HeaderLoading
     let string = core::str::from_utf8(&json_buffer)?;
     let metadata: HashMetadata = serde_json::from_str(string)?;
     Ok((stop, metadata))
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SafeTensorData<'data> {
+    pub name: String,
+    pub shape: Box<[usize]>,
+    pub data_type: DataType,
+    pub data: Cow<'data, [u8]>,
+}
+
+pub fn write_safetensors<W: Write>(
+    writer: &mut W,
+    tensors: &[SafeTensorData<'_>],
+) -> Result<(), io::Error> {
+    write_safetensors_with_metadata(writer, tensors, None)
+}
+
+pub fn write_safetensors_with_metadata<W: Write>(
+    writer: &mut W,
+    tensors: &[SafeTensorData<'_>],
+    metadata: Option<&BTreeMap<String, String>>,
+) -> Result<(), io::Error> {
+    let mut sorted_tensors: Vec<&SafeTensorData<'_>> = tensors.iter().collect();
+    sorted_tensors.sort_by(|left, right| {
+        right.data_type.size_in_bytes().cmp(&left.data_type.size_in_bytes()).then_with(|| left.name.cmp(&right.name))
+    });
+    let Some(first_tensor) = sorted_tensors.first() else {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, "safetensors requires at least one tensor"));
+    };
+
+    let mut header = serde_json::Map::new();
+    if let Some(metadata) = metadata {
+        header.insert("__metadata__".to_string(), serde_json::to_value(metadata)?);
+    }
+
+    let mut offset: usize = 0;
+    let mut names = BTreeSet::new();
+    for tensor in sorted_tensors.iter() {
+        if tensor.name == "__metadata__" {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "__metadata__ is reserved"));
+        }
+        if !names.insert(tensor.name.as_str()) {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "duplicate safetensors tensor name"));
+        }
+        let dtype = Dtype::try_from(tensor.data_type)
+            .map_err(|dtype| io::Error::new(io::ErrorKind::InvalidInput, format!("unsupported dtype: {dtype:?}")))?;
+        let expected_len = tensor
+            .shape
+            .iter()
+            .try_fold(tensor.data_type.size_in_bytes(), |size, dim| size.checked_mul(*dim))
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidInput, "safetensors tensor byte size overflows usize")
+            })?;
+        if expected_len != tensor.data.len() {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "safetensors tensor shape does not match data"));
+        }
+        let end = offset
+            .checked_add(tensor.data.len())
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "safetensors tensor offsets overflow usize"))?;
+        header.insert(
+            tensor.name.clone(),
+            serde_json::to_value(TensorInfo {
+                dtype,
+                shape: tensor.shape.to_vec(),
+                data_offsets: (offset, end),
+            })?,
+        );
+        offset = end;
+    }
+
+    let data_alignment = first_tensor.data_type.size_in_bytes().max(8);
+    let mut header_bytes = serde_json::to_vec(&header)?;
+    let padding = (data_alignment - header_bytes.len() % data_alignment) % data_alignment;
+    header_bytes.extend(std::iter::repeat_n(b' ', padding));
+
+    let header_len = u64::try_from(header_bytes.len())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "safetensors header length does not fit into u64"))?;
+    writer.write_all(&header_len.to_le_bytes())?;
+    writer.write_all(&header_bytes)?;
+    for tensor in sorted_tensors {
+        writer.write_all(tensor.data.as_ref())?;
+    }
+    Ok(())
 }

--- a/crates/backend-uzu/src/parameters/safetensors_metadata.rs
+++ b/crates/backend-uzu/src/parameters/safetensors_metadata.rs
@@ -1,6 +1,10 @@
 // This code is based on the safetensors implementation: https://docs.rs/safetensors/latest/src/safetensors/tensor.rs.html
 
-use std::{collections::HashMap, fs::File};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    fs::File,
+    io::{self, Write},
+};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -95,17 +99,21 @@ impl From<Dtype> for DataType {
     }
 }
 
-impl From<DataType> for Dtype {
-    fn from(dtype: DataType) -> Self {
+impl TryFrom<DataType> for Dtype {
+    type Error = DataType;
+
+    fn try_from(dtype: DataType) -> Result<Self, Self::Error> {
         match dtype {
-            DataType::F16 => Dtype::F16,
-            DataType::BF16 => Dtype::BF16,
-            DataType::F32 => Dtype::F32,
-            DataType::I8 => Dtype::I8,
-            DataType::I32 => Dtype::I32,
-            DataType::I64 => Dtype::I64,
-            DataType::U64 => Dtype::U64,
-            _ => panic!("Unsupported dtype: {:?}", dtype),
+            DataType::F16 => Ok(Dtype::F16),
+            DataType::BF16 => Ok(Dtype::BF16),
+            DataType::F32 => Ok(Dtype::F32),
+            DataType::I8 => Ok(Dtype::I8),
+            DataType::U8 => Ok(Dtype::U8),
+            DataType::I32 => Ok(Dtype::I32),
+            DataType::U32 => Ok(Dtype::U32),
+            DataType::I64 => Ok(Dtype::I64),
+            DataType::U64 => Ok(Dtype::U64),
+            DataType::F64 | DataType::I4 | DataType::U4 | DataType::I16 | DataType::U16 => Err(dtype),
         }
     }
 }
@@ -128,4 +136,85 @@ pub fn read_metadata(file: &File) -> Result<(usize, HashMetadata), HeaderLoading
     let metadata: HashMetadata =
         serde_json::from_str(string).map_err(|_| HeaderLoadingError::InvalidHeaderDeserialization)?;
     Ok((stop, metadata))
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SafeTensorData {
+    pub name: String,
+    pub shape: Box<[usize]>,
+    pub data_type: DataType,
+    pub data: Box<[u8]>,
+}
+
+pub fn write_safetensors<W: Write>(
+    writer: &mut W,
+    tensors: &[SafeTensorData],
+) -> Result<(), io::Error> {
+    write_safetensors_with_metadata(writer, tensors, None)
+}
+
+pub fn write_safetensors_with_metadata<W: Write>(
+    writer: &mut W,
+    tensors: &[SafeTensorData],
+    metadata: Option<&BTreeMap<String, String>>,
+) -> Result<(), io::Error> {
+    let mut sorted_tensors: Vec<&SafeTensorData> = tensors.iter().collect();
+    sorted_tensors.sort_by(|left, right| {
+        right.data_type.size_in_bytes().cmp(&left.data_type.size_in_bytes()).then_with(|| left.name.cmp(&right.name))
+    });
+    let Some(first_tensor) = sorted_tensors.first() else {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, "safetensors requires at least one tensor"));
+    };
+
+    let mut header = serde_json::Map::new();
+    if let Some(metadata) = metadata {
+        header.insert("__metadata__".to_string(), serde_json::to_value(metadata)?);
+    }
+
+    let mut offset = 0;
+    let mut names = BTreeSet::new();
+    for tensor in sorted_tensors.iter() {
+        if tensor.name == "__metadata__" {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "__metadata__ is reserved"));
+        }
+        if !names.insert(tensor.name.as_str()) {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "duplicate safetensors tensor name"));
+        }
+        let dtype = Dtype::try_from(tensor.data_type)
+            .map_err(|dtype| io::Error::new(io::ErrorKind::InvalidInput, format!("unsupported dtype: {dtype:?}")))?;
+        let expected_len = tensor
+            .shape
+            .iter()
+            .try_fold(tensor.data_type.size_in_bytes(), |size, dim| size.checked_mul(*dim))
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidInput, "safetensors tensor byte size overflows usize")
+            })?;
+        if expected_len != tensor.data.len() {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "safetensors tensor shape does not match data"));
+        }
+        let end = offset + tensor.data.len();
+        header.insert(
+            tensor.name.clone(),
+            serde_json::to_value(TensorInfo {
+                dtype,
+                shape: tensor.shape.to_vec(),
+                data_offsets: (offset, end),
+            })?,
+        );
+        offset = end;
+    }
+
+    let data_alignment = first_tensor.data_type.size_in_bytes().max(8);
+    let mut header_bytes = serde_json::to_vec(&header)?;
+    let padding = (data_alignment - header_bytes.len() % data_alignment) % data_alignment;
+    header_bytes.extend(std::iter::repeat_n(b' ', padding));
+
+    let header_len = u64::try_from(header_bytes.len())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "safetensors header length does not fit into u64"))?;
+    writer.write_all(&header_len.to_le_bytes())?;
+    writer.write_all(&header_bytes)?;
+    for tensor in sorted_tensors {
+        writer.write_all(&tensor.data)?;
+    }
+    Ok(())
 }

--- a/crates/backend-uzu/src/session/types/error.rs
+++ b/crates/backend-uzu/src/session/types/error.rs
@@ -177,6 +177,8 @@ pub enum Error {
     InvalidTtsRunConfig(#[from] TtsRunConfigError),
     #[error("Unable to load model weights: {0}")]
     UnableToLoadWeights(#[source] Box<dyn std::error::Error>),
+    #[error("Unable to write trace: {0}")]
+    UnableToWriteTrace(#[source] Box<dyn std::error::Error>),
     #[error("Unable to create decoder: {0}")]
     UnableToCreateDecoder(#[source] Box<dyn std::error::Error>),
     #[error("Unable to create classifier layer: {0}")]

--- a/crates/backend-uzu/src/session/types/error.rs
+++ b/crates/backend-uzu/src/session/types/error.rs
@@ -178,6 +178,8 @@ pub enum Error {
     InvalidTtsRunConfig(#[from] TtsRunConfigError),
     #[error("Unable to load model weights")]
     UnableToLoadWeights,
+    #[error("Unable to write trace")]
+    UnableToWriteTrace,
     #[error("Unable to load tokenizer")]
     UnableToLoadTokenizer,
     #[error("Model is too large to fit into available RAM")]

--- a/crates/backend-uzu/tests/integration/parameters/safetensors_metadata_test.rs
+++ b/crates/backend-uzu/tests/integration/parameters/safetensors_metadata_test.rs
@@ -1,8 +1,86 @@
-use std::fs::File;
+use std::{borrow::Cow, collections::BTreeMap, fs::File};
 
-use backend_uzu::parameters::read_safetensors_metadata;
+use backend_uzu::{
+    array::{Array, ArrayContextExt},
+    backends::{
+        common::{Backend, Context},
+        cpu::Cpu,
+    },
+    data_type::DataType,
+    parameters::{
+        ParameterLoader, SafeTensorData, read_safetensors_metadata, write_safetensors, write_safetensors_with_metadata,
+    },
+};
 
 use crate::common::path::get_test_weights_path;
+
+fn tensor_from_array<'data, B: Backend>(
+    name: &str,
+    array: &'data Array<B>,
+) -> SafeTensorData<'data> {
+    SafeTensorData {
+        name: name.to_string(),
+        shape: array.shape().into(),
+        data_type: array.data_type(),
+        data: Cow::Borrowed(array.as_bytes()),
+    }
+}
+
+#[test]
+fn test_safetensors_metadata_writer_rejects_empty_tensors() {
+    let mut bytes = Vec::new();
+    let err = write_safetensors(&mut bytes, &[]).expect_err("empty safetensors should fail");
+
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+}
+
+#[test]
+fn test_safetensors_metadata_writer_rejects_shape_data_mismatch() {
+    let mut bytes = Vec::new();
+    let err = write_safetensors(
+        &mut bytes,
+        &[SafeTensorData {
+            name: "bad".to_string(),
+            shape: [2].into(),
+            data_type: DataType::F32,
+            data: Cow::Owned(vec![0; 4]),
+        }],
+    )
+    .expect_err("shape mismatch should fail");
+
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+}
+
+#[test]
+fn test_safetensors_metadata_writer_rejects_duplicate_names() {
+    let mut bytes = Vec::new();
+    let tensor = SafeTensorData {
+        name: "duplicate".to_string(),
+        shape: [1].into(),
+        data_type: DataType::I32,
+        data: Cow::Owned(vec![0; 4]),
+    };
+    let err = write_safetensors(&mut bytes, &[tensor.clone(), tensor]).expect_err("duplicate names should fail");
+
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+}
+
+#[test]
+fn test_safetensors_metadata_writer_rejects_metadata_tensor_name() {
+    let mut bytes = Vec::new();
+    let err = write_safetensors(
+        &mut bytes,
+        &[SafeTensorData {
+            name: "__metadata__".to_string(),
+            shape: [1].into(),
+            data_type: DataType::I32,
+            data: Cow::Owned(vec![0; 4]),
+        }],
+    )
+    .expect_err("__metadata__ tensor name should fail");
+
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+}
 
 #[test]
 fn test_metadata_loading() {
@@ -10,4 +88,56 @@ fn test_metadata_loading() {
     let file = File::open(&path).expect("weights not found");
     let (_offset, metadata) = read_safetensors_metadata(&file).expect("read metadata");
     assert!(!metadata.tensors.is_empty());
+}
+
+#[test]
+fn test_safetensors_metadata_writer_roundtrips_arrays() {
+    let context = <Cpu as Backend>::Context::new().expect("create CPU context");
+    let floats = context.create_array_from(&[2, 2], &[1.0f32, 2.0, 3.0, 4.0]);
+    let doubles = context.create_array_from(&[2], &[1.25f64, -2.5]);
+    let i16s = context.create_array_from(&[2], &[7i16, -9]);
+    let u16s = context.create_array_from(&[2], &[7u16, 9]);
+    let ints = context.create_array_from(&[2], &[7i32, 9]);
+    let mut file = tempfile::NamedTempFile::new().expect("create safetensors file");
+
+    write_safetensors(
+        file.as_file_mut(),
+        &[
+            tensor_from_array("floats", &floats),
+            tensor_from_array("doubles", &doubles),
+            tensor_from_array("i16s", &i16s),
+            tensor_from_array("u16s", &u16s),
+            tensor_from_array("ints", &ints),
+        ],
+    )
+    .expect("write safetensors file");
+
+    let loader_file = file.reopen().expect("open safetensors file");
+    let loader = ParameterLoader::<Cpu>::new(&loader_file, context.as_ref()).expect("create loader");
+    let floats = loader.tree().leaf("floats").unwrap().validate(&[2, 2], DataType::F32).unwrap().read_array().unwrap();
+    let doubles = loader.tree().leaf("doubles").unwrap().validate(&[2], DataType::F64).unwrap().read_array().unwrap();
+    let i16s = loader.tree().leaf("i16s").unwrap().validate(&[2], DataType::I16).unwrap().read_array().unwrap();
+    let u16s = loader.tree().leaf("u16s").unwrap().validate(&[2], DataType::U16).unwrap().read_array().unwrap();
+    let ints = loader.tree().leaf("ints").unwrap().validate(&[2], DataType::I32).unwrap().read_array().unwrap();
+    assert_eq!(floats.as_slice::<f32>(), &[1.0, 2.0, 3.0, 4.0]);
+    assert_eq!(doubles.as_slice::<f64>(), &[1.25, -2.5]);
+    assert_eq!(i16s.as_slice::<i16>(), &[7, -9]);
+    assert_eq!(u16s.as_slice::<u16>(), &[7, 9]);
+    assert_eq!(ints.as_slice::<i32>(), &[7, 9]);
+}
+
+#[test]
+fn test_safetensors_metadata_writer_roundtrips_metadata() {
+    let context = <Cpu as Backend>::Context::new().expect("create CPU context");
+    let ints = context.create_array_from(&[2], &[7i32, 9]);
+    let mut metadata = BTreeMap::new();
+    metadata.insert("rendered_request".to_string(), "trace".to_string());
+    let mut file = tempfile::NamedTempFile::new().expect("create safetensors file");
+
+    write_safetensors_with_metadata(file.as_file_mut(), &[tensor_from_array("ints", &ints)], Some(&metadata))
+        .expect("write safetensors file");
+
+    let loader_file = file.reopen().expect("open safetensors file");
+    let (_offset, loaded_metadata) = read_safetensors_metadata(&loader_file).expect("read metadata");
+    assert_eq!(loaded_metadata.metadata.unwrap()["rendered_request"], "trace");
 }

--- a/crates/backend-uzu/tests/integration/parameters/safetensors_metadata_test.rs
+++ b/crates/backend-uzu/tests/integration/parameters/safetensors_metadata_test.rs
@@ -1,8 +1,83 @@
-use std::fs::File;
+use std::{collections::BTreeMap, fs::File};
 
-use backend_uzu::read_safetensors_metadata;
+use backend_uzu::{
+    ArrayContextExt, DataType, ParameterLoader, SafeTensorData,
+    backends::{
+        common::{Backend, Context, allocation_as_bytes},
+        cpu::Cpu,
+    },
+    read_safetensors_metadata, write_safetensors, write_safetensors_with_metadata,
+};
 
 use crate::common::path::get_test_weights_path;
+
+fn tensor_from_array<B: Backend>(
+    name: &str,
+    array: &backend_uzu::Array<B>,
+) -> SafeTensorData {
+    SafeTensorData {
+        name: name.to_string(),
+        shape: array.shape().into(),
+        data_type: array.data_type(),
+        data: allocation_as_bytes(array.allocation()).into(),
+    }
+}
+
+#[test]
+fn test_safetensors_metadata_writer_rejects_empty_tensors() {
+    let mut bytes = Vec::new();
+    let err = write_safetensors(&mut bytes, &[]).expect_err("empty safetensors should fail");
+
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+}
+
+#[test]
+fn test_safetensors_metadata_writer_rejects_shape_data_mismatch() {
+    let mut bytes = Vec::new();
+    let err = write_safetensors(
+        &mut bytes,
+        &[SafeTensorData {
+            name: "bad".to_string(),
+            shape: [2].into(),
+            data_type: DataType::F32,
+            data: vec![0; 4].into_boxed_slice(),
+        }],
+    )
+    .expect_err("shape mismatch should fail");
+
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+}
+
+#[test]
+fn test_safetensors_metadata_writer_rejects_duplicate_names() {
+    let mut bytes = Vec::new();
+    let tensor = SafeTensorData {
+        name: "duplicate".to_string(),
+        shape: [1].into(),
+        data_type: DataType::I32,
+        data: vec![0; 4].into_boxed_slice(),
+    };
+    let err = write_safetensors(&mut bytes, &[tensor.clone(), tensor]).expect_err("duplicate names should fail");
+
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+}
+
+#[test]
+fn test_safetensors_metadata_writer_rejects_metadata_tensor_name() {
+    let mut bytes = Vec::new();
+    let err = write_safetensors(
+        &mut bytes,
+        &[SafeTensorData {
+            name: "__metadata__".to_string(),
+            shape: [1].into(),
+            data_type: DataType::I32,
+            data: vec![0; 4].into_boxed_slice(),
+        }],
+    )
+    .expect_err("__metadata__ tensor name should fail");
+
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+}
 
 #[test]
 fn test_metadata_loading() {
@@ -10,4 +85,36 @@ fn test_metadata_loading() {
     let file = File::open(&path).expect("weights not found");
     let (_offset, metadata) = read_safetensors_metadata(&file).expect("read metadata");
     assert!(metadata.tensors.len() > 0);
+}
+
+#[test]
+fn test_safetensors_metadata_writer_roundtrips_arrays() {
+    let context = <Cpu as Backend>::Context::new().expect("create CPU context");
+    let floats = context.create_array_from(&[2, 2], &[1.0f32, 2.0, 3.0, 4.0]);
+    let ints = context.create_array_from(&[2], &[7i32, 9]);
+    let mut file = tempfile::NamedTempFile::new().expect("create safetensors file");
+
+    write_safetensors(file.as_file_mut(), &[tensor_from_array("floats", &floats), tensor_from_array("ints", &ints)])
+        .expect("write safetensors file");
+
+    let loader_file = file.reopen().expect("open safetensors file");
+    let loader = ParameterLoader::new(&loader_file, context.as_ref()).expect("create loader");
+    assert_eq!(loader.tree().leaf_array("floats").unwrap().as_slice::<f32>(), &[1.0, 2.0, 3.0, 4.0]);
+    assert_eq!(loader.tree().leaf_array("ints").unwrap().as_slice::<i32>(), &[7, 9]);
+}
+
+#[test]
+fn test_safetensors_metadata_writer_roundtrips_metadata() {
+    let context = <Cpu as Backend>::Context::new().expect("create CPU context");
+    let ints = context.create_array_from(&[2], &[7i32, 9]);
+    let mut metadata = BTreeMap::new();
+    metadata.insert("rendered_request".to_string(), "trace".to_string());
+    let mut file = tempfile::NamedTempFile::new().expect("create safetensors file");
+
+    write_safetensors_with_metadata(file.as_file_mut(), &[tensor_from_array("ints", &ints)], Some(&metadata))
+        .expect("write safetensors file");
+
+    let loader_file = file.reopen().expect("open safetensors file");
+    let (_offset, loaded_metadata) = read_safetensors_metadata(&loader_file).expect("read metadata");
+    assert_eq!(loaded_metadata.metadata.unwrap()["rendered_request"], "trace");
 }

--- a/crates/backend-uzu/tests/integration/tracer/trace_validator.rs
+++ b/crates/backend-uzu/tests/integration/tracer/trace_validator.rs
@@ -1,247 +1,63 @@
-//! Unified trace validation for any model type (LLM or classifier).
-//!
-//! This module provides a single `TraceValidator` that can validate activation
-//! traces for any model type. It automatically detects the model type from the
-//! config and runs the appropriate validation.
-
 use std::{
+    borrow::Cow,
     cell::RefCell,
-    collections::HashMap,
+    collections::BTreeMap,
     fs::File,
-    io::BufReader,
     path::{Path, PathBuf},
     rc::Rc,
 };
 
 use backend_uzu::{
     _private::{
-        ActivationTrace, AnyModelConfig, CacheLayers, Classifier, DecoderDecodeInput, KVCacheLayer,
-        LanguageModelGeneratorContext, TokenInputs,
+        ActivationTrace, AnyModelConfig, AnyTokenCodecConfig, CacheLayers, Classifier, DecoderDecodeInput,
+        KVCacheLayer, LanguageModelGeneratorContext, TokenInputs, TransformerLayerConfig,
     },
-    array::{Array, ArrayElement},
-    backends::common::{Allocation, AllocationType, Backend, Context, Encoder},
+    array::{Array, ArrayContextExt, ArrayElement, size_for_shape},
+    backends::common::{AsBufferRangeRef, Backend, Buffer, Encoder},
     data_type::DataType,
-    parameters::{ParameterLoader, ParameterLoaderError, ParameterTree, read_safetensors_metadata},
+    parameters::{
+        HashMetadata, ParameterLoader, ParameterTree, SafeTensorData, read_safetensors_metadata,
+        write_safetensors_with_metadata,
+    },
     session::{
         config::{DecodingConfig, SpeculatorConfig},
+        helpers::{InputProcessor, InputProcessorDefault},
         parameter::{AsyncBatchSize, ConfigResolvableValue, ContextLength, ContextMode, PrefillStepSize, SamplingSeed},
-        types::Error,
+        types::{Error, Input, Message},
     },
 };
-use half::{bf16, f16};
-use ndarray::{ArrayView, IxDyn, s};
 use num_traits::NumCast;
-
-use crate::common;
-
-fn argmax<T: ArrayElement>(input: &[T]) -> usize {
-    input
-        .iter()
-        .enumerate()
-        .fold((0, f32::NEG_INFINITY), |(best_index, best_value), (index, &value)| {
-            let value_f32 = NumCast::from(value).unwrap_or(f32::NEG_INFINITY);
-            if value_f32 > best_value || (value_f32 == best_value && index < best_index) {
-                (index, value_f32)
-            } else {
-                (best_index, best_value)
-            }
-        })
-        .0
-}
-
-fn sample_argmax<T: ArrayElement>(logits: ArrayView<T, IxDyn>) -> Vec<u64> {
-    let mut result = Vec::with_capacity(logits.shape()[0]);
-    for row in logits.rows() {
-        let max_index = if let Some(slice) = row.as_slice_memory_order() {
-            argmax(slice)
-        } else {
-            let data: Vec<T> = row.iter().copied().collect();
-            argmax(&data)
-        };
-        result.push(max_index as u64);
-    }
-    result
-}
-// ============================================================================
-// Validation Types
-// ============================================================================
-
-/// Metrics from validating a single tensor.
-pub struct TracerValidationMetrics {
-    pub atol: f32,
-    pub rtol: f32,
-    #[allow(unused)]
-    pub fraction_of_allowed_violations: f32,
-    pub reference_shape: Vec<usize>,
-    pub result_shape: Vec<usize>,
-    pub num_violations: usize,
-    pub max_allowed_violations: usize,
-    pub max_err_idx: usize,
-    pub max_err: f32,
-    pub max_err_rel: f32,
-    pub max_err_reference_value: f32,
-    pub rms_diff: f32,
-    pub rms_result: f32,
-    pub rms_reference: f32,
-    pub rel_rms_reference: f32,
-    pub diff_max: f32,
-    pub diff_avg: f32,
-    pub result_nan: bool,
-}
-
-impl TracerValidationMetrics {
-    pub fn is_valid(&self) -> bool {
-        self.num_violations <= self.max_allowed_violations && !self.result_nan
-    }
-
-    pub fn message(&self) -> String {
-        if self.result_nan {
-            return "Result contains NaN values".to_string();
-        }
-
-        let allowed_violation_explainer = if self.max_allowed_violations > 0 {
-            format!(" (Max {} allowed)", self.max_allowed_violations)
-        } else {
-            String::new()
-        };
-
-        let reference_size: usize = self.reference_shape.iter().product();
-
-        format!(
-            "{} violations > {:.1e} + {:.2}% out of total {} elements{}.\n\
-            Worst violation: {:.3} ({:.2}%) at index {} (reference value: {:.3}).\n\
-            Error RMS: {:.3}.\n\
-            RMS of result: {:.3}, RMS of reference: {:.3}.\n\
-            Relative error RMS: {:.2}% of RMS of reference.\n\
-            Shape: {:?}\n\
-            Max diff: {:.3}, Avg diff: {:.3}",
-            self.num_violations,
-            self.atol,
-            self.rtol * 100.0,
-            reference_size,
-            allowed_violation_explainer,
-            self.max_err,
-            self.max_err_rel * 100.0,
-            self.max_err_idx,
-            self.max_err_reference_value,
-            self.rms_diff,
-            self.rms_result,
-            self.rms_reference,
-            self.rel_rms_reference * 100.0,
-            self.result_shape,
-            self.diff_max,
-            self.diff_avg,
-        )
-    }
-}
-
-/// Result of validating a single tensor.
-pub struct TracerValidationResult {
-    pub name: String,
-    pub metrics: TracerValidationMetrics,
-}
-
-/// Results from validating all traces.
-pub struct TracerValidationResults {
-    pub suffix_length: usize,
-    pub results: Vec<TracerValidationResult>,
-    pub tokens_violation_indices: Vec<usize>,
-}
-
-impl TracerValidationResults {
-    pub fn number_of_tokens_violations(&self) -> usize {
-        self.tokens_violation_indices.len()
-    }
-
-    pub fn number_of_allowed_tokens_violations(&self) -> usize {
-        let threshold: f64 = 0.01;
-        (self.suffix_length as f64 * threshold).ceil() as usize
-    }
-}
-
-/// Transform to apply to produced arrays before comparison.
-pub enum ArrayTransform {
-    /// Slice KV cache to match expected shape.
-    KVCacheSlice,
-    /// Transform SSM conv state layout.
-    SsmConvState,
-}
-
-// ============================================================================
-// Model Context (internal)
-// ============================================================================
+use serde_json::json;
+use tokenizers::Tokenizer;
 
 #[derive(Clone, Copy)]
-struct LayerTraceRequirements {
-    post_mixer_norm: bool,
-    post_mlp_norm: bool,
+enum ExportShape {
+    Native,
+    Batched,
 }
 
 enum ModelContext<B: Backend> {
-    LanguageModelGenerator {
-        context: LanguageModelGeneratorContext<B>,
-        layer_trace_requirements: Box<[LayerTraceRequirements]>,
-    },
-    Classifier {
-        classifier: Classifier<B>,
-        layer_trace_requirements: Box<[LayerTraceRequirements]>,
-    },
+    LanguageModelGenerator(LanguageModelGeneratorContext<B>),
+    Classifier(Classifier<B>),
 }
 
-// ============================================================================
-// Unified TraceValidator
-// ============================================================================
-
-/// Unified trace validator for any model type.
-///
-/// Automatically detects whether the model is an LLM or classifier and
-/// runs the appropriate validation.
 pub struct TraceValidator<B: Backend> {
     model_path: PathBuf,
     context: ModelContext<B>,
 }
 
 impl<B: Backend> TraceValidator<B> {
-    /// Create a new trace validator for the given model path.
-    ///
-    /// Automatically detects the model type from config.json.
     pub fn new(model_path: &Path) -> Result<Self, Error> {
         if !model_path.exists() {
             return Err(Error::ModelFolderNotFound);
         }
 
-        let config_path = model_path.join("config.json");
-        let config_file = File::open(&config_path)?;
-        let model_config: AnyModelConfig = serde_json::from_reader(BufReader::new(config_file))?;
-
+        let model_config = load_model_config(model_path)?;
         let context = match model_config {
             AnyModelConfig::ClassifierModelConfig(model_config) => {
-                let layer_trace_requirements = model_config
-                    .classifier_config
-                    .transformer_config
-                    .layer_configs
-                    .iter()
-                    .map(|layer_config| LayerTraceRequirements {
-                        post_mixer_norm: layer_config.post_mixer_norm_config.is_some(),
-                        post_mlp_norm: layer_config.post_mlp_norm_config.is_some(),
-                    })
-                    .collect();
-                ModelContext::Classifier {
-                    classifier: Classifier::new(model_path, &model_config)?,
-                    layer_trace_requirements,
-                }
+                ModelContext::Classifier(Classifier::new(model_path, &model_config)?)
             },
             AnyModelConfig::LanguageModelConfig(model_config) => {
-                let layer_trace_requirements = model_config
-                    .decoder_config
-                    .transformer_config
-                    .layer_configs
-                    .iter()
-                    .map(|layer_config| LayerTraceRequirements {
-                        post_mixer_norm: layer_config.post_mixer_norm_config.is_some(),
-                        post_mlp_norm: layer_config.post_mlp_norm_config.is_some(),
-                    })
-                    .collect();
                 let prefill_step_size = Self::determine_prefill_step_size(model_path)?;
                 let decoding_config = DecodingConfig::new(
                     ContextMode::default(),
@@ -254,13 +70,10 @@ impl<B: Backend> TraceValidator<B> {
                 let mut llm_context = LanguageModelGeneratorContext::new(model_path, &decoding_config, &model_config)?;
                 let desired_suffix_length = prefill_step_size.max(decoding_config.generate_suffix_length());
                 Self::ensure_llm_context_capacity(&decoding_config, desired_suffix_length, &mut llm_context);
-                ModelContext::LanguageModelGenerator {
-                    context: llm_context,
-                    layer_trace_requirements,
-                }
+                ModelContext::LanguageModelGenerator(llm_context)
             },
             AnyModelConfig::TTSModelConfig(_) => {
-                return Err(Error::InvalidModelConfig("TTS trace validation is not supported".to_string()));
+                return Err(Error::InvalidModelConfig("TTS trace export is not supported".to_string()));
             },
         };
 
@@ -270,74 +83,88 @@ impl<B: Backend> TraceValidator<B> {
         })
     }
 
-    /// Run trace validation and return results.
-    pub fn run(&mut self) -> Result<TracerValidationResults, Error> {
+    pub fn export_trace(
+        &mut self,
+        output_path: &Path,
+    ) -> Result<(), Error> {
         let traces_path = self.model_path.join("traces.safetensors");
         match &mut self.context {
-            ModelContext::LanguageModelGenerator {
-                context,
-                layer_trace_requirements,
-            } => Self::run_llm_validation(context, layer_trace_requirements, &traces_path),
-            ModelContext::Classifier {
-                classifier,
-                layer_trace_requirements,
-            } => Self::run_classifier_validation(classifier, layer_trace_requirements, &traces_path),
+            ModelContext::LanguageModelGenerator(ctx) => Self::export_llm_trace(ctx, &traces_path, output_path),
+            ModelContext::Classifier(classifier) => {
+                Self::export_classifier_trace(classifier, &traces_path, output_path)
+            },
         }
     }
 
-    // ========================================================================
-    // LLM Validation
-    // ========================================================================
-
-    fn run_llm_validation(
+    fn export_llm_trace(
         ctx: &LanguageModelGeneratorContext<B>,
-        layer_trace_requirements: &[LayerTraceRequirements],
         traces_path: &Path,
-    ) -> Result<TracerValidationResults, Error> {
+        output_path: &Path,
+    ) -> Result<(), Error> {
         let traces_file = File::open(traces_path).map_err(|error| Error::UnableToLoadWeights(Box::new(error)))?;
-        let (_header_len, traces_metadata) =
+        let (_offset, traces_header) =
             read_safetensors_metadata(&traces_file).map_err(|error| Error::UnableToLoadWeights(Box::new(error)))?;
-        let trace_shapes: HashMap<String, Vec<usize>> =
-            traces_metadata.tensors.iter().map(|(name, tensor)| (name.clone(), tensor.shape.clone())).collect();
-        let token_shape = Self::trace_shape(&trace_shapes, "activation_trace.token_ids");
-        let position_shape = Self::trace_shape(&trace_shapes, "activation_trace.token_positions");
-        let suffix_length = Self::trace_token_count("activation_trace.token_ids", token_shape);
-        assert_eq!(
-            Self::trace_token_count("activation_trace.token_positions", position_shape),
-            suffix_length,
-            "trace token ids and token positions must have the same suffix length"
-        );
-
+        let token_ids_shape = trace_tensor_shape(&traces_header, "activation_trace.token_ids")?;
+        let token_positions_shape = trace_tensor_shape(&traces_header, "activation_trace.token_positions")?;
+        let input_metadata = traces_header.metadata.clone().map(|values| values.into_iter().collect());
         let traces_loader = ParameterLoader::new(&traces_file, ctx.context.as_ref())
             .map_err(|error| Error::UnableToLoadWeights(Box::new(error)))?;
         let traces_view = traces_loader.tree();
+        let (token_ids_array, token_positions_array, token_ids, token_positions) =
+            Self::load_trace_inputs(&traces_view, &token_ids_shape, &token_positions_shape)?;
+        let traces = Self::run_llm_trace(ctx, &token_ids, &token_positions)?;
+        let cache_state_arrays = {
+            let cache_layers = ctx.cache_layers.borrow();
+            Self::cache_state_arrays(ctx.context.as_ref(), &cache_layers, &traces_header)?
+        };
 
-        let token_ids = Self::load_array_as_vec::<i32, u64>(&traces_view, &trace_shapes, "activation_trace.token_ids");
-        let token_positions =
-            Self::load_array_as_vec::<i32, usize>(&traces_view, &trace_shapes, "activation_trace.token_positions");
+        let mut tensors = vec![
+            Self::tensor_from_array("activation_trace.token_ids", &token_ids_array),
+            Self::tensor_from_array("activation_trace.token_positions", &token_positions_array),
+        ];
+        Self::push_activation_trace_tensors(
+            &mut tensors,
+            &traces,
+            &ctx.model_config.decoder_config.transformer_config.layer_configs,
+            ExportShape::Batched,
+        );
+        for (path, array) in &cache_state_arrays {
+            tensors.push(Self::tensor_from_array(path, array));
+        }
+        Self::write_trace_file(output_path, &tensors, input_metadata.as_ref())
+    }
+
+    fn run_llm_trace(
+        ctx: &LanguageModelGeneratorContext<B>,
+        token_ids: &[u64],
+        token_positions: &[usize],
+    ) -> Result<ActivationTrace<B>, Error> {
         let token_inputs = TokenInputs::new_llm(
             ctx.context.as_ref(),
             &ctx.model_shape,
-            &token_ids,
+            token_ids,
             None,
-            &token_positions,
+            token_positions,
             None,
             None,
             /*sampling_start=*/ 0,
-            /*sampling_length=*/ suffix_length,
+            /*sampling_length=*/ token_ids.len(),
         );
-        let mut traces = ActivationTrace::new_llm(ctx.context.as_ref(), &ctx.model_shape, suffix_length);
+        let mut traces = ActivationTrace::new_llm(ctx.context.as_ref(), &ctx.model_shape, token_ids.len());
 
-        let mut encoder =
-            Encoder::<B>::new(ctx.context.as_ref()).map_err(|e| Error::UnableToCreateCommandBuffer(e.into()))?;
+        ctx.cache_layers.borrow_mut().clear(ctx.context.as_ref());
+
+        let mut encoder = Encoder::<B>::new(ctx.context.as_ref())
+            .map_err(|error| Error::UnableToCreateCommandBuffer(error.into()))?;
         {
             let mut cache_layers = ctx.cache_layers.borrow_mut();
+            cache_layers.prepare_for_forward_pass(ctx.context.as_ref(), token_ids.len());
             let decoder_arguments = token_inputs.decoder_arguments(
                 ctx.shared_buffers.as_ref(),
                 Some(&mut *cache_layers),
-                suffix_length,
+                token_ids.len(),
                 /*sampling_start=*/ 0,
-                /*sampling_length=*/ suffix_length,
+                /*sampling_length=*/ token_ids.len(),
                 #[cfg(feature = "tracing")]
                 Some(&mut traces),
             );
@@ -348,652 +175,508 @@ impl<B: Backend> TraceValidator<B> {
                     None,
                     &mut encoder,
                 )
-                .map_err(|e| Error::EncodeFailed(Box::new(e)))?;
-        }
-        let pending = encoder.end_encoding().submit();
-        pending.wait_until_completed().map_err(|e| Error::CommandBufferFailed(Box::new(e)))?;
-
-        // Common layer validation
-        let mut results = Self::validate_layer_traces(
-            &traces,
-            &traces_view,
-            &trace_shapes,
-            ctx.model_shape.data_type,
-            layer_trace_requirements,
-        );
-
-        // LLM-specific state validation
-        let cache = ctx.cache_layers.borrow();
-        for (index, layer) in cache.iter_layers() {
-            if let Some(kv) = layer.as_transformer() {
-                let shape = kv.shape();
-                let keys_path = format!("activation_trace.layer_results.{}.updated_state.keys", index);
-                let expected =
-                    Self::read_required_array(&traces_view, &trace_shapes, &keys_path, ctx.model_shape.data_type);
-                let size = shape.iter().product::<usize>() * ctx.model_shape.data_type.size_in_bytes();
-                let keys = if let Some(layer) = kv.as_any().downcast_ref::<KVCacheLayer<B, B::SparseBuffer>>() {
-                    common::helpers::sparse_buffer_read_allocation(ctx.context.as_ref(), &layer.keys, size)
-                } else if let Some(layer) = kv.as_any().downcast_ref::<KVCacheLayer<B, B::DenseBuffer>>() {
-                    let mut allocation = ctx
-                        .context
-                        .create_allocation(size, AllocationType::Global)
-                        .expect("Failed to create KV cache keys read allocation");
-                    let mut encoder =
-                        Encoder::<B>::new(ctx.context.as_ref()).expect("Failed to create KV cache keys read encoder");
-                    encoder.encode_copy(&layer.keys, 0..size, &mut allocation, 0..size);
-                    encoder.end_encoding().submit().wait_until_completed().expect("Failed to read KV cache keys");
-                    allocation
-                } else {
-                    panic!("Wrong keys type")
-                };
-                results.push(TracerValidationResult {
-                    name: keys_path,
-                    metrics: Self::validate_allocation(
-                        ctx.model_shape.data_type,
-                        &expected,
-                        &keys,
-                        &shape,
-                        Some(ArrayTransform::KVCacheSlice),
-                    ),
-                });
-
-                let values_path = format!("activation_trace.layer_results.{}.updated_state.values", index);
-                let expected =
-                    Self::read_required_array(&traces_view, &trace_shapes, &values_path, ctx.model_shape.data_type);
-                let values = if let Some(layer) = kv.as_any().downcast_ref::<KVCacheLayer<B, B::SparseBuffer>>() {
-                    common::helpers::sparse_buffer_read_allocation(ctx.context.as_ref(), &layer.values, size)
-                } else if let Some(layer) = kv.as_any().downcast_ref::<KVCacheLayer<B, B::DenseBuffer>>() {
-                    let mut allocation = ctx
-                        .context
-                        .create_allocation(size, AllocationType::Global)
-                        .expect("Failed to create KV cache values read allocation");
-                    let mut encoder =
-                        Encoder::<B>::new(ctx.context.as_ref()).expect("Failed to create KV cache values read encoder");
-                    encoder.encode_copy(&layer.values, 0..size, &mut allocation, 0..size);
-                    encoder.end_encoding().submit().wait_until_completed().expect("Failed to read KV cache values");
-                    allocation
-                } else {
-                    panic!("Wrong values type")
-                };
-                results.push(TracerValidationResult {
-                    name: values_path,
-                    metrics: Self::validate_allocation(
-                        ctx.model_shape.data_type,
-                        &expected,
-                        &values,
-                        &shape,
-                        Some(ArrayTransform::KVCacheSlice),
-                    ),
-                });
-            } else if let Some(ssm) = layer.as_state_space() {
-                let conv_path = format!("activation_trace.layer_results.{}.updated_state.conv_state", index);
-                let expected =
-                    Self::read_required_array(&traces_view, &trace_shapes, &conv_path, ctx.model_shape.data_type);
-                let conv_state = ssm.conv_state.as_ref().expect("SSM trace requires a produced conv state");
-                results.push(TracerValidationResult {
-                    name: conv_path,
-                    metrics: Self::validate_allocation(
-                        ctx.model_shape.data_type,
-                        &expected,
-                        conv_state,
-                        &ssm.conv_shape,
-                        Some(ArrayTransform::SsmConvState),
-                    ),
-                });
-
-                let ssm_path = format!("activation_trace.layer_results.{}.updated_state.ssm_state", index);
-                let expected =
-                    Self::read_required_array(&traces_view, &trace_shapes, &ssm_path, ctx.model_shape.data_type);
-                results.push(TracerValidationResult {
-                    name: ssm_path,
-                    metrics: Self::validate_allocation(
-                        ctx.model_shape.data_type,
-                        &expected,
-                        &ssm.ssm_state,
-                        &ssm.ssm_shape,
-                        None,
-                    ),
-                });
-            } else if let Some(delta) = layer.as_delta_net() {
-                let conv_path = format!("activation_trace.layer_results.{}.updated_state.conv_state", index);
-                let expected =
-                    Self::read_required_array(&traces_view, &trace_shapes, &conv_path, ctx.model_shape.data_type);
-                results.push(TracerValidationResult {
-                    name: conv_path,
-                    metrics: Self::validate_allocation(
-                        ctx.model_shape.data_type,
-                        &expected,
-                        &delta.conv_state,
-                        &delta.conv_shape,
-                        Some(ArrayTransform::SsmConvState),
-                    ),
-                });
-
-                let ssm_path = format!("activation_trace.layer_results.{}.updated_state.ssm_state", index);
-                let expected =
-                    Self::read_required_array(&traces_view, &trace_shapes, &ssm_path, ctx.model_shape.data_type);
-                results.push(TracerValidationResult {
-                    name: ssm_path,
-                    metrics: Self::validate_allocation(
-                        ctx.model_shape.data_type,
-                        &expected,
-                        &delta.ssm_state,
-                        &delta.ssm_shape,
-                        None,
-                    ),
-                });
-            } else if let Some(short_conv) = layer.as_short_conv() {
-                let conv_path = format!("activation_trace.layer_results.{}.updated_state.conv_state", index);
-                let expected =
-                    Self::read_required_array(&traces_view, &trace_shapes, &conv_path, ctx.model_shape.data_type);
-                results.push(TracerValidationResult {
-                    name: conv_path,
-                    metrics: Self::validate_allocation(
-                        ctx.model_shape.data_type,
-                        &expected,
-                        &short_conv.conv_state,
-                        &short_conv.conv_shape,
-                        Some(ArrayTransform::SsmConvState),
-                    ),
-                });
-            } else {
-                panic!("Unsupported cache layer type at layer {index}");
+                .map_err(|error| Error::EncodeFailed(Box::new(error)))?;
+            if token_ids.len() > 1 {
+                cache_layers.commit_short_conv_suffix_states(token_ids.len() - 1, &mut encoder);
             }
         }
-
-        // LLM-specific: Token comparison
-        let expected_logits =
-            Self::read_required_array(&traces_view, &trace_shapes, "logits", ctx.model_shape.data_type);
-        let expected_tokens = Self::get_tokens_from_logits(&expected_logits);
-        let produced_tokens = Self::get_tokens_from_logits(&traces.logits);
-        let tokens_violation_indices = expected_tokens
-            .iter()
-            .zip(produced_tokens.iter())
-            .enumerate()
-            .filter_map(|(i, (a, b))| {
-                if a != b {
-                    Some(i)
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        traces_view.assert_all_tensors_validated().unwrap_or_else(|error| {
-            panic!("Trace contains tensors that Uzu tracer did not validate: {error}");
-        });
-
-        Ok(TracerValidationResults {
-            suffix_length,
-            results,
-            tokens_violation_indices,
-        })
+        let pending = encoder.end_encoding().submit();
+        pending.wait_until_completed().map_err(|error| Error::CommandBufferFailed(Box::new(error)))?;
+        Ok(traces)
     }
 
-    // ========================================================================
-    // Classifier Validation
-    // ========================================================================
-
-    fn run_classifier_validation(
+    fn export_classifier_trace(
         classifier: &mut Classifier<B>,
-        layer_trace_requirements: &[LayerTraceRequirements],
         traces_path: &Path,
-    ) -> Result<TracerValidationResults, Error> {
+        output_path: &Path,
+    ) -> Result<(), Error> {
         let traces_file = File::open(traces_path).map_err(|error| Error::UnableToLoadWeights(Box::new(error)))?;
-        let (_header_len, traces_metadata) =
+        let (_offset, traces_header) =
             read_safetensors_metadata(&traces_file).map_err(|error| Error::UnableToLoadWeights(Box::new(error)))?;
-        let trace_shapes: HashMap<String, Vec<usize>> =
-            traces_metadata.tensors.iter().map(|(name, tensor)| (name.clone(), tensor.shape.clone())).collect();
+        let token_ids_shape = trace_tensor_shape(&traces_header, "activation_trace.token_ids")?;
+        let token_positions_shape = trace_tensor_shape(&traces_header, "activation_trace.token_positions")?;
+        let input_metadata = traces_header.metadata.clone().map(|values| values.into_iter().collect());
         let context = classifier.context.context.clone();
         let traces_loader = ParameterLoader::new(&traces_file, context.as_ref())
             .map_err(|error| Error::UnableToLoadWeights(Box::new(error)))?;
         let traces_view = traces_loader.tree();
-
-        let token_shape = Self::trace_shape(&trace_shapes, "activation_trace.token_ids");
-        let position_shape = Self::trace_shape(&trace_shapes, "activation_trace.token_positions");
-        let suffix_length = Self::trace_token_count("activation_trace.token_ids", token_shape);
-        assert_eq!(
-            Self::trace_token_count("activation_trace.token_positions", position_shape),
-            suffix_length,
-            "trace token ids and token positions must have the same suffix length"
-        );
-
-        let token_ids = Self::load_array_as_vec::<i32, u64>(&traces_view, &trace_shapes, "activation_trace.token_ids");
-        let token_positions =
-            Self::load_array_as_vec::<i32, usize>(&traces_view, &trace_shapes, "activation_trace.token_positions");
-
+        let (token_ids_array, token_positions_array, token_ids, token_positions) =
+            Self::load_trace_inputs(&traces_view, &token_ids_shape, &token_positions_shape)?;
         let (_logits, traces) = classifier.forward_pass_with_traces(&token_ids, &token_positions)?;
 
-        // Common layer validation
-        let mut results = Self::validate_layer_traces(
+        let mut tensors = vec![
+            Self::tensor_from_array("activation_trace.token_ids", &token_ids_array),
+            Self::tensor_from_array("activation_trace.token_positions", &token_positions_array),
+        ];
+        Self::push_activation_trace_tensors(
+            &mut tensors,
             &traces,
-            &traces_view,
-            &trace_shapes,
-            classifier.context.model_shape.data_type,
-            layer_trace_requirements,
+            &classifier.context.model_config.classifier_config.transformer_config.layer_configs,
+            ExportShape::Batched,
         );
-
-        // Classifier-specific: embedding_norm, output_pooling
-        let classifier_results = Self::validate_classifier_traces(
-            &traces,
-            &traces_view,
-            &trace_shapes,
-            classifier.context.model_shape.data_type,
-        );
-        results.extend(classifier_results);
-        traces_view.assert_all_tensors_validated().unwrap_or_else(|error| {
-            panic!("Trace contains tensors that Uzu tracer did not validate: {error}");
-        });
-
-        Ok(TracerValidationResults {
-            suffix_length,
-            results,
-            tokens_violation_indices: Vec::new(), // Classifiers don't compare tokens
-        })
+        Self::write_trace_file(output_path, &tensors, input_metadata.as_ref())
     }
 
-    // ========================================================================
-    // Common Validation Helpers
-    // ========================================================================
-
-    fn validate_layer_traces(
-        traces: &ActivationTrace<B>,
+    fn load_trace_inputs(
         traces_view: &ParameterTree<B>,
-        trace_shapes: &HashMap<String, Vec<usize>>,
-        data_type: DataType,
-        layer_trace_requirements: &[LayerTraceRequirements],
-    ) -> Vec<TracerValidationResult> {
-        let mut results = Vec::new();
-
-        assert_eq!(
-            traces.layer_results.len(),
-            layer_trace_requirements.len(),
-            "trace layer count must match model layer count"
-        );
-
-        let validate = |path: &str, array: &Array<B>| -> TracerValidationResult {
-            let expected = Self::read_required_array(traces_view, trace_shapes, path, data_type);
-            TracerValidationResult {
-                name: path.to_string(),
-                metrics: Self::validate_allocation(data_type, &expected, array.allocation(), array.shape(), None),
-            }
-        };
-
-        for (index, layer_traces) in traces.layer_results.iter().enumerate() {
-            let requirements = layer_trace_requirements[index];
-            let path = |suffix: &str| -> String {
-                format!("activation_trace.layer_results.{}.activation_trace.{}", index, suffix)
-            };
-
-            results.push(validate(&path("inputs"), &layer_traces.inputs));
-            results.push(validate(&path("pre_mixer_norm"), &layer_traces.pre_attention_norm));
-            results.push(validate(&path("mixer"), &layer_traces.attention));
-            if requirements.post_mixer_norm {
-                results.push(validate(&path("post_mixer_norm"), &layer_traces.post_attention_norm));
-            }
-            results.push(validate(&path("mlp_inputs"), &layer_traces.mlp_inputs));
-            results.push(validate(&path("pre_mlp_norm"), &layer_traces.pre_mlp_norm));
-            results.push(validate(&path("mlp"), &layer_traces.mlp));
-            if requirements.post_mlp_norm {
-                results.push(validate(&path("post_mlp_norm"), &layer_traces.post_mlp_norm));
-            }
-
-            let outputs_path = format!("activation_trace.layer_results.{}.outputs", index);
-            results.push(validate(&outputs_path, &layer_traces.outputs));
-        }
-
-        // Output norm (common to all models)
-        results.push(validate("activation_trace.output_norm", &traces.output_norm));
-
-        // Logits live on DecoderResult/ClassifierResult, not inside activation_trace.
-        results.push(validate("logits", &traces.logits));
-
-        results
+        token_ids_shape: &[usize],
+        token_positions_shape: &[usize],
+    ) -> Result<(Array<B>, Array<B>, Vec<u64>, Vec<usize>), Error> {
+        let token_ids_array = Self::read_trace_array(traces_view, "activation_trace.token_ids", token_ids_shape)?;
+        let token_positions_array =
+            Self::read_trace_array(traces_view, "activation_trace.token_positions", token_positions_shape)?;
+        Self::validate_trace_input_shape(&token_ids_array, &token_positions_array)?;
+        let token_ids = Self::array_as_vec::<i32, u64>(&token_ids_array, "activation_trace.token_ids")?;
+        let token_positions =
+            Self::array_as_vec::<i32, usize>(&token_positions_array, "activation_trace.token_positions")?;
+        Self::validate_token_positions(&token_positions)?;
+        Ok((token_ids_array, token_positions_array, token_ids, token_positions))
     }
 
-    fn validate_classifier_traces(
-        traces: &ActivationTrace<B>,
-        traces_view: &ParameterTree<B>,
-        trace_shapes: &HashMap<String, Vec<usize>>,
-        data_type: DataType,
-    ) -> Vec<TracerValidationResult> {
-        let mut results = Vec::new();
-
-        let embedding_norm =
-            traces.embedding_norm.as_ref().expect("classifier traces must include produced embedding norm output");
-        let expected =
-            Self::read_required_array(traces_view, trace_shapes, "activation_trace.embedding_norm_output", data_type);
-        results.push(TracerValidationResult {
-            name: "activation_trace.embedding_norm_output".to_string(),
-            metrics: Self::validate_allocation(
-                data_type,
-                &expected,
-                embedding_norm.allocation(),
-                embedding_norm.shape(),
-                None,
-            ),
-        });
-
-        if let Some(output_pooling) = &traces.output_pooling {
-            let expected =
-                Self::read_required_array(traces_view, trace_shapes, "activation_trace.output_pooling", data_type);
-            results.push(TracerValidationResult {
-                name: "activation_trace.output_pooling".to_string(),
-                metrics: Self::validate_allocation(
-                    data_type,
-                    &expected,
-                    output_pooling.allocation(),
-                    output_pooling.shape(),
-                    None,
-                ),
-            });
-        } else {
-            panic!("classifier traces must include produced output pooling");
-        };
-
-        results
-    }
-
-    // ========================================================================
-    // Allocation Validation
-    // ========================================================================
-
-    fn validate_allocation(
-        data_type: DataType,
-        expected_array: &Array<B>,
-        produced_allocation: &Allocation<B>,
-        produced_shape: &[usize],
-        transform: Option<ArrayTransform>,
-    ) -> TracerValidationMetrics {
-        match data_type {
-            DataType::F16 => {
-                Self::validate_allocation_of_type::<f16>(expected_array, produced_allocation, produced_shape, transform)
-            },
-            DataType::BF16 => Self::validate_allocation_of_type::<bf16>(
-                expected_array,
-                produced_allocation,
-                produced_shape,
-                transform,
-            ),
-            DataType::F32 => {
-                Self::validate_allocation_of_type::<f32>(expected_array, produced_allocation, produced_shape, transform)
-            },
-            _ => panic!("Unsupported data type: {:?}", data_type),
-        }
-    }
-
-    fn validate_allocation_of_type<Precision: ArrayElement>(
-        expected_array: &Array<B>,
-        produced_allocation: &Allocation<B>,
-        produced_shape: &[usize],
-        transform: Option<ArrayTransform>,
-    ) -> TracerValidationMetrics {
-        let produced = produced_allocation.copyout::<Precision>();
-        Self::validate_allocation_data_of_type(expected_array, &produced, produced_shape, transform)
-    }
-
-    fn validate_allocation_data_of_type<Precision: ArrayElement>(
-        expected_array: &Array<B>,
-        produced_slice: &[Precision],
-        produced_shape: &[usize],
-        transform: Option<ArrayTransform>,
-    ) -> TracerValidationMetrics {
-        let expected_view = expected_array.as_view::<Precision>();
-        let produced_view = ndarray::ArrayView::from_shape(IxDyn(produced_shape), produced_slice)
-            .expect("Failed to reshape allocation");
-
-        let (expected_data, mut produced_data) = match transform {
-            Some(ArrayTransform::KVCacheSlice) => {
-                let expected_shape = expected_view.shape();
-                let expected_tokens = expected_view.shape()[1];
-                let sliced = produced_view.slice(s![..expected_tokens, .., ..]);
-                let reshaped = sliced
-                    .into_owned()
-                    .to_shape(IxDyn(expected_shape))
-                    .expect("Failed to reshape KV cache slice")
-                    .to_owned();
-                (expected_view.to_owned(), reshaped)
-            },
-            Some(ArrayTransform::SsmConvState) => {
-                let produced_shape = produced_view.shape();
-                let history_len = produced_shape[1];
-                let dim = produced_shape[0];
-
-                let permuted = expected_view.permuted_axes(IxDyn(&[0, 2, 1]));
-                let total_time = permuted.shape()[2];
-                let start = total_time.saturating_sub(history_len);
-                let sliced = permuted.slice(s![.., .., start..]);
-
-                let reshaped_expected = sliced
-                    .into_owned()
-                    .to_shape(IxDyn(&[dim, history_len]))
-                    .expect("Failed to reshape SSM conv state slice")
-                    .to_owned();
-
-                (reshaped_expected, produced_view.to_owned())
-            },
-            None => (expected_view.to_owned(), produced_view.to_owned()),
-        };
-
-        let expected_shape = expected_data.shape().to_vec();
-        let produced_shape = produced_data.shape().to_vec();
-
-        if expected_shape != produced_shape {
-            if expected_shape.len() == produced_shape.len() + 1
-                && expected_shape.first() == Some(&1)
-                && expected_shape[1..] == produced_shape[..]
-            {
-                produced_data = produced_data
-                    .to_shape(IxDyn(&expected_shape))
-                    .expect("Failed to reshape produced data to trace shape")
-                    .to_owned();
-            } else {
-                panic!(
-                    "Shape mismatch: expected trace shape {expected_shape:?}, produced Uzu shape {produced_shape:?}"
-                );
-            }
-        }
-
-        if expected_data.shape() != produced_data.shape() {
-            panic!(
-                "Shape mismatch after alignment: expected {:?}, produced {:?}",
-                expected_data.shape(),
-                produced_data.shape()
-            );
-        }
-
-        let reference: Vec<f32> = expected_data
-            .iter()
-            .map(|value| NumCast::from(*value).expect("Failed to cast reference trace value"))
-            .collect();
-        let result: Vec<f32> = produced_data
-            .iter()
-            .map(|value| NumCast::from(*value).expect("Failed to cast produced trace value"))
-            .collect();
-
-        let (atol, rtol, allowed_voilations_tol) = match expected_array.data_type() {
-            DataType::BF16 => (0.04, 0.06, 0.03),
-            _ => (0.01, 0.03, 0.01),
-        };
-
-        Self::compare_arrays(
-            &reference,
-            expected_data.shape().to_vec(),
-            &result,
-            produced_data.shape().to_vec(),
-            atol,
-            rtol,
-            allowed_voilations_tol,
-        )
-    }
-
-    fn compare_arrays(
-        reference: &[f32],
-        reference_shape: Vec<usize>,
-        result: &[f32],
-        result_shape: Vec<usize>,
-        atol: f32,
-        rtol: f32,
-        fraction_of_allowed_violations: f32,
-    ) -> TracerValidationMetrics {
-        assert_eq!(result.len(), reference.len());
-        if reference.is_empty() {
-            return TracerValidationMetrics {
-                atol,
-                rtol,
-                fraction_of_allowed_violations,
-                reference_shape,
-                result_shape,
-                num_violations: 0,
-                max_allowed_violations: 0,
-                max_err_idx: 0,
-                max_err: 0.0,
-                max_err_rel: 0.0,
-                max_err_reference_value: 0.0,
-                rms_diff: 0.0,
-                rms_result: 0.0,
-                rms_reference: 0.0,
-                rel_rms_reference: 0.0,
-                diff_max: 0.0,
-                diff_avg: 0.0,
-                result_nan: false,
-            };
-        }
-
-        let mut num_violations = 0;
-        let mut max_err = 0.0f32;
-        let mut max_err_idx = 0;
-        let mut max_err_rel = 0.0f32;
-        let mut max_err_reference_value = 0.0f32;
-        let mut sum_sq_diff = 0.0f32;
-        let mut sum_sq_result = 0.0f32;
-        let mut sum_sq_reference = 0.0f32;
-        let mut diff_sum = 0.0f32;
-        let mut diff_max = 0.0f32;
-        let mut result_nan = false;
-
-        for (i, (&exp, &prod)) in reference.iter().zip(result.iter()).enumerate() {
-            if prod.is_nan() {
-                result_nan = true;
-            }
-
-            let abs_diff = (exp - prod).abs();
-            let rel_diff = if exp.abs() > 1e-8 {
-                abs_diff / exp.abs()
-            } else {
-                abs_diff
-            };
-
-            diff_sum += abs_diff;
-            diff_max = diff_max.max(abs_diff);
-            sum_sq_diff += abs_diff * abs_diff;
-            sum_sq_result += prod * prod;
-            sum_sq_reference += exp * exp;
-
-            if abs_diff > atol && rel_diff > rtol {
-                num_violations += 1;
-            }
-
-            if abs_diff > max_err {
-                max_err = abs_diff;
-                max_err_idx = i;
-                max_err_rel = rel_diff;
-                max_err_reference_value = exp;
-            }
-        }
-
-        let n = reference.len() as f32;
-        let rms_diff = (sum_sq_diff / n).sqrt();
-        let rms_result = (sum_sq_result / n).sqrt();
-        let rms_reference = (sum_sq_reference / n).sqrt();
-        let rel_rms_reference = if rms_reference > 1e-8 {
-            rms_diff / rms_reference
-        } else {
-            rms_diff
-        };
-        let diff_avg = diff_sum / n;
-
-        let max_allowed_violations = (fraction_of_allowed_violations * n).ceil() as usize;
-
-        TracerValidationMetrics {
-            atol,
-            rtol,
-            fraction_of_allowed_violations,
-            reference_shape,
-            result_shape,
-            num_violations,
-            max_allowed_violations,
-            max_err_idx,
-            max_err,
-            max_err_rel,
-            max_err_reference_value,
-            rms_diff,
-            rms_result,
-            rms_reference,
-            rel_rms_reference,
-            diff_max,
-            diff_avg,
-            result_nan,
-        }
-    }
-
-    // ========================================================================
-    // Utility Functions
-    // ========================================================================
-
-    fn load_array_as_vec<SourcePrecision: ArrayElement, TargetPrecision: NumCast>(
-        traces_view: &ParameterTree<B>,
-        trace_shapes: &HashMap<String, Vec<usize>>,
-        name: &str,
-    ) -> Vec<TargetPrecision> {
-        let expected_shape = Self::trace_shape(trace_shapes, name);
-        let leaf = traces_view
-            .leaf(name)
-            .unwrap_or_else(|error| panic!("Missing required trace tensor {name}: {error}"))
-            .validate(expected_shape, SourcePrecision::data_type())
-            .unwrap_or_else(|error| panic!("Invalid trace tensor {name}: {error}"));
-        let slice = leaf.read_slice::<SourcePrecision>().unwrap_or_else(|error| {
-            panic!("Failed to read trace tensor {name}: {error}");
-        });
-        slice.iter().map(|x| NumCast::from(*x).expect("Failed to cast trace tensor value")).collect()
-    }
-
-    fn trace_shape<'shape>(
-        trace_shapes: &'shape HashMap<String, Vec<usize>>,
-        name: &str,
-    ) -> &'shape [usize] {
-        trace_shapes.get(name).unwrap_or_else(|| panic!("Missing required trace tensor {name}"))
-    }
-
-    fn trace_token_count(
-        name: &str,
-        shape: &[usize],
-    ) -> usize {
-        let [batch_size, suffix_length] = shape else {
-            panic!("Trace tensor {name} must have shape [1, suffix_tokens], got {shape:?}");
-        };
-        assert_eq!(*batch_size, 1, "Trace tensor {name} must have batch size 1, got {shape:?}");
-        *suffix_length
-    }
-
-    fn read_required_array(
-        traces_view: &ParameterTree<B>,
-        trace_shapes: &HashMap<String, Vec<usize>>,
-        name: &str,
-        data_type: DataType,
-    ) -> Array<B> {
-        let expected_shape = Self::trace_shape(trace_shapes, name);
-        Self::read_array(traces_view, name, expected_shape, data_type)
-            .unwrap_or_else(|error| panic!("Invalid trace tensor {name}: {error}"))
-    }
-
-    fn read_array(
+    fn read_trace_array(
         traces_view: &ParameterTree<B>,
         name: &str,
         expected_shape: &[usize],
+    ) -> Result<Array<B>, Error> {
+        traces_view
+            .leaf(name)
+            .map_err(|error| Error::UnableToLoadWeights(Box::new(error)))?
+            .validate(expected_shape, DataType::I32)
+            .map_err(|error| Error::UnableToLoadWeights(Box::new(error)))?
+            .read_array()
+            .map_err(|error| Error::UnableToLoadWeights(Box::new(error)))
+    }
+
+    fn validate_trace_input_shape(
+        token_ids: &Array<B>,
+        token_positions: &Array<B>,
+    ) -> Result<(), Error> {
+        let &[batch, suffix_length] = token_ids.shape() else {
+            return Err(Error::InvalidModelConfig(format!(
+                "activation_trace.token_ids must have shape [1, suffix_tokens], got {:?}",
+                token_ids.shape()
+            )));
+        };
+        if batch != 1 || suffix_length == 0 {
+            return Err(Error::InvalidModelConfig(format!(
+                "activation_trace.token_ids must have shape [1, suffix_tokens], got {:?}",
+                token_ids.shape()
+            )));
+        }
+        if token_positions.shape() != token_ids.shape() {
+            return Err(Error::InvalidModelConfig(format!(
+                "activation_trace.token_positions shape {:?} must match activation_trace.token_ids {:?}",
+                token_positions.shape(),
+                token_ids.shape()
+            )));
+        }
+        Ok(())
+    }
+
+    fn validate_token_positions(token_positions: &[usize]) -> Result<(), Error> {
+        for (expected, position) in token_positions.iter().copied().enumerate() {
+            if position != expected {
+                return Err(Error::InvalidModelConfig(format!(
+                    "activation_trace.token_positions must be [0, 1, ..., suffix_tokens - 1], got {token_positions:?}"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn array_as_vec<SourcePrecision: ArrayElement, TargetPrecision: NumCast>(
+        array: &Array<B>,
+        name: &str,
+    ) -> Result<Vec<TargetPrecision>, Error> {
+        array
+            .as_slice::<SourcePrecision>()
+            .iter()
+            .map(|value| {
+                NumCast::from(*value)
+                    .ok_or_else(|| Error::InvalidModelConfig(format!("{name} contains an out-of-range value")))
+            })
+            .collect()
+    }
+
+    fn push_array<'data>(
+        tensors: &mut Vec<SafeTensorData<'data>>,
+        path: impl Into<String>,
+        array: &'data Array<B>,
+        export_shape: ExportShape,
+    ) {
+        let path = path.into();
+        let tensor = match export_shape {
+            ExportShape::Native => Self::tensor_from_array(path, array),
+            ExportShape::Batched => {
+                let shape = std::iter::once(1).chain(array.shape().iter().copied()).collect::<Vec<_>>();
+                Self::tensor_from_array_with_shape(path, array, shape.into_boxed_slice())
+            },
+        };
+        tensors.push(tensor);
+    }
+
+    fn tensor_from_array<'data>(
+        name: impl Into<String>,
+        array: &'data Array<B>,
+    ) -> SafeTensorData<'data> {
+        Self::tensor_from_array_with_shape(name, array, array.shape().into())
+    }
+
+    fn tensor_from_array_with_shape<'data>(
+        name: impl Into<String>,
+        array: &'data Array<B>,
+        shape: Box<[usize]>,
+    ) -> SafeTensorData<'data> {
+        SafeTensorData {
+            name: name.into(),
+            shape,
+            data_type: array.data_type(),
+            data: Cow::Borrowed(array.as_bytes()),
+        }
+    }
+
+    fn push_activation_trace_tensors<'data>(
+        tensors: &mut Vec<SafeTensorData<'data>>,
+        traces: &'data ActivationTrace<B>,
+        layer_configs: &[TransformerLayerConfig],
+        export_shape: ExportShape,
+    ) {
+        if let Some(embedding_norm) = &traces.embedding_norm {
+            Self::push_array(tensors, "activation_trace.embedding_norm_output", embedding_norm, export_shape);
+        }
+
+        for (index, layer_traces) in traces.layer_results.iter().enumerate() {
+            let layer_config = &layer_configs[index];
+            let path = |suffix: &str| format!("activation_trace.layer_results.{index}.activation_trace.{suffix}");
+
+            Self::push_array(tensors, path("inputs"), &layer_traces.inputs, export_shape);
+            Self::push_array(tensors, path("pre_mixer_norm"), &layer_traces.pre_attention_norm, export_shape);
+            Self::push_array(tensors, path("mixer"), &layer_traces.attention, export_shape);
+            if layer_config.post_mixer_norm_config.is_some() {
+                Self::push_array(tensors, path("post_mixer_norm"), &layer_traces.post_attention_norm, export_shape);
+            }
+            Self::push_array(tensors, path("mlp_inputs"), &layer_traces.mlp_inputs, export_shape);
+            Self::push_array(tensors, path("pre_mlp_norm"), &layer_traces.pre_mlp_norm, export_shape);
+            Self::push_array(tensors, path("mlp"), &layer_traces.mlp, export_shape);
+            if layer_config.post_mlp_norm_config.is_some() {
+                Self::push_array(tensors, path("post_mlp_norm"), &layer_traces.post_mlp_norm, export_shape);
+            }
+            Self::push_array(
+                tensors,
+                format!("activation_trace.layer_results.{index}.outputs"),
+                &layer_traces.outputs,
+                export_shape,
+            );
+        }
+
+        Self::push_array(tensors, "activation_trace.output_norm", &traces.output_norm, export_shape);
+        if let Some(output_pooling) = &traces.output_pooling {
+            Self::push_array(tensors, "activation_trace.output_pooling", output_pooling, ExportShape::Native);
+        }
+        let logits_shape = if traces.output_pooling.is_some() {
+            ExportShape::Native
+        } else {
+            export_shape
+        };
+        Self::push_array(tensors, "logits", &traces.logits, logits_shape);
+    }
+
+    fn cache_state_arrays(
+        context: &B::Context,
+        cache_layers: &CacheLayers<B>,
+        trace_metadata: &HashMetadata,
+    ) -> Result<Vec<(String, Array<B>)>, Error> {
+        let mut arrays = Vec::new();
+        for (index, layer) in cache_layers.iter_layers() {
+            if let Some(kv) = layer.as_transformer() {
+                if let Some(layer) = kv.as_any().downcast_ref::<KVCacheLayer<B, B::SparseBuffer>>() {
+                    Self::push_kv_cache_arrays(&mut arrays, context, trace_metadata, index, layer)?;
+                } else if let Some(layer) = kv.as_any().downcast_ref::<KVCacheLayer<B, B::DenseBuffer>>() {
+                    Self::push_kv_cache_arrays(&mut arrays, context, trace_metadata, index, layer)?;
+                } else {
+                    panic!("Unsupported KV cache layer buffer type");
+                }
+            } else if let Some(ssm) = layer.as_state_space() {
+                let path = format!("activation_trace.layer_results.{index}.updated_state.conv_state");
+                if let Some(reference_shape) = trace_optional_shape(trace_metadata, &path) {
+                    let conv_state = ssm.conv_state.as_ref().ok_or_else(|| {
+                        Error::InvalidModelConfig(format!(
+                            "{path} is present in the trace but Uzu produced no conv state"
+                        ))
+                    })?;
+                    let array = Self::conv_state_array(
+                        context,
+                        conv_state,
+                        &path,
+                        reference_shape,
+                        &ssm.conv_shape,
+                        ssm.data_type,
+                    )?;
+                    arrays.push((path, array));
+                }
+                Self::push_cache_exact_array(
+                    &mut arrays,
+                    context,
+                    trace_metadata,
+                    format!("activation_trace.layer_results.{index}.updated_state.ssm_state"),
+                    &ssm.ssm_state,
+                    &ssm.ssm_shape,
+                    ssm.data_type,
+                )?;
+            } else if let Some(delta) = layer.as_delta_net() {
+                Self::push_conv_state_array(
+                    &mut arrays,
+                    context,
+                    trace_metadata,
+                    format!("activation_trace.layer_results.{index}.updated_state.conv_state"),
+                    &delta.conv_state,
+                    &delta.conv_shape,
+                    delta.data_type,
+                )?;
+                Self::push_cache_exact_array(
+                    &mut arrays,
+                    context,
+                    trace_metadata,
+                    format!("activation_trace.layer_results.{index}.updated_state.ssm_state"),
+                    &delta.ssm_state,
+                    &delta.ssm_shape,
+                    delta.data_type,
+                )?;
+            } else if let Some(short_conv) = layer.as_short_conv() {
+                Self::push_conv_state_array(
+                    &mut arrays,
+                    context,
+                    trace_metadata,
+                    format!("activation_trace.layer_results.{index}.updated_state.conv_state"),
+                    &short_conv.conv_state,
+                    &short_conv.conv_shape,
+                    short_conv.data_type,
+                )?;
+            } else {
+                panic!("Unsupported cache layer type at layer {index}");
+            }
+        }
+        Ok(arrays)
+    }
+
+    fn push_kv_cache_arrays<Buf>(
+        arrays: &mut Vec<(String, Array<B>)>,
+        context: &B::Context,
+        trace_metadata: &HashMetadata,
+        index: usize,
+        layer: &KVCacheLayer<B, Buf>,
+    ) -> Result<(), Error>
+    where
+        Buf: Buffer<Backend = B>,
+    {
+        Self::push_cache_prefix_array(
+            arrays,
+            context,
+            trace_metadata,
+            format!("activation_trace.layer_results.{index}.updated_state.keys"),
+            &layer.keys,
+            &layer.shape,
+            layer.data_type,
+        )?;
+        Self::push_cache_prefix_array(
+            arrays,
+            context,
+            trace_metadata,
+            format!("activation_trace.layer_results.{index}.updated_state.values"),
+            &layer.values,
+            &layer.shape,
+            layer.data_type,
+        )
+    }
+
+    fn push_cache_prefix_array<Source>(
+        arrays: &mut Vec<(String, Array<B>)>,
+        context: &B::Context,
+        trace_metadata: &HashMetadata,
+        path: String,
+        source: &Source,
+        native_shape: &[usize],
         data_type: DataType,
-    ) -> Result<Array<B>, ParameterLoaderError<B>> {
-        traces_view.leaf(name)?.validate(expected_shape, data_type)?.read_array()
+    ) -> Result<(), Error>
+    where
+        Source: AsBufferRangeRef<Buffer: Buffer<Backend = B>>,
+    {
+        let Some(reference_shape) = trace_optional_shape(trace_metadata, &path) else {
+            return Ok(());
+        };
+        let array = Self::cache_prefix_array(context, source, &path, reference_shape, native_shape, data_type)?;
+        arrays.push((path, array));
+        Ok(())
+    }
+
+    fn push_cache_exact_array<Source>(
+        arrays: &mut Vec<(String, Array<B>)>,
+        context: &B::Context,
+        trace_metadata: &HashMetadata,
+        path: String,
+        source: &Source,
+        native_shape: &[usize],
+        data_type: DataType,
+    ) -> Result<(), Error>
+    where
+        Source: AsBufferRangeRef<Buffer: Buffer<Backend = B>>,
+    {
+        let Some(reference_shape) = trace_optional_shape(trace_metadata, &path) else {
+            return Ok(());
+        };
+        let array = Self::cache_exact_array(context, source, &path, reference_shape, native_shape, data_type)?;
+        arrays.push((path, array));
+        Ok(())
+    }
+
+    fn push_conv_state_array<Source>(
+        arrays: &mut Vec<(String, Array<B>)>,
+        context: &B::Context,
+        trace_metadata: &HashMetadata,
+        path: String,
+        source: &Source,
+        native_shape: &[usize; 2],
+        data_type: DataType,
+    ) -> Result<(), Error>
+    where
+        Source: AsBufferRangeRef<Buffer: Buffer<Backend = B>>,
+    {
+        let Some(reference_shape) = trace_optional_shape(trace_metadata, &path) else {
+            return Ok(());
+        };
+        let array = Self::conv_state_array(context, source, &path, reference_shape, native_shape, data_type)?;
+        arrays.push((path, array));
+        Ok(())
+    }
+
+    fn cache_prefix_array<Source>(
+        context: &B::Context,
+        source: &Source,
+        path: &str,
+        reference_shape: &[usize],
+        native_shape: &[usize],
+        data_type: DataType,
+    ) -> Result<Array<B>, Error>
+    where
+        Source: AsBufferRangeRef<Buffer: Buffer<Backend = B>>,
+    {
+        let aligned = match reference_shape {
+            shape if shape == native_shape => true,
+            [tokens, rest @ ..] if reference_shape.len() == native_shape.len() => {
+                *tokens <= native_shape[0] && rest == &native_shape[1..]
+            },
+            [1, tokens, rest @ ..] if reference_shape.len() == native_shape.len() + 1 => {
+                *tokens <= native_shape[0] && rest == &native_shape[1..]
+            },
+            _ => false,
+        };
+        if !aligned {
+            return Err(Error::InvalidModelConfig(format!(
+                "{path} trace shape {reference_shape:?} is incompatible with Uzu cache shape {native_shape:?}"
+            )));
+        }
+        Self::copy_buffer_prefix_to_array(context, source, path, reference_shape, data_type)
+    }
+
+    fn cache_exact_array<Source>(
+        context: &B::Context,
+        source: &Source,
+        path: &str,
+        reference_shape: &[usize],
+        native_shape: &[usize],
+        data_type: DataType,
+    ) -> Result<Array<B>, Error>
+    where
+        Source: AsBufferRangeRef<Buffer: Buffer<Backend = B>>,
+    {
+        let aligned =
+            reference_shape == native_shape || matches!(reference_shape, [1, rest @ ..] if rest == native_shape);
+        if !aligned {
+            return Err(Error::InvalidModelConfig(format!(
+                "{path} trace shape {reference_shape:?} is incompatible with Uzu cache shape {native_shape:?}"
+            )));
+        }
+        Self::copy_buffer_prefix_to_array(context, source, path, reference_shape, data_type)
+    }
+
+    fn conv_state_array<Source>(
+        context: &B::Context,
+        source: &Source,
+        path: &str,
+        reference_shape: &[usize],
+        native_shape: &[usize; 2],
+        data_type: DataType,
+    ) -> Result<Array<B>, Error>
+    where
+        Source: AsBufferRangeRef<Buffer: Buffer<Backend = B>>,
+    {
+        let [source_dim, source_history] = *native_shape;
+        let (target_time, dim) = match reference_shape {
+            [time, dim] => (*time, *dim),
+            [1, time, dim] => (*time, *dim),
+            _ => {
+                return Err(Error::InvalidModelConfig(format!(
+                    "{path} trace shape {reference_shape:?} is incompatible with Uzu conv state shape {native_shape:?}"
+                )));
+            },
+        };
+        if dim != source_dim || target_time != source_history {
+            return Err(Error::InvalidModelConfig(format!(
+                "{path} trace shape {reference_shape:?} is incompatible with Uzu conv state shape {native_shape:?}"
+            )));
+        }
+
+        let source_array = Self::copy_buffer_prefix_to_array(context, source, path, native_shape, data_type)?;
+        let mut target_array = context.create_array_uninitialized(reference_shape, data_type);
+        let element_bytes = data_type.size_in_bytes();
+        for dim_index in 0..dim {
+            for history_index in 0..source_history {
+                let source_offset = (dim_index * source_history + history_index) * element_bytes;
+                let target_offset = (history_index * dim + dim_index) * element_bytes;
+                target_array.as_bytes_mut()[target_offset..target_offset + element_bytes]
+                    .copy_from_slice(&source_array.as_bytes()[source_offset..source_offset + element_bytes]);
+            }
+        }
+        Ok(target_array)
+    }
+
+    fn copy_buffer_prefix_to_array<Source>(
+        context: &B::Context,
+        source: &Source,
+        path: &str,
+        shape: &[usize],
+        data_type: DataType,
+    ) -> Result<Array<B>, Error>
+    where
+        Source: AsBufferRangeRef<Buffer: Buffer<Backend = B>>,
+    {
+        let target_size = size_for_shape(shape, data_type);
+        let source_size = source.as_buffer_range_ref().range().len();
+        if target_size > source_size {
+            return Err(Error::InvalidModelConfig(format!(
+                "{path} trace shape {shape:?} requires {target_size} bytes but Uzu cache has {source_size}"
+            )));
+        }
+        let mut array = context.create_array_uninitialized(shape, data_type);
+        let mut encoder =
+            Encoder::<B>::new(context).map_err(|error| Error::UnableToCreateCommandBuffer(error.into()))?;
+        encoder.encode_copy(source, 0..target_size, array.allocation_mut(), 0..target_size);
+        encoder
+            .end_encoding()
+            .submit()
+            .wait_until_completed()
+            .map_err(|error| Error::CommandBufferFailed(Box::new(error)))?;
+        Ok(array)
+    }
+
+    fn write_trace_file(
+        output_path: &Path,
+        tensors: &[SafeTensorData<'_>],
+        metadata: Option<&BTreeMap<String, String>>,
+    ) -> Result<(), Error> {
+        let mut file = File::create_new(output_path).map_err(|error| Error::UnableToWriteTrace(Box::new(error)))?;
+        write_safetensors_with_metadata(&mut file, tensors, metadata)
+            .map_err(|error| Error::UnableToWriteTrace(Box::new(error)))
     }
 
     fn determine_prefill_step_size(model_path: &Path) -> Result<usize, Error> {
@@ -1005,8 +688,16 @@ impl<B: Backend> TraceValidator<B> {
             metadata.tensors.get("activation_trace.token_ids").map(|tensor| tensor.shape.as_slice()).ok_or_else(
                 || Error::InvalidModelConfig("missing required trace tensor activation_trace.token_ids".to_string()),
             )?;
-        let suffix_length = Self::trace_token_count("activation_trace.token_ids", token_shape);
-        assert!(suffix_length > 0, "trace must contain at least one token");
+        let &[batch, suffix_length] = token_shape else {
+            return Err(Error::InvalidModelConfig(format!(
+                "activation_trace.token_ids must have shape [1, suffix_tokens], got {token_shape:?}"
+            )));
+        };
+        if batch != 1 || suffix_length == 0 {
+            return Err(Error::InvalidModelConfig(format!(
+                "activation_trace.token_ids must have shape [1, suffix_tokens], got {token_shape:?}"
+            )));
+        }
         Ok(suffix_length)
     }
 
@@ -1032,14 +723,205 @@ impl<B: Backend> TraceValidator<B> {
             desired_suffix_length,
         )));
     }
+}
 
-    fn get_tokens_from_logits(logits: &Array<B>) -> Vec<u64> {
-        let data_type = logits.data_type();
-        match data_type {
-            DataType::F16 => sample_argmax(logits.as_view::<f16>()),
-            DataType::BF16 => sample_argmax(logits.as_view::<bf16>()),
-            DataType::F32 => sample_argmax(logits.as_view::<f32>()),
-            _ => panic!("Unsupported data type: {:?}", data_type),
-        }
+pub fn export_tokenization_trace(
+    model_path: &Path,
+    output_path: &Path,
+    message: &str,
+) -> Result<(), Error> {
+    let model_config = load_model_config(model_path)?;
+    let AnyModelConfig::LanguageModelConfig(model_config) = model_config else {
+        return Err(Error::InvalidModelConfig("tokenization trace export requires a language model".to_string()));
+    };
+    let AnyTokenCodecConfig::ChatCodecConfig(token_codec_config) = model_config.token_codec_config else {
+        return Err(Error::InvalidModelConfig("tokenization trace export requires a chat token codec".to_string()));
+    };
+    let tokenizer = Tokenizer::from_file(model_path.join("tokenizer.json")).map_err(Error::UnableToLoadTokenizer)?;
+    let messages = tokenization_trace_messages(token_codec_config.default_system_prompt.clone(), message);
+    let input = Input::Messages(messages.clone());
+    let add_generation_prompt = true;
+    let enable_thinking = true;
+    let rendered_request = InputProcessorDefault::new(token_codec_config.clone()).process(
+        &input,
+        add_generation_prompt,
+        enable_thinking,
+    )?;
+    let encoding = tokenizer.encode(rendered_request.as_str(), false).map_err(Error::UnableToEncodeText)?;
+    let token_ids = encoding
+        .get_ids()
+        .iter()
+        .map(|token| i32::try_from(*token).map_err(|_| Error::InvalidModelConfig("token id exceeds int32".to_string())))
+        .collect::<Result<Vec<_>, _>>()?;
+    if token_ids.is_empty() {
+        return Err(Error::InvalidModelConfig("tokenization trace must contain at least one token".to_string()));
+    }
+    let token_positions = (0..token_ids.len())
+        .map(|position| {
+            i32::try_from(position).map_err(|_| Error::InvalidModelConfig("token position exceeds int32".to_string()))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let shape = [1, token_ids.len()];
+    let tensors = [
+        tensor_from_i32_slice("activation_trace.token_ids", &shape, &token_ids),
+        tensor_from_i32_slice("activation_trace.token_positions", &shape, &token_positions),
+    ];
+    let request = json!({
+        "add_generation_prompt": add_generation_prompt,
+        "messages": messages.iter().map(|message| message.resolve(&token_codec_config)).collect::<Vec<_>>(),
+        "bos_token": token_codec_config.bos_token,
+        "eos_token": token_codec_config.eos_token,
+        "enable_thinking": enable_thinking,
+    });
+    let mut trace_metadata = BTreeMap::new();
+    trace_metadata.insert("add_special_tokens".to_string(), "false".to_string());
+    trace_metadata.insert("prompt_template".to_string(), token_codec_config.prompt_template);
+    trace_metadata.insert("rendered_request".to_string(), rendered_request);
+    trace_metadata.insert(
+        "request".to_string(),
+        serde_json::to_string(&request).map_err(|error| Error::UnableToWriteTrace(Box::new(error)))?,
+    );
+    trace_metadata.insert(
+        "tokens".to_string(),
+        serde_json::to_string(encoding.get_tokens()).map_err(|error| Error::UnableToWriteTrace(Box::new(error)))?,
+    );
+
+    let mut file = File::create_new(output_path).map_err(|error| Error::UnableToWriteTrace(Box::new(error)))?;
+    write_safetensors_with_metadata(&mut file, &tensors, Some(&trace_metadata))
+        .map_err(|error| Error::UnableToWriteTrace(Box::new(error)))
+}
+
+fn tokenization_trace_messages(
+    default_system_prompt: Option<String>,
+    message: &str,
+) -> Vec<Message> {
+    let mut messages = vec![Message::user(message.to_string())];
+    if let Some(default_system_prompt) = default_system_prompt {
+        messages.insert(0, Message::system(default_system_prompt));
+    }
+    messages
+}
+
+fn load_model_config(model_path: &Path) -> Result<AnyModelConfig, Error> {
+    let config_file = File::open(model_path.join("config.json"))?;
+    serde_json::from_reader(std::io::BufReader::new(config_file)).map_err(Error::UnableToDeserializeConfig)
+}
+
+fn trace_tensor_shape(
+    metadata: &backend_uzu::parameters::HashMetadata,
+    name: &str,
+) -> Result<Vec<usize>, Error> {
+    metadata
+        .tensors
+        .get(name)
+        .map(|tensor| tensor.shape.clone())
+        .ok_or_else(|| Error::InvalidModelConfig(format!("missing required trace tensor {name}")))
+}
+
+fn trace_optional_shape<'metadata>(
+    metadata: &'metadata HashMetadata,
+    name: &str,
+) -> Option<&'metadata [usize]> {
+    metadata.tensors.get(name).map(|tensor| tensor.shape.as_slice())
+}
+
+fn tensor_from_i32_slice(
+    name: impl Into<String>,
+    shape: &[usize; 2],
+    values: &[i32],
+) -> SafeTensorData<'static> {
+    SafeTensorData {
+        name: name.into(),
+        shape: Box::new(*shape),
+        data_type: DataType::I32,
+        data: Cow::Owned(values.iter().flat_map(|value| value.to_le_bytes()).collect()),
+    }
+}
+
+mod tests {
+    use backend_uzu::{
+        array::ArrayContextExt,
+        backends::{
+            common::{Backend, Context},
+            cpu::Cpu,
+        },
+        data_type::DataType,
+        session::types::{Error, Role},
+    };
+
+    use super::{TraceValidator, tokenization_trace_messages};
+
+    #[test]
+    fn test_tokenization_trace_messages_preserve_default_system_prompt() {
+        let messages = tokenization_trace_messages(Some("Stay brief".to_string()), "Hello");
+
+        assert_eq!(messages[0].role, Role::System);
+        assert_eq!(messages[0].content, "Stay brief");
+        assert_eq!(messages[1].role, Role::User);
+        assert_eq!(messages[1].content, "Hello");
+    }
+
+    #[test]
+    fn test_conv_state_array_matches_lalamo_state_layout() {
+        let context = <Cpu as Backend>::Context::new().expect("create CPU context");
+        let source = context.create_array_from(&[2, 3], &[1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+        let result = TraceValidator::<Cpu>::conv_state_array(
+            context.as_ref(),
+            source.allocation(),
+            "activation_trace.layer_results.0.updated_state.conv_state",
+            &[1, 3, 2],
+            &[2, 3],
+            DataType::F32,
+        )
+        .expect("export conv state");
+
+        assert_eq!(result.shape(), &[1, 3, 2]);
+        assert_eq!(result.as_slice::<f32>(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    }
+
+    #[test]
+    fn test_conv_state_array_transposes_square_state() {
+        let context = <Cpu as Backend>::Context::new().expect("create CPU context");
+        let source = context.create_array_from(&[2, 2], &[1.0f32, 2.0, 3.0, 4.0]);
+
+        let result = TraceValidator::<Cpu>::conv_state_array(
+            context.as_ref(),
+            source.allocation(),
+            "activation_trace.layer_results.0.updated_state.conv_state",
+            &[1, 2, 2],
+            &[2, 2],
+            DataType::F32,
+        )
+        .expect("export conv state");
+
+        assert_eq!(result.shape(), &[1, 2, 2]);
+        assert_eq!(result.as_slice::<f32>(), &[1.0, 3.0, 2.0, 4.0]);
+    }
+
+    #[test]
+    fn test_conv_state_array_rejects_history_padding() {
+        let context = <Cpu as Backend>::Context::new().expect("create CPU context");
+        let source = context.create_array_from(&[2, 3], &[1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+        let result = TraceValidator::<Cpu>::conv_state_array(
+            context.as_ref(),
+            source.allocation(),
+            "activation_trace.layer_results.0.updated_state.conv_state",
+            &[1, 5, 2],
+            &[2, 3],
+            DataType::F32,
+        );
+
+        assert!(matches!(result, Err(Error::InvalidModelConfig(message)) if message.contains("incompatible")));
+    }
+
+    #[test]
+    fn test_validate_token_positions_requires_sequential_positions() {
+        assert!(TraceValidator::<Cpu>::validate_token_positions(&[0, 1, 2]).is_ok());
+
+        let result = TraceValidator::<Cpu>::validate_token_positions(&[0, 2]);
+
+        assert!(matches!(result, Err(Error::InvalidModelConfig(message)) if message.contains("token_positions")));
     }
 }

--- a/crates/backend-uzu/tests/integration/tracer/trace_validator.rs
+++ b/crates/backend-uzu/tests/integration/tracer/trace_validator.rs
@@ -1,11 +1,6 @@
-//! Unified trace validation for any model type (LLM or classifier).
-//!
-//! This module provides a single `TraceValidator` that can validate activation
-//! traces for any model type. It automatically detects the model type from the
-//! config and runs the appropriate validation.
-
 use std::{
     cell::RefCell,
+    collections::BTreeMap,
     fs::File,
     path::{Path, PathBuf},
     rc::Rc,
@@ -13,155 +8,41 @@ use std::{
 
 use backend_uzu::{
     _private::{
-        ActivationTrace, ArgmaxSampler, CacheLayers, Classifier, DecoderDecodeInput, KVCacheLayer,
-        LanguageModelGeneratorContext, LogitsSampler, ModelConfig, ModelMetadata, ModelType, ParameterTree, Sampling,
-        TokenInputs,
+        ActivationTrace, CacheLayers, Classifier, DecoderDecodeInput, LanguageModelGeneratorContext, ModelConfig,
+        ModelMetadata, ModelType, ParameterTree, Sampling, TokenInputs, TransformerLayerConfig,
     },
-    Array, ArrayElement, DataType, ParameterLoader, allocation_to_vec,
-    backends::common::{Allocation, Backend, Encoder, kernel::kv_cache_update::KVCacheUpdate},
+    Array, ArrayElement, DataType, ParameterLoader, SafeTensorData,
+    backends::common::{Backend, Encoder, kernel::kv_cache_update::KVCacheUpdate},
     read_safetensors_metadata,
     session::{
         config::{DecodingConfig, SpeculatorConfig},
+        helpers::{InputProcessor, InputProcessorDefault},
         parameter::{AsyncBatchSize, ConfigResolvableValue, ContextLength, ContextMode, PrefillStepSize, SamplingSeed},
-        types::Error,
+        types::{Error, Input, Message},
     },
+    write_safetensors_with_metadata,
 };
-use half::{bf16, f16};
-use ndarray::{IxDyn, s};
 use num_traits::NumCast;
+use serde_json::json;
+use tokenizers::Tokenizer;
 
-use crate::common;
-// ============================================================================
-// Validation Types
-// ============================================================================
-
-/// Metrics from validating a single tensor.
-pub struct TracerValidationMetrics {
-    pub atol: f32,
-    pub rtol: f32,
-    #[allow(unused)]
-    pub fraction_of_allowed_violations: f32,
-    pub reference_shape: Vec<usize>,
-    pub result_shape: Vec<usize>,
-    pub num_violations: usize,
-    pub max_allowed_violations: usize,
-    pub max_err_idx: usize,
-    pub max_err: f32,
-    pub max_err_rel: f32,
-    pub max_err_reference_value: f32,
-    pub rms_diff: f32,
-    pub rms_result: f32,
-    pub rms_reference: f32,
-    pub rel_rms_reference: f32,
-    pub diff_max: f32,
-    pub diff_avg: f32,
-    pub result_nan: bool,
+#[derive(Clone, Copy)]
+enum ExportShape {
+    Native,
+    Batched,
 }
-
-impl TracerValidationMetrics {
-    pub fn is_valid(&self) -> bool {
-        self.num_violations <= self.max_allowed_violations && !self.result_nan
-    }
-
-    pub fn message(&self) -> String {
-        if self.result_nan {
-            return "Result contains NaN values".to_string();
-        }
-
-        let allowed_violation_explainer = if self.max_allowed_violations > 0 {
-            format!(" (Max {} allowed)", self.max_allowed_violations)
-        } else {
-            String::new()
-        };
-
-        let reference_size: usize = self.reference_shape.iter().product();
-
-        format!(
-            "{} violations > {:.1e} + {:.2}% out of total {} elements{}.\n\
-            Worst violation: {:.3} ({:.2}%) at index {} (reference value: {:.3}).\n\
-            Error RMS: {:.3}.\n\
-            RMS of result: {:.3}, RMS of reference: {:.3}.\n\
-            Relative error RMS: {:.2}% of RMS of reference.\n\
-            Shape: {:?}\n\
-            Max diff: {:.3}, Avg diff: {:.3}",
-            self.num_violations,
-            self.atol,
-            self.rtol * 100.0,
-            reference_size,
-            allowed_violation_explainer,
-            self.max_err,
-            self.max_err_rel * 100.0,
-            self.max_err_idx,
-            self.max_err_reference_value,
-            self.rms_diff,
-            self.rms_result,
-            self.rms_reference,
-            self.rel_rms_reference * 100.0,
-            self.result_shape,
-            self.diff_max,
-            self.diff_avg,
-        )
-    }
-}
-
-/// Result of validating a single tensor.
-pub struct TracerValidationResult {
-    pub name: String,
-    pub metrics: TracerValidationMetrics,
-}
-
-/// Results from validating all traces.
-pub struct TracerValidationResults {
-    pub suffix_length: usize,
-    pub results: Vec<TracerValidationResult>,
-    pub tokens_violation_indices: Vec<usize>,
-}
-
-impl TracerValidationResults {
-    pub fn number_of_tokens_violations(&self) -> usize {
-        self.tokens_violation_indices.len()
-    }
-
-    pub fn number_of_allowed_tokens_violations(&self) -> usize {
-        let threshold: f64 = 0.01;
-        (self.suffix_length as f64 * threshold).ceil() as usize
-    }
-}
-
-/// Transform to apply to produced arrays before comparison.
-pub enum ArrayTransform {
-    /// Slice KV cache to match expected shape.
-    KVCacheSlice,
-    /// Transform SSM conv state layout.
-    SsmConvState,
-}
-
-// ============================================================================
-// Model Context (internal)
-// ============================================================================
 
 enum ModelContext<B: Backend> {
     LanguageModelGenerator(LanguageModelGeneratorContext<B>),
     Classifier(Classifier<B>),
 }
 
-// ============================================================================
-// Unified TraceValidator
-// ============================================================================
-
-/// Unified trace validator for any model type.
-///
-/// Automatically detects whether the model is an LLM or classifier and
-/// runs the appropriate validation.
 pub struct TraceValidator<B: Backend> {
     model_path: PathBuf,
     context: ModelContext<B>,
 }
 
 impl<B: Backend> TraceValidator<B> {
-    /// Create a new trace validator for the given model path.
-    ///
-    /// Automatically detects the model type from config.json.
     pub fn new(model_path: &Path) -> Result<Self, Error> {
         let config_path = model_path.join("config.json");
         if !config_path.exists() {
@@ -209,7 +90,7 @@ impl<B: Backend> TraceValidator<B> {
                     model_config,
                     grammar_start_tokens: raw_metadata.grammar_start_tokens,
                 };
-                let prefill_step_size = Self::determine_prefill_step_size(model_path);
+                let prefill_step_size = Self::determine_prefill_step_size(model_path)?;
                 let decoding_config = DecodingConfig::new(
                     ContextMode::default(),
                     ContextLength::default(),
@@ -232,40 +113,61 @@ impl<B: Backend> TraceValidator<B> {
         })
     }
 
-    /// Run trace validation and return results.
-    pub fn run(&mut self) -> Result<TracerValidationResults, Error> {
+    pub fn export_trace(
+        &mut self,
+        output_path: &Path,
+    ) -> Result<(), Error> {
         let traces_path = self.model_path.join("traces.safetensors");
         if !traces_path.exists() {
             return Err(Error::UnableToLoadWeights);
         }
 
         match &mut self.context {
-            ModelContext::LanguageModelGenerator(ctx) => Self::run_llm_validation(ctx, &traces_path),
-            ModelContext::Classifier(classifier) => Self::run_classifier_validation(classifier, &traces_path),
+            ModelContext::LanguageModelGenerator(ctx) => Self::export_llm_trace(ctx, &traces_path, output_path),
+            ModelContext::Classifier(classifier) => {
+                Self::export_classifier_trace(classifier, &traces_path, output_path)
+            },
         }
     }
 
-    // ========================================================================
-    // LLM Validation
-    // ========================================================================
-
-    fn run_llm_validation(
+    fn export_llm_trace(
         ctx: &LanguageModelGeneratorContext<B>,
         traces_path: &Path,
-    ) -> Result<TracerValidationResults, Error> {
+        output_path: &Path,
+    ) -> Result<(), Error> {
         let traces_file = File::open(traces_path).map_err(|_| Error::UnableToLoadWeights)?;
+        let input_metadata = trace_metadata(&traces_file)?;
         let traces_loader =
             ParameterLoader::new(&traces_file, ctx.context.as_ref()).map_err(|_| Error::UnableToLoadWeights)?;
         let traces_view = traces_loader.tree();
+        let (token_ids_array, token_positions_array, token_ids, token_positions) =
+            Self::load_trace_inputs(&traces_view)?;
+        let traces = Self::run_llm_trace(ctx, &token_ids, &token_positions)?;
 
-        let token_ids = Self::load_array_as_vec::<i32, u64>(&traces_view, "activation_trace.token_ids");
-        let token_positions = Self::load_array_as_vec::<i32, usize>(&traces_view, "activation_trace.token_positions");
+        let mut tensors = vec![
+            Self::tensor_from_array("activation_trace.token_ids", &token_ids_array),
+            Self::tensor_from_array("activation_trace.token_positions", &token_positions_array),
+        ];
+        Self::push_activation_trace_tensors(
+            &mut tensors,
+            &traces,
+            &ctx.model_config.model_config.transformer_config.layer_configs,
+            ExportShape::Batched,
+        );
+        Self::write_trace_file(output_path, &tensors, input_metadata.as_ref())
+    }
+
+    fn run_llm_trace(
+        ctx: &LanguageModelGeneratorContext<B>,
+        token_ids: &[u64],
+        token_positions: &[usize],
+    ) -> Result<ActivationTrace<B>, Error> {
         let token_inputs = TokenInputs::new_llm(
             ctx.context.as_ref(),
             &ctx.model_shape,
-            &token_ids,
+            token_ids,
             None,
-            &token_positions,
+            token_positions,
             None,
             None,
             /*sampling_start=*/ 0,
@@ -274,9 +176,10 @@ impl<B: Backend> TraceValidator<B> {
         let mut traces = ActivationTrace::new_llm(ctx.context.as_ref(), &ctx.model_shape, token_ids.len());
 
         let mut encoder =
-            Encoder::<B>::new(ctx.context.as_ref()).map_err(|e| Error::UnableToCreateCommandBuffer(e.into()))?;
+            Encoder::<B>::new(ctx.context.as_ref()).map_err(|err| Error::UnableToCreateCommandBuffer(err.into()))?;
         {
             let mut cache_layers = ctx.cache_layers.borrow_mut();
+            cache_layers.prepare_for_forward_pass(ctx.context.as_ref(), token_ids.len());
             let decoder_arguments = token_inputs.decoder_arguments(
                 ctx.shared_buffers.as_ref(),
                 Some(&mut *cache_layers),
@@ -293,643 +196,184 @@ impl<B: Backend> TraceValidator<B> {
                     None,
                     &mut encoder,
                 )
-                .map_err(|e| Error::EncodeFailed(Box::new(e)))?;
+                .map_err(|err| Error::EncodeFailed(Box::new(err)))?;
         }
         let pending = encoder.end_encoding().submit();
-        pending.wait_until_completed().map_err(|e| Error::CommandBufferFailed(Box::new(e)))?;
-
-        let data_type = ctx.model_shape.activation_data_type();
-
-        // Common layer validation
-        let mut results = Self::validate_layer_traces(&traces, &traces_view, data_type);
-
-        // LLM-specific: KV cache validation
-        let cache = ctx.cache_layers.borrow();
-        for (index, layer) in cache.iter_layers() {
-            let Some(kv) = layer.as_transformer() else {
-                continue;
-            };
-
-            if let Ok(expected) = traces_view.leaf_array(&format!("updated_kv_cache.{}.keys", index)) {
-                let size = kv.shape().iter().product::<usize>() * data_type.size_in_bytes();
-                let keys = if let Some(layer) = kv.as_any().downcast_ref::<KVCacheLayer<B, B::SparseBuffer>>() {
-                    common::helpers::sparse_buffer_read_allocation(ctx.context.as_ref(), &layer.keys, size)
-                } else {
-                    panic!("Wrong keys type")
-                };
-                results.push(TracerValidationResult {
-                    name: format!("updated_kv_cache.{}.keys", index),
-                    metrics: Self::validate_allocation(
-                        data_type,
-                        &expected,
-                        &keys,
-                        &kv.shape(),
-                        Some(ArrayTransform::KVCacheSlice),
-                    ),
-                });
-            }
-
-            if let Ok(expected) = traces_view.leaf_array(&format!("updated_kv_cache.{}.values", index)) {
-                let size = kv.shape().iter().product::<usize>() * data_type.size_in_bytes();
-                let values = if let Some(layer) = kv.as_any().downcast_ref::<KVCacheLayer<B, B::SparseBuffer>>() {
-                    common::helpers::sparse_buffer_read_allocation(ctx.context.as_ref(), &layer.values, size)
-                } else {
-                    panic!("Wrong values type")
-                };
-                results.push(TracerValidationResult {
-                    name: format!("updated_kv_cache.{}.values", index),
-                    metrics: Self::validate_allocation(
-                        data_type,
-                        &expected,
-                        &values,
-                        &kv.shape(),
-                        Some(ArrayTransform::KVCacheSlice),
-                    ),
-                });
-            }
-        }
-
-        // LLM-specific: SSM state validation
-        for (index, layer) in cache.iter_layers() {
-            let Some(ssm) = layer.as_state_space() else {
-                continue;
-            };
-
-            for path in [
-                format!("updated_state.{}.conv_state", index),
-                format!("activation_trace.layer_results.{}.updated_state.conv_state", index),
-            ] {
-                if let Ok(expected) = traces_view.leaf_array(&path) {
-                    results.push(TracerValidationResult {
-                        name: path,
-                        metrics: Self::validate_optional_allocation(
-                            data_type,
-                            &expected,
-                            ssm.conv_state.as_ref(),
-                            &ssm.conv_shape,
-                            Some(ArrayTransform::SsmConvState),
-                        ),
-                    });
-                }
-            }
-
-            for path in [
-                format!("updated_state.{}.ssm_state", index),
-                format!("activation_trace.layer_results.{}.updated_state.ssm_state", index),
-            ] {
-                if let Ok(expected) = traces_view.leaf_array(&path) {
-                    results.push(TracerValidationResult {
-                        name: path,
-                        metrics: Self::validate_allocation(data_type, &expected, &ssm.ssm_state, &ssm.ssm_shape, None),
-                    });
-                }
-            }
-        }
-
-        // LLM-specific: DeltaNet state validation
-        for (index, layer) in cache.iter_layers() {
-            let Some(delta) = layer.as_delta_net() else {
-                continue;
-            };
-
-            for path in [
-                format!("updated_state.{}.conv_state", index),
-                format!("activation_trace.layer_results.{}.updated_state.conv_state", index),
-            ] {
-                if let Ok(expected) = traces_view.leaf_array(&path) {
-                    results.push(TracerValidationResult {
-                        name: path,
-                        metrics: Self::validate_allocation(
-                            data_type,
-                            &expected,
-                            &delta.conv_state,
-                            &delta.conv_shape,
-                            Some(ArrayTransform::SsmConvState),
-                        ),
-                    });
-                }
-            }
-
-            for path in [
-                format!("updated_state.{}.ssm_state", index),
-                format!("activation_trace.layer_results.{}.updated_state.ssm_state", index),
-            ] {
-                if let Ok(expected) = traces_view.leaf_array(&path) {
-                    results.push(TracerValidationResult {
-                        name: path,
-                        metrics: Self::validate_allocation(
-                            data_type,
-                            &expected,
-                            &delta.ssm_state,
-                            &delta.ssm_shape,
-                            None,
-                        ),
-                    });
-                }
-            }
-        }
-
-        // LLM-specific: Token comparison
-        let tokens_violation_indices = if let Ok(expected_logits) = traces_view.leaf_array("logits") {
-            let expected_tokens = Self::get_tokens_from_logits(&expected_logits);
-            let produced_tokens = Self::get_tokens_from_logits(&traces.logits);
-            expected_tokens
-                .iter()
-                .zip(produced_tokens.iter())
-                .enumerate()
-                .filter_map(|(i, (a, b))| {
-                    if a != b {
-                        Some(i)
-                    } else {
-                        None
-                    }
-                })
-                .collect()
-        } else {
-            Vec::new()
-        };
-
-        Ok(TracerValidationResults {
-            suffix_length: token_ids.len(),
-            results,
-            tokens_violation_indices,
-        })
+        pending.wait_until_completed().map_err(|err| Error::CommandBufferFailed(Box::new(err)))?;
+        Ok(traces)
     }
 
-    // ========================================================================
-    // Classifier Validation
-    // ========================================================================
-
-    fn run_classifier_validation(
+    fn export_classifier_trace(
         classifier: &mut Classifier<B>,
         traces_path: &Path,
-    ) -> Result<TracerValidationResults, Error> {
+        output_path: &Path,
+    ) -> Result<(), Error> {
         let traces_file = File::open(traces_path).map_err(|_| Error::UnableToLoadWeights)?;
+        let input_metadata = trace_metadata(&traces_file)?;
         let context = classifier.context.context.clone();
         let traces_loader =
             ParameterLoader::new(&traces_file, context.as_ref()).map_err(|_| Error::UnableToLoadWeights)?;
         let traces_view = traces_loader.tree();
-
-        let has_token_ids = traces_view.leaf_array("activation_trace.token_ids").is_ok();
-        let has_token_positions = traces_view.leaf_array("activation_trace.token_positions").is_ok();
-
-        if !has_token_ids || !has_token_positions {
-            return Ok(Self::handle_missing_tokens(&traces_view));
-        }
-
-        let token_ids = Self::load_array_as_vec::<i32, u64>(&traces_view, "activation_trace.token_ids");
-        let token_positions = Self::load_array_as_vec::<i32, usize>(&traces_view, "activation_trace.token_positions");
-
-        let suffix_length = token_ids.len();
-
+        let (token_ids_array, token_positions_array, token_ids, token_positions) =
+            Self::load_trace_inputs(&traces_view)?;
         let (_logits, traces) =
             classifier.forward_pass_with_traces(&token_ids, &token_positions).map_err(|_| Error::GenerateFailed)?;
 
-        let data_type = classifier.context.model_shape.activation_data_type();
-
-        // Common layer validation
-        let mut results = Self::validate_layer_traces(&traces, &traces_view, data_type);
-
-        // Classifier-specific: embedding_norm, output_pooling
-        let classifier_results = Self::validate_classifier_traces(&traces, &traces_view, data_type);
-        results.extend(classifier_results);
-
-        Ok(TracerValidationResults {
-            suffix_length,
-            results,
-            tokens_violation_indices: Vec::new(), // Classifiers don't compare tokens
-        })
+        let mut tensors = vec![
+            Self::tensor_from_array("activation_trace.token_ids", &token_ids_array),
+            Self::tensor_from_array("activation_trace.token_positions", &token_positions_array),
+        ];
+        Self::push_activation_trace_tensors(
+            &mut tensors,
+            &traces,
+            &classifier.context.model_config.model_config.transformer_config.layer_configs,
+            ExportShape::Batched,
+        );
+        Self::write_trace_file(output_path, &tensors, input_metadata.as_ref())
     }
 
-    fn handle_missing_tokens(traces_view: &ParameterTree<B::Context>) -> TracerValidationResults {
-        if let Ok(expected_logits) = traces_view.leaf_array("logits") {
-            let reference_shape = expected_logits.shape().to_vec();
-            let metrics = TracerValidationMetrics {
-                atol: 0.0,
-                rtol: 0.0,
-                fraction_of_allowed_violations: 0.0,
-                reference_shape: reference_shape.clone(),
-                result_shape: reference_shape,
-                num_violations: 0,
-                max_allowed_violations: 0,
-                max_err_idx: 0,
-                max_err: 0.0,
-                max_err_rel: 0.0,
-                max_err_reference_value: 0.0,
-                rms_diff: 0.0,
-                rms_result: 0.0,
-                rms_reference: 0.0,
-                rel_rms_reference: 0.0,
-                diff_max: 0.0,
-                diff_avg: 0.0,
-                result_nan: false,
-            };
-            return TracerValidationResults {
-                suffix_length: 1,
-                results: vec![TracerValidationResult {
-                    name: "activation_trace.logits".to_string(),
-                    metrics,
-                }],
-                tokens_violation_indices: Vec::new(),
-            };
-        }
-
-        TracerValidationResults {
-            suffix_length: 1,
-            results: Vec::new(),
-            tokens_violation_indices: Vec::new(),
-        }
+    fn load_trace_inputs(
+        traces_view: &ParameterTree<B::Context>
+    ) -> Result<(Array<B>, Array<B>, Vec<u64>, Vec<usize>), Error> {
+        let token_ids_array =
+            traces_view.leaf_array("activation_trace.token_ids").map_err(|_| Error::UnableToLoadWeights)?;
+        let token_positions_array =
+            traces_view.leaf_array("activation_trace.token_positions").map_err(|_| Error::UnableToLoadWeights)?;
+        Self::validate_trace_input_shape(&token_ids_array, &token_positions_array)?;
+        let token_ids = Self::array_as_vec::<i32, u64>(&token_ids_array)?;
+        let token_positions = Self::array_as_vec::<i32, usize>(&token_positions_array)?;
+        Ok((token_ids_array, token_positions_array, token_ids, token_positions))
     }
 
-    // ========================================================================
-    // Common Validation Helpers
-    // ========================================================================
-
-    fn validate_layer_traces(
-        traces: &ActivationTrace<B>,
-        traces_view: &ParameterTree<B::Context>,
-        data_type: DataType,
-    ) -> Vec<TracerValidationResult> {
-        let mut results = Vec::new();
-
-        let validate = |path: &str, array: &Array<B>| -> Option<TracerValidationResult> {
-            if let Ok(expected) = traces_view.leaf_array(path) {
-                Some(TracerValidationResult {
-                    name: path.to_string(),
-                    metrics: Self::validate_allocation(data_type, &expected, array.allocation(), array.shape(), None),
-                })
-            } else {
-                None
-            }
+    fn validate_trace_input_shape(
+        token_ids: &Array<B>,
+        token_positions: &Array<B>,
+    ) -> Result<(), Error> {
+        let &[batch, suffix_length] = token_ids.shape() else {
+            return Err(Error::UnableToLoadWeights);
         };
+        if batch != 1
+            || suffix_length == 0
+            || token_positions.shape() != token_ids.shape()
+            || token_ids.data_type() != DataType::I32
+            || token_positions.data_type() != DataType::I32
+        {
+            return Err(Error::UnableToLoadWeights);
+        }
+        Ok(())
+    }
+
+    fn array_as_vec<SourcePrecision: ArrayElement, TargetPrecision: NumCast>(
+        array: &Array<B>
+    ) -> Result<Vec<TargetPrecision>, Error> {
+        let slice = array.as_slice::<SourcePrecision>();
+        slice.iter().map(|value| NumCast::from(*value).ok_or(Error::UnableToLoadWeights)).collect()
+    }
+
+    fn push_array(
+        tensors: &mut Vec<SafeTensorData>,
+        path: impl Into<String>,
+        array: &Array<B>,
+        export_shape: ExportShape,
+    ) {
+        let path = path.into();
+        let tensor = match export_shape {
+            ExportShape::Native => Self::tensor_from_array(path, array),
+            ExportShape::Batched => {
+                let shape = std::iter::once(1).chain(array.shape().iter().copied()).collect::<Vec<_>>();
+                Self::tensor_from_array_with_shape(path, array, shape.into_boxed_slice())
+            },
+        };
+        tensors.push(tensor);
+    }
+
+    fn tensor_from_array(
+        name: impl Into<String>,
+        array: &Array<B>,
+    ) -> SafeTensorData {
+        Self::tensor_from_array_with_shape(name, array, array.shape().into())
+    }
+
+    fn tensor_from_array_with_shape(
+        name: impl Into<String>,
+        array: &Array<B>,
+        shape: Box<[usize]>,
+    ) -> SafeTensorData {
+        SafeTensorData {
+            name: name.into(),
+            shape,
+            data_type: array.data_type(),
+            data: array.as_bytes().into(),
+        }
+    }
+
+    fn push_activation_trace_tensors(
+        tensors: &mut Vec<SafeTensorData>,
+        traces: &ActivationTrace<B>,
+        layer_configs: &[TransformerLayerConfig],
+        export_shape: ExportShape,
+    ) {
+        if let Some(embedding_norm) = &traces.embedding_norm {
+            Self::push_array(tensors, "activation_trace.embedding_norm_output", embedding_norm, export_shape);
+        }
 
         for (index, layer_traces) in traces.layer_results.iter().enumerate() {
-            let path = |suffix: &str| -> String {
-                format!("activation_trace.layer_results.{}.activation_trace.{}", index, suffix)
-            };
+            let layer_config = &layer_configs[index];
+            let path = |suffix: &str| format!("activation_trace.layer_results.{index}.activation_trace.{suffix}");
 
-            if let Some(r) = validate(&path("inputs"), &layer_traces.inputs) {
-                results.push(r);
+            Self::push_array(tensors, path("inputs"), &layer_traces.inputs, export_shape);
+            Self::push_array(tensors, path("pre_mixer_norm"), &layer_traces.pre_attention_norm, export_shape);
+            Self::push_array(tensors, path("mixer"), &layer_traces.attention, export_shape);
+            if layer_config.post_mixer_norm_config.is_some() {
+                Self::push_array(tensors, path("post_mixer_norm"), &layer_traces.post_attention_norm, export_shape);
             }
-            if let Some(r) = validate(&path("pre_mixer_norm"), &layer_traces.pre_attention_norm) {
-                results.push(r);
+            Self::push_array(tensors, path("mlp_inputs"), &layer_traces.mlp_inputs, export_shape);
+            Self::push_array(tensors, path("pre_mlp_norm"), &layer_traces.pre_mlp_norm, export_shape);
+            Self::push_array(tensors, path("mlp"), &layer_traces.mlp, export_shape);
+            if layer_config.post_mlp_norm_config.is_some() {
+                Self::push_array(tensors, path("post_mlp_norm"), &layer_traces.post_mlp_norm, export_shape);
             }
-            if let Some(r) = validate(&path("mixer"), &layer_traces.attention) {
-                results.push(r);
-            }
-            if let Some(r) = validate(&path("post_mixer_norm"), &layer_traces.post_attention_norm) {
-                results.push(r);
-            }
-            if let Some(r) = validate(&path("mlp_inputs"), &layer_traces.mlp_inputs) {
-                results.push(r);
-            }
-            if let Some(r) = validate(&path("pre_mlp_norm"), &layer_traces.pre_mlp_norm) {
-                results.push(r);
-            }
-            if let Some(r) = validate(&path("mlp"), &layer_traces.mlp) {
-                results.push(r);
-            }
-            if let Some(r) = validate(&path("post_mlp_norm"), &layer_traces.post_mlp_norm) {
-                results.push(r);
-            }
-
-            let outputs_path = format!("activation_trace.layer_results.{}.outputs", index);
-            if let Some(r) = validate(&outputs_path, &layer_traces.outputs) {
-                results.push(r);
-            }
-        }
-
-        // Output norm (common to all models)
-        if let Some(r) = validate("activation_trace.output_norm", &traces.output_norm) {
-            results.push(r);
-        }
-
-        // Logits (common to all models, but path may vary)
-        if let Some(r) = validate("activation_trace.logits", &traces.logits) {
-            results.push(r);
-        } else if let Some(r) = validate("logits", &traces.logits) {
-            results.push(r);
-        }
-
-        results
-    }
-
-    fn validate_classifier_traces(
-        traces: &ActivationTrace<B>,
-        traces_view: &ParameterTree<B::Context>,
-        data_type: DataType,
-    ) -> Vec<TracerValidationResult> {
-        let mut results = Vec::new();
-
-        // Output pooling (classifier-specific)
-        if let Some(output_pooling) = &traces.output_pooling {
-            if let Ok(expected) = traces_view.leaf_array("activation_trace.output_pooling") {
-                results.push(TracerValidationResult {
-                    name: "activation_trace.output_pooling".to_string(),
-                    metrics: Self::validate_allocation(
-                        data_type,
-                        &expected,
-                        output_pooling.allocation(),
-                        output_pooling.shape(),
-                        None,
-                    ),
-                });
-            }
-        }
-
-        results
-    }
-
-    // ========================================================================
-    // Allocation Validation
-    // ========================================================================
-
-    fn validate_allocation(
-        data_type: DataType,
-        expected_array: &Array<B>,
-        produced_allocation: &Allocation<B>,
-        produced_shape: &[usize],
-        transform: Option<ArrayTransform>,
-    ) -> TracerValidationMetrics {
-        match data_type {
-            DataType::F16 => {
-                Self::validate_allocation_of_type::<f16>(expected_array, produced_allocation, produced_shape, transform)
-            },
-            DataType::BF16 => Self::validate_allocation_of_type::<bf16>(
-                expected_array,
-                produced_allocation,
-                produced_shape,
-                transform,
-            ),
-            DataType::F32 => {
-                Self::validate_allocation_of_type::<f32>(expected_array, produced_allocation, produced_shape, transform)
-            },
-            _ => panic!("Unsupported data type: {:?}", data_type),
-        }
-    }
-
-    fn validate_optional_allocation(
-        data_type: DataType,
-        expected_array: &Array<B>,
-        produced_allocation: Option<&Allocation<B>>,
-        produced_shape: &[usize],
-        transform: Option<ArrayTransform>,
-    ) -> TracerValidationMetrics {
-        match produced_allocation {
-            Some(produced_allocation) => {
-                Self::validate_allocation(data_type, expected_array, produced_allocation, produced_shape, transform)
-            },
-            None => match data_type {
-                DataType::F16 => {
-                    Self::validate_allocation_data_of_type::<f16>(expected_array, &[], produced_shape, transform)
-                },
-                DataType::BF16 => {
-                    Self::validate_allocation_data_of_type::<bf16>(expected_array, &[], produced_shape, transform)
-                },
-                DataType::F32 => {
-                    Self::validate_allocation_data_of_type::<f32>(expected_array, &[], produced_shape, transform)
-                },
-                _ => panic!("Unsupported data type: {:?}", data_type),
-            },
-        }
-    }
-
-    fn validate_allocation_of_type<Precision: ArrayElement>(
-        expected_array: &Array<B>,
-        produced_allocation: &Allocation<B>,
-        produced_shape: &[usize],
-        transform: Option<ArrayTransform>,
-    ) -> TracerValidationMetrics {
-        let produced = allocation_to_vec::<B, Precision>(produced_allocation);
-        Self::validate_allocation_data_of_type(expected_array, &produced, produced_shape, transform)
-    }
-
-    fn validate_allocation_data_of_type<Precision: ArrayElement>(
-        expected_array: &Array<B>,
-        produced_slice: &[Precision],
-        produced_shape: &[usize],
-        transform: Option<ArrayTransform>,
-    ) -> TracerValidationMetrics {
-        let expected_view = expected_array.as_view::<Precision>();
-        let produced_view = ndarray::ArrayView::from_shape(IxDyn(produced_shape), produced_slice)
-            .expect("Failed to reshape allocation");
-
-        let (mut expected_data, mut produced_data) = match transform {
-            Some(ArrayTransform::KVCacheSlice) => {
-                let permuted = produced_view.permuted_axes(IxDyn(&[1, 0, 2]));
-                let total_tokens = permuted.shape()[0];
-                let expected_tokens = expected_view.shape()[1];
-                let start = total_tokens.saturating_sub(expected_tokens);
-                let sliced = permuted.slice(s![start.., .., ..]);
-                let reshaped = sliced
-                    .into_owned()
-                    .to_shape(IxDyn(&[1, expected_tokens, permuted.shape()[1], permuted.shape()[2]]))
-                    .expect("Failed to reshape KV cache slice")
-                    .to_owned();
-                (expected_view.to_owned(), reshaped)
-            },
-            Some(ArrayTransform::SsmConvState) => {
-                let produced_shape = produced_view.shape();
-                let history_len = produced_shape[1];
-                let dim = produced_shape[0];
-
-                let permuted = expected_view.permuted_axes(IxDyn(&[0, 2, 1]));
-                let total_time = permuted.shape()[2];
-                let start = total_time.saturating_sub(history_len);
-                let sliced = permuted.slice(s![.., .., start..]);
-
-                let reshaped_expected = sliced
-                    .into_owned()
-                    .to_shape(IxDyn(&[dim, history_len]))
-                    .expect("Failed to reshape SSM conv state slice")
-                    .to_owned();
-
-                (reshaped_expected, produced_view.to_owned())
-            },
-            None => (expected_view.to_owned(), produced_view.to_owned()),
-        };
-
-        let expected_shape = expected_data.shape().to_vec();
-        let produced_shape = produced_data.shape().to_vec();
-
-        if expected_shape != produced_shape {
-            if expected_shape.len() == produced_shape.len() + 1
-                && expected_shape.get(0) == Some(&1)
-                && expected_shape[1..] == produced_shape[..]
-            {
-                expected_data =
-                    expected_data.to_shape(IxDyn(&produced_shape)).expect("Failed to reshape expected data").to_owned();
-            } else if produced_shape.len() == expected_shape.len() + 1
-                && produced_shape.get(0) == Some(&1)
-                && produced_shape[1..] == expected_shape[..]
-            {
-                produced_data =
-                    produced_data.to_shape(IxDyn(&expected_shape)).expect("Failed to reshape produced data").to_owned();
-            }
-        }
-
-        if expected_data.shape() != produced_data.shape() {
-            panic!(
-                "Shape mismatch after alignment: expected {:?}, produced {:?}",
-                expected_data.shape(),
-                produced_data.shape()
+            Self::push_array(
+                tensors,
+                format!("activation_trace.layer_results.{index}.outputs"),
+                &layer_traces.outputs,
+                export_shape,
             );
         }
 
-        let reference: Vec<f32> = expected_data.iter().map(|value| NumCast::from(*value).unwrap_or(0.0)).collect();
-        let result: Vec<f32> = produced_data.iter().map(|value| NumCast::from(*value).unwrap_or(0.0)).collect();
-
-        let (atol, rtol, allowed_voilations_tol) = match expected_array.data_type() {
-            DataType::BF16 => (0.04, 0.06, 0.03),
-            _ => (0.01, 0.03, 0.01),
-        };
-
-        Self::compare_arrays(
-            &reference,
-            expected_data.shape().to_vec(),
-            &result,
-            produced_data.shape().to_vec(),
-            atol,
-            rtol,
-            allowed_voilations_tol,
-        )
-    }
-
-    fn compare_arrays(
-        reference: &[f32],
-        reference_shape: Vec<usize>,
-        result: &[f32],
-        result_shape: Vec<usize>,
-        atol: f32,
-        rtol: f32,
-        fraction_of_allowed_violations: f32,
-    ) -> TracerValidationMetrics {
-        assert_eq!(result.len(), reference.len());
-        if reference.is_empty() {
-            return TracerValidationMetrics {
-                atol,
-                rtol,
-                fraction_of_allowed_violations,
-                reference_shape,
-                result_shape,
-                num_violations: 0,
-                max_allowed_violations: 0,
-                max_err_idx: 0,
-                max_err: 0.0,
-                max_err_rel: 0.0,
-                max_err_reference_value: 0.0,
-                rms_diff: 0.0,
-                rms_result: 0.0,
-                rms_reference: 0.0,
-                rel_rms_reference: 0.0,
-                diff_max: 0.0,
-                diff_avg: 0.0,
-                result_nan: false,
-            };
+        Self::push_array(tensors, "activation_trace.output_norm", &traces.output_norm, export_shape);
+        if let Some(output_pooling) = &traces.output_pooling {
+            Self::push_array(tensors, "activation_trace.output_pooling", output_pooling, ExportShape::Native);
         }
-
-        let mut num_violations = 0;
-        let mut max_err = 0.0f32;
-        let mut max_err_idx = 0;
-        let mut max_err_rel = 0.0f32;
-        let mut max_err_reference_value = 0.0f32;
-        let mut sum_sq_diff = 0.0f32;
-        let mut sum_sq_result = 0.0f32;
-        let mut sum_sq_reference = 0.0f32;
-        let mut diff_sum = 0.0f32;
-        let mut diff_max = 0.0f32;
-        let mut result_nan = false;
-
-        for (i, (&exp, &prod)) in reference.iter().zip(result.iter()).enumerate() {
-            if prod.is_nan() {
-                result_nan = true;
-            }
-
-            let abs_diff = (exp - prod).abs();
-            let rel_diff = if exp.abs() > 1e-8 {
-                abs_diff / exp.abs()
-            } else {
-                abs_diff
-            };
-
-            diff_sum += abs_diff;
-            diff_max = diff_max.max(abs_diff);
-            sum_sq_diff += abs_diff * abs_diff;
-            sum_sq_result += prod * prod;
-            sum_sq_reference += exp * exp;
-
-            if abs_diff > atol && rel_diff > rtol {
-                num_violations += 1;
-            }
-
-            if abs_diff > max_err {
-                max_err = abs_diff;
-                max_err_idx = i;
-                max_err_rel = rel_diff;
-                max_err_reference_value = exp;
-            }
-        }
-
-        let n = reference.len() as f32;
-        let rms_diff = (sum_sq_diff / n).sqrt();
-        let rms_result = (sum_sq_result / n).sqrt();
-        let rms_reference = (sum_sq_reference / n).sqrt();
-        let rel_rms_reference = if rms_reference > 1e-8 {
-            rms_diff / rms_reference
+        let logits_shape = if traces.output_pooling.is_some() {
+            ExportShape::Native
         } else {
-            rms_diff
+            export_shape
         };
-        let diff_avg = diff_sum / n;
-
-        let max_allowed_violations = (fraction_of_allowed_violations * n).ceil() as usize;
-
-        TracerValidationMetrics {
-            atol,
-            rtol,
-            fraction_of_allowed_violations,
-            reference_shape,
-            result_shape,
-            num_violations,
-            max_allowed_violations,
-            max_err_idx,
-            max_err,
-            max_err_rel,
-            max_err_reference_value,
-            rms_diff,
-            rms_result,
-            rms_reference,
-            rel_rms_reference,
-            diff_max,
-            diff_avg,
-            result_nan,
-        }
+        Self::push_array(tensors, "logits", &traces.logits, logits_shape);
     }
 
-    // ========================================================================
-    // Utility Functions
-    // ========================================================================
-
-    fn load_array_as_vec<SourcePrecision: ArrayElement, TargetPrecision: NumCast>(
-        traces_view: &ParameterTree<B::Context>,
-        name: &str,
-    ) -> Vec<TargetPrecision> {
-        let array = traces_view.leaf_array(name).unwrap();
-        let slice = array.as_slice::<SourcePrecision>();
-        slice.iter().map(|x| NumCast::from(*x).unwrap()).collect()
+    fn write_trace_file(
+        output_path: &Path,
+        tensors: &[SafeTensorData],
+        metadata: Option<&BTreeMap<String, String>>,
+    ) -> Result<(), Error> {
+        let mut file = File::create_new(output_path).map_err(|_| Error::UnableToWriteTrace)?;
+        write_safetensors_with_metadata(&mut file, tensors, metadata).map_err(|_| Error::UnableToWriteTrace)
     }
 
-    fn determine_prefill_step_size(model_path: &Path) -> usize {
+    fn determine_prefill_step_size(model_path: &Path) -> Result<usize, Error> {
         let traces_path = model_path.join("traces.safetensors");
-        if let Ok(file) = File::open(&traces_path) {
-            if let Ok((_header_len, metadata)) = read_safetensors_metadata(&file) {
-                if let Some(tensor) = metadata.tensors.get("activation_trace.token_ids") {
-                    if let Some(&length) = tensor.shape.first() {
-                        return tensor.shape.iter().copied().max().unwrap_or(length).max(1);
-                    }
-                }
-            }
+        let file = File::open(&traces_path).map_err(|_| Error::UnableToLoadWeights)?;
+        let (_header_len, metadata) = read_safetensors_metadata(&file).map_err(|_| Error::UnableToLoadWeights)?;
+        let tensor = metadata.tensors.get("activation_trace.token_ids").ok_or(Error::UnableToLoadWeights)?;
+        let &[batch, suffix_length] = tensor.shape.as_slice() else {
+            return Err(Error::UnableToLoadWeights);
+        };
+        if batch != 1 || suffix_length == 0 {
+            return Err(Error::UnableToLoadWeights);
         }
-        1
+        Ok(suffix_length)
     }
 
     fn ensure_llm_context_capacity(
@@ -965,19 +409,88 @@ impl<B: Backend> TraceValidator<B> {
         context.gpu_sampler =
             Sampling::new(context.context.as_ref(), intermediate_dtype).expect("Failed to create sampling kernel");
     }
+}
 
-    fn get_tokens_from_logits(logits: &Array<B>) -> Vec<u64> {
-        let data_type = logits.data_type();
-        match data_type {
-            DataType::F16 => Self::get_tokens_from_logits_of_type::<f16>(logits),
-            DataType::BF16 => Self::get_tokens_from_logits_of_type::<bf16>(logits),
-            DataType::F32 => Self::get_tokens_from_logits_of_type::<f32>(logits),
-            _ => panic!("Unsupported data type: {:?}", data_type),
-        }
+pub fn export_tokenization_trace(
+    model_path: &Path,
+    output_path: &Path,
+    message: &str,
+) -> Result<(), Error> {
+    let metadata = load_model_metadata(model_path)?;
+    let message_processor_config = match metadata.model_config {
+        ModelConfig::LanguageModel(config) => config.message_processor_config,
+        ModelConfig::ClassifierModel(_) => return Err(Error::UnableToLoadConfig),
+        #[cfg(metal_backend)]
+        ModelConfig::TtsModel(_) => return Err(Error::UnableToLoadConfig),
+    };
+    let tokenizer_path = model_path.join("tokenizer.json");
+    if !tokenizer_path.exists() {
+        return Err(Error::UnableToLoadTokenizer);
     }
+    let tokenizer = Tokenizer::from_file(&tokenizer_path).map_err(|_| Error::UnableToLoadTokenizer)?;
+    let input = Input::Messages(vec![Message::user(message.to_string())]);
+    let rendered_request = InputProcessorDefault::new(message_processor_config.clone()).process(&input, true, true)?;
+    let encoding = tokenizer.encode(rendered_request.as_str(), false).map_err(|_| Error::UnableToEncodeText)?;
+    let token_ids = encoding
+        .get_ids()
+        .iter()
+        .map(|token| i32::try_from(*token).map_err(|_| Error::UnableToEncodeText))
+        .collect::<Result<Vec<_>, _>>()?;
+    if token_ids.is_empty() {
+        return Err(Error::UnableToEncodeText);
+    }
+    let token_positions = (0..token_ids.len())
+        .map(|position| i32::try_from(position).map_err(|_| Error::UnableToEncodeText))
+        .collect::<Result<Vec<_>, _>>()?;
+    let shape = [1, token_ids.len()];
+    let tensors = [
+        tensor_from_i32_slice("activation_trace.token_ids", &shape, &token_ids),
+        tensor_from_i32_slice("activation_trace.token_positions", &shape, &token_positions),
+    ];
+    let request = json!({
+        "add_generation_prompt": true,
+        "messages": [{"role": message_processor_config.user_role_name, "content": message}],
+        "bos_token": message_processor_config.bos_token,
+        "enable_thinking": true,
+    });
+    let mut trace_metadata = BTreeMap::new();
+    trace_metadata.insert("add_special_tokens".to_string(), "false".to_string());
+    trace_metadata.insert("prompt_template".to_string(), message_processor_config.prompt_template);
+    trace_metadata.insert("rendered_request".to_string(), rendered_request);
+    trace_metadata
+        .insert("request".to_string(), serde_json::to_string(&request).map_err(|_| Error::UnableToWriteTrace)?);
+    trace_metadata.insert(
+        "tokens".to_string(),
+        serde_json::to_string(encoding.get_tokens()).map_err(|_| Error::UnableToWriteTrace)?,
+    );
 
-    fn get_tokens_from_logits_of_type<Precision: ArrayElement>(logits: &Array<B>) -> Vec<u64> {
-        let sampler = ArgmaxSampler {};
-        sampler.sample(logits.as_view::<Precision>())
+    let mut file = File::create_new(output_path).map_err(|_| Error::UnableToWriteTrace)?;
+    write_safetensors_with_metadata(&mut file, &tensors, Some(&trace_metadata)).map_err(|_| Error::UnableToWriteTrace)
+}
+
+fn load_model_metadata(model_path: &Path) -> Result<ModelMetadata<ModelConfig>, Error> {
+    let config_path = model_path.join("config.json");
+    if !config_path.exists() {
+        return Err(Error::ModelFolderNotFound);
+    }
+    let config_file = File::open(&config_path).map_err(|_| Error::UnableToLoadConfig)?;
+    serde_json::from_reader(std::io::BufReader::new(config_file)).map_err(|_| Error::UnableToLoadConfig)
+}
+
+fn trace_metadata(file: &File) -> Result<Option<BTreeMap<String, String>>, Error> {
+    let (_offset, metadata) = read_safetensors_metadata(file).map_err(|_| Error::UnableToLoadWeights)?;
+    Ok(metadata.metadata.map(|values| values.into_iter().collect()))
+}
+
+fn tensor_from_i32_slice(
+    name: impl Into<String>,
+    shape: &[usize; 2],
+    values: &[i32],
+) -> SafeTensorData {
+    SafeTensorData {
+        name: name.into(),
+        shape: Box::new(*shape),
+        data_type: DataType::I32,
+        data: values.iter().flat_map(|value| value.to_le_bytes()).collect::<Vec<_>>().into_boxed_slice(),
     }
 }

--- a/crates/backend-uzu/tests/integration/tracer/trace_validator_test.rs
+++ b/crates/backend-uzu/tests/integration/tracer/trace_validator_test.rs
@@ -1,34 +1,50 @@
-use backend_uzu::backends::common::Backend;
+use std::{fs::File, path::PathBuf};
+
+use backend_uzu::{
+    backends::{
+        common::{Backend, Context},
+        cpu::Cpu,
+    },
+    data_type::DataType,
+    parameters::{Dtype, ParameterLoader, read_safetensors_metadata},
+};
+use tokenizers::Tokenizer;
 
 use crate::{
     common::{
         for_each_non_cpu_backend,
         path::{get_test_model_path, get_traces_path},
     },
-    tracer::trace_validator::TraceValidator,
+    tracer::trace_validator::{TraceValidator, export_tokenization_trace},
 };
 
 fn test_tracer_internal<B: Backend>() {
     let model_path = get_test_model_path();
     let mut tracer = TraceValidator::<B>::new(&model_path).expect("Failed to create TraceValidator");
-    let results = tracer.run().expect("Failed to run tracer");
-    for result in results.results.iter() {
-        assert!(result.metrics.is_valid(), "{} error:\n{}", result.name, result.metrics.message().as_str());
-    }
+    let input_file = File::open(get_traces_path()).expect("open input trace");
+    let (_offset, input_trace) = read_safetensors_metadata(&input_file).expect("read input trace metadata");
+    let (export_path, _temp_file) = match std::env::var_os("UZU_TRACE_EXPORT_PATH") {
+        Some(path) => (PathBuf::from(path), None),
+        None => {
+            let directory = tempfile::TempDir::new().expect("create exported trace directory");
+            (directory.path().join("uzu-traces.safetensors"), Some(directory))
+        },
+    };
+    tracer.export_trace(&export_path).expect("export uzu trace");
 
-    let total_token_violations = results.number_of_tokens_violations();
-    let allowed_token_violations = results.number_of_allowed_tokens_violations();
-    assert!(
-        total_token_violations < allowed_token_violations,
-        "Too much token violations: {} / {}. Indices: {:?}",
-        total_token_violations,
-        allowed_token_violations,
-        results.tokens_violation_indices
-    );
+    let file = File::open(&export_path).expect("open exported trace");
+    let (_offset, metadata) = read_safetensors_metadata(&file).expect("read exported trace metadata");
+    assert_eq!(metadata.metadata, input_trace.metadata);
+    assert!(metadata.tensors.contains_key("activation_trace.token_ids"));
+    assert!(metadata.tensors.contains_key("activation_trace.token_positions"));
+    assert!(metadata.tensors.contains_key("activation_trace.output_norm"));
+    assert!(metadata.tensors.contains_key("logits"));
+    assert!(metadata.tensors.keys().any(|path| path.ends_with(".activation_trace.inputs")));
+    assert!(metadata.tensors.keys().any(|path| path.ends_with(".updated_state.keys")));
 }
 
 #[test]
-#[ignore = "Lalamo 0.10.0 doesn't support exporting traces"] // TODO: this is horrible, should be resolved asap
+#[ignore = "requires a Lalamo traces.safetensors fixture in the test model directory"]
 fn test_tracer() {
     let traces_path = get_traces_path();
     assert!(traces_path.exists(), "Traces file missing at {:?}", traces_path);
@@ -36,4 +52,72 @@ fn test_tracer() {
     for_each_non_cpu_backend!(|B| {
         test_tracer_internal::<B>();
     })
+}
+
+#[test]
+fn test_tokenization_tracer() {
+    let model_path = get_test_model_path();
+    let (export_path, _temp_directory) = match std::env::var_os("UZU_TOKENIZATION_TRACE_EXPORT_PATH") {
+        Some(path) => (PathBuf::from(path), None),
+        None => {
+            let directory = tempfile::TempDir::new().expect("create tokenization trace directory");
+            (directory.path().join("uzu-tokenization-trace.safetensors"), Some(directory))
+        },
+    };
+    let message = std::env::var("UZU_TRACE_MESSAGE").unwrap_or_else(|_| "Tell me about London".to_string());
+
+    export_tokenization_trace(&model_path, &export_path, &message).expect("export tokenization trace");
+
+    let file = File::open(&export_path).expect("open tokenization trace");
+    let (_offset, trace) = read_safetensors_metadata(&file).expect("read tokenization trace metadata");
+    let token_ids_info = &trace.tensors["activation_trace.token_ids"];
+    let token_positions_info = &trace.tensors["activation_trace.token_positions"];
+    assert_eq!(token_ids_info.dtype, Dtype::I32);
+    assert_eq!(token_positions_info.dtype, Dtype::I32);
+    assert_eq!(token_ids_info.shape[0], 1);
+    assert_eq!(token_positions_info.shape, token_ids_info.shape);
+    let metadata = trace.metadata.expect("tokenization trace metadata");
+    assert_eq!(metadata["add_special_tokens"], "false");
+    assert!(metadata["rendered_request"].contains(&message));
+    let request: serde_json::Value = serde_json::from_str(&metadata["request"]).expect("parse request metadata");
+    assert_eq!(request["add_generation_prompt"], true);
+    let messages = request["messages"].as_array().expect("request messages");
+    assert_eq!(messages.last().expect("user message"), &serde_json::json!({"role": "user", "content": message}));
+    assert_eq!(request["enable_thinking"], true);
+    assert!(request.get("bos_token").is_some());
+    assert!(request.get("eos_token").is_some());
+
+    let context = <Cpu as Backend>::Context::new().expect("create CPU context");
+    let loader = ParameterLoader::<Cpu>::new(&file, context.as_ref()).expect("load tokenization trace");
+    let token_shape = token_ids_info.shape.as_slice();
+    let token_ids = loader
+        .tree()
+        .leaf("activation_trace.token_ids")
+        .unwrap()
+        .validate(token_shape, DataType::I32)
+        .unwrap()
+        .read_array()
+        .unwrap();
+    let token_positions = loader
+        .tree()
+        .leaf("activation_trace.token_positions")
+        .unwrap()
+        .validate(token_shape, DataType::I32)
+        .unwrap()
+        .read_array()
+        .unwrap();
+    let expected_tokens = Tokenizer::from_file(model_path.join("tokenizer.json"))
+        .expect("load tokenizer")
+        .encode(metadata["rendered_request"].as_str(), false)
+        .expect("encode rendered request");
+    let expected_token_ids =
+        expected_tokens.get_ids().iter().map(|token| i32::try_from(*token).unwrap()).collect::<Vec<_>>();
+    let expected_positions = (0..expected_token_ids.len()).map(|position| position as i32).collect::<Vec<_>>();
+
+    assert_eq!(token_ids.as_slice::<i32>(), expected_token_ids.as_slice());
+    assert_eq!(token_positions.as_slice::<i32>(), expected_positions.as_slice());
+    assert_eq!(
+        serde_json::from_str::<Vec<String>>(&metadata["tokens"]).unwrap(),
+        expected_tokens.get_tokens().to_vec()
+    );
 }

--- a/crates/backend-uzu/tests/integration/tracer/trace_validator_test.rs
+++ b/crates/backend-uzu/tests/integration/tracer/trace_validator_test.rs
@@ -1,34 +1,45 @@
-use backend_uzu::backends::common::Backend;
+use std::{fs::File, path::PathBuf};
+
+use backend_uzu::{
+    Dtype, ParameterLoader,
+    backends::{
+        common::{Backend, Context},
+        cpu::Cpu,
+    },
+    read_safetensors_metadata,
+};
+use tokenizers::Tokenizer;
 
 use crate::{
     common::{
         for_each_non_cpu_backend,
         path::{get_test_model_path, get_traces_path},
     },
-    tracer::trace_validator::TraceValidator,
+    tracer::trace_validator::{TraceValidator, export_tokenization_trace},
 };
 
 fn test_tracer_internal<B: Backend>() {
     let model_path = get_test_model_path();
     let mut tracer = TraceValidator::<B>::new(&model_path).expect("Failed to create TraceValidator");
-    let results = tracer.run().expect("Failed to run tracer");
-    for result in results.results.iter() {
-        // this layers contains too many errors
-        if result.name == "activation_trace.output_norm" || result.name == "logits" {
-            continue;
-        }
-        assert!(result.metrics.is_valid(), "{} error:\n{}", result.name, result.metrics.message().as_str());
-    }
+    let input_file = File::open(get_traces_path()).expect("open input trace");
+    let (_offset, input_trace) = read_safetensors_metadata(&input_file).expect("read input trace metadata");
+    let (export_path, _temp_file) = match std::env::var_os("UZU_TRACE_EXPORT_PATH") {
+        Some(path) => (PathBuf::from(path), None),
+        None => {
+            let directory = tempfile::TempDir::new().expect("create exported trace directory");
+            (directory.path().join("uzu-traces.safetensors"), Some(directory))
+        },
+    };
+    tracer.export_trace(&export_path).expect("export uzu trace");
 
-    let total_token_violations = results.number_of_tokens_violations();
-    let allowed_token_violations = results.number_of_allowed_tokens_violations();
-    assert!(
-        total_token_violations < allowed_token_violations,
-        "Too much token violations: {} / {}. Indices: {:?}",
-        total_token_violations,
-        allowed_token_violations,
-        results.tokens_violation_indices
-    );
+    let file = File::open(&export_path).expect("open exported trace");
+    let (_offset, metadata) = read_safetensors_metadata(&file).expect("read exported trace metadata");
+    assert_eq!(metadata.metadata, input_trace.metadata);
+    assert!(metadata.tensors.contains_key("activation_trace.token_ids"));
+    assert!(metadata.tensors.contains_key("activation_trace.token_positions"));
+    assert!(metadata.tensors.contains_key("activation_trace.output_norm"));
+    assert!(metadata.tensors.contains_key("logits"));
+    assert!(metadata.tensors.keys().any(|path| path.ends_with(".activation_trace.inputs")));
 }
 
 #[test]
@@ -39,4 +50,56 @@ fn test_tracer() {
     for_each_non_cpu_backend!(|B| {
         test_tracer_internal::<B>();
     })
+}
+
+#[test]
+fn test_tokenization_tracer() {
+    let model_path = get_test_model_path();
+    let (export_path, _temp_directory) = match std::env::var_os("UZU_TOKENIZATION_TRACE_EXPORT_PATH") {
+        Some(path) => (PathBuf::from(path), None),
+        None => {
+            let directory = tempfile::TempDir::new().expect("create tokenization trace directory");
+            (directory.path().join("uzu-tokenization-trace.safetensors"), Some(directory))
+        },
+    };
+    let message = std::env::var("UZU_TRACE_MESSAGE").unwrap_or_else(|_| "Tell me about London".to_string());
+
+    export_tokenization_trace(&model_path, &export_path, &message).expect("export tokenization trace");
+
+    let file = File::open(&export_path).expect("open tokenization trace");
+    let (_offset, trace) = read_safetensors_metadata(&file).expect("read tokenization trace metadata");
+    let token_ids_info = &trace.tensors["activation_trace.token_ids"];
+    let token_positions_info = &trace.tensors["activation_trace.token_positions"];
+    assert_eq!(token_ids_info.dtype, Dtype::I32);
+    assert_eq!(token_positions_info.dtype, Dtype::I32);
+    assert_eq!(token_ids_info.shape[0], 1);
+    assert_eq!(token_positions_info.shape, token_ids_info.shape);
+    let metadata = trace.metadata.expect("tokenization trace metadata");
+    assert_eq!(metadata["add_special_tokens"], "false");
+    assert!(metadata["rendered_request"].contains(&message));
+    let request: serde_json::Value = serde_json::from_str(&metadata["request"]).expect("parse request metadata");
+    assert_eq!(request["add_generation_prompt"], true);
+    assert_eq!(request["messages"], serde_json::json!([{"role": "user", "content": message}]));
+    assert_eq!(request["enable_thinking"], true);
+    assert!(request.get("bos_token").is_some());
+    assert!(request.get("eos_token").is_none());
+
+    let context = <Cpu as Backend>::Context::new().expect("create CPU context");
+    let loader = ParameterLoader::new(&file, context.as_ref()).expect("load tokenization trace");
+    let token_ids = loader.tree().leaf_array("activation_trace.token_ids").unwrap();
+    let token_positions = loader.tree().leaf_array("activation_trace.token_positions").unwrap();
+    let expected_tokens = Tokenizer::from_file(model_path.join("tokenizer.json"))
+        .expect("load tokenizer")
+        .encode(metadata["rendered_request"].as_str(), false)
+        .expect("encode rendered request");
+    let expected_token_ids =
+        expected_tokens.get_ids().iter().map(|token| i32::try_from(*token).unwrap()).collect::<Vec<_>>();
+    let expected_positions = (0..expected_token_ids.len()).map(|position| position as i32).collect::<Vec<_>>();
+
+    assert_eq!(token_ids.as_slice::<i32>(), expected_token_ids.as_slice());
+    assert_eq!(token_positions.as_slice::<i32>(), expected_positions.as_slice());
+    assert_eq!(
+        serde_json::from_str::<Vec<String>>(&metadata["tokens"]).unwrap(),
+        expected_tokens.get_tokens().to_vec()
+    );
 }


### PR DESCRIPTION
## Summary

Reworks the Uzu tracing integration around activation/tokenization export instead of local comparison:

- removes the old trace comparator/metrics implementation from the Uzu integration tracer
- exports Uzu activation traces to `traces.safetensors`-compatible safetensors output
- exports Uzu tokenization traces with `activation_trace.token_ids` / `activation_trace.token_positions` plus rendered request metadata
- keeps trace input loading strict for token id/position shape
- adds a minimal safetensors writer for exported trace tensors and metadata
- keeps the reusable writer byte/schema oriented instead of tying it to backend arrays

This pairs with the Lalamo comparator PR: https://github.com/trymirai/lalamo/pull/285

## Validation

- `cargo test -p backend-uzu test_safetensors_metadata_writer --test integration`
- `cargo check -p backend-uzu --tests`
- `cargo fmt --check -p backend-uzu`
- `git diff --check`

`cargo fmt --check` passes but prints existing stable-rustfmt warnings about nightly-only config keys.