### PR TITLE
tools: install clang-format in setup for the metal format check

### DIFF
--- a/crates/cli-tools/src/main.rs
+++ b/crates/cli-tools/src/main.rs
@@ -70,6 +70,7 @@ fn run_setup(include_platform_specific: bool) -> Result<()> {
             Command::xcodebuild_first_launch().run()?;
             Command::xcodebuild_download_metal_toolchain().run()?;
             Command::cmake_setup().run()?;
+            Command::clang_format_setup().run()?;
         }
     }
 

--- a/crates/cli-tools/src/types/command.rs
+++ b/crates/cli-tools/src/types/command.rs
@@ -413,6 +413,12 @@ impl Command {
         Self::new("sh").with_argument("-c").with_argument("cmake --version >/dev/null 2>&1 || brew install cmake")
     }
 
+    pub fn clang_format_setup() -> Self {
+        Self::new("sh")
+            .with_argument("-c")
+            .with_argument("clang-format --version >/dev/null 2>&1 || brew install clang-format")
+    }
+
     pub fn xcodebuild_create_xcframework(
         slice_libraries_with_headers_paths: Vec<(PathBuf, PathBuf)>,
         output_path: PathBuf,


### PR DESCRIPTION
`cargo tools setup` installs the Metal toolchain and cmake on Apple but not clang-format, which the linters job uses to enforce `.metal`/header formatting ([`scripts/clang-format.sh --check`](https://github.com/trymirai/uzu/blob/main/.github/workflows/tests.yml#L44)). CI already installs clang-format via brew alongside cmake ([`.github/actions/setup/action.yml`](https://github.com/trymirai/uzu/blob/main/.github/actions/setup/action.yml#L65)); mirror that here so a contributor who edits a Metal kernel can satisfy the format check locally after the documented setup.