### PR TITLE
tools: install cmake in setup for the grammar feature

### DIFF
--- a/crates/cli-tools/src/main.rs
+++ b/crates/cli-tools/src/main.rs
@@ -69,6 +69,7 @@ fn run_setup(include_platform_specific: bool) -> Result<()> {
         if cfg!(target_vendor = "apple") {
             Command::xcodebuild_first_launch().run()?;
             Command::xcodebuild_download_metal_toolchain().run()?;
+            Command::cmake_setup().run()?;
         }
     }
 

--- a/crates/cli-tools/src/types/command.rs
+++ b/crates/cli-tools/src/types/command.rs
@@ -409,6 +409,10 @@ impl Command {
         Self::xcodebuild().with_arguments(vec!["-downloadComponent".to_string(), "MetalToolchain".to_string()])
     }
 
+    pub fn cmake_setup() -> Self {
+        Self::new("sh").with_argument("-c").with_argument("cmake --version >/dev/null 2>&1 || brew install cmake")
+    }
+
     pub fn xcodebuild_create_xcframework(
         slice_libraries_with_headers_paths: Vec<(PathBuf, PathBuf)>,
         output_path: PathBuf,


### PR DESCRIPTION
`cargo tools setup` downloads the Metal toolchain on Apple but not cmake, which the default grammar feature needs to build xgrammar-rs. CI already installs cmake via brew alongside the Metal toolchain ([`.github/actions/setup/action.yml`](https://github.com/trymirai/uzu/blob/main/.github/actions/setup/action.yml#L70)); mirror that here so a default `cargo build -p cli` works after the documented setup.