### PR TITLE
bench: configurable speculator and acceptance metrics

### DIFF
--- a/crates/benchmarks/src/runner/runner.rs
+++ b/crates/benchmarks/src/runner/runner.rs
@@ -1,20 +1,22 @@
 use std::{
     path::PathBuf,
+    sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
 
 use backend_uzu::{
     VERSION,
+    prelude::PromptLookupSpeculator,
     session::{
         ChatSession,
-        config::{DecodingConfig, RunConfig},
+        config::{DecodingConfig, RunConfig, SpeculatorConfig},
         parameter::{PrefillStepSize, SamplingMethod, SamplingPolicy},
         types::{Input, Output},
     },
 };
 use sysinfo::System;
 
-use crate::runner::types::{Device, Result as TaskResult, Task};
+use crate::runner::types::{Device, Result as TaskResult, SpeculatorSpec, Task};
 
 pub struct Runner {
     pub task: Task,
@@ -46,6 +48,18 @@ impl Runner {
         if let Some(prefill_step_size) = self.prefill_step_size {
             decoding_config = decoding_config.with_prefill_step_size(PrefillStepSize::Custom(prefill_step_size));
         }
+        if let Some(speculator) = &self.task.speculator {
+            let speculator_config = match speculator {
+                SpeculatorSpec::PromptLookup {
+                    max_ngram_size,
+                    number_of_speculated_tokens,
+                } => SpeculatorConfig::new(
+                    *number_of_speculated_tokens,
+                    Arc::new(PromptLookupSpeculator::new_with_params(*max_ngram_size)),
+                ),
+            };
+            decoding_config = decoding_config.with_speculator_config(speculator_config);
+        }
 
         let mut session = ChatSession::new(PathBuf::from(self.model_path.clone()), decoding_config)?;
         let data_type = session.activation_data_type();
@@ -71,6 +85,13 @@ impl Runner {
 
             let memory_used = session.peak_memory_usage();
 
+            let (speculator_proposed, speculator_accepted) = output
+                .stats
+                .generate_stats
+                .as_ref()
+                .map(|stats| (stats.speculator_proposed, stats.speculator_accepted))
+                .unwrap_or((0, 0));
+
             let result = TaskResult {
                 task: self.task.clone(),
                 device: device.clone(),
@@ -83,6 +104,8 @@ impl Runner {
                 time_to_first_token: output.stats.prefill_stats.duration,
                 prompt_tokens_per_second: output.stats.prefill_stats.processed_tokens_per_second,
                 generate_tokens_per_second: output.stats.generate_stats.map(|stats| stats.tokens_per_second),
+                speculator_proposed,
+                speculator_accepted,
                 text: output.text.original,
             };
             results.push(result);

--- a/crates/benchmarks/src/runner/types/mod.rs
+++ b/crates/benchmarks/src/runner/types/mod.rs
@@ -4,4 +4,4 @@ mod task;
 
 pub use device::Device;
 pub use result::Result;
-pub use task::Task;
+pub use task::{SpeculatorSpec, Task};

--- a/crates/benchmarks/src/runner/types/result.rs
+++ b/crates/benchmarks/src/runner/types/result.rs
@@ -16,5 +16,7 @@ pub struct Result {
     pub time_to_first_token: f64,
     pub prompt_tokens_per_second: f64,
     pub generate_tokens_per_second: Option<f64>,
+    pub speculator_proposed: u64,
+    pub speculator_accepted: u64,
     pub text: String,
 }

--- a/crates/benchmarks/src/runner/types/task.rs
+++ b/crates/benchmarks/src/runner/types/task.rs
@@ -1,6 +1,15 @@
 use backend_uzu::session::types::Message;
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SpeculatorSpec {
+    PromptLookup {
+        max_ngram_size: usize,
+        number_of_speculated_tokens: usize,
+    },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Task {
     pub identifier: String,
@@ -9,4 +18,6 @@ pub struct Task {
     pub tokens_limit: u64,
     pub messages: Vec<Message>,
     pub greedy: bool,
+    #[serde(default)]
+    pub speculator: Option<SpeculatorSpec>,
 }

--- a/crates/cli/src/bench.rs
+++ b/crates/cli/src/bench.rs
@@ -59,6 +59,26 @@ fn print_summary(results: &[BenchmarkResult]) -> Result<()> {
     let prompt_tokens_per_second_metric = calculate_metric(&prompt_tokens_per_second_list);
     let generate_tokens_per_second_metric = calculate_metric(&generate_tokens_per_second_list);
 
+    let speculator_proposed_total: u64 = results.iter().map(|result| result.speculator_proposed).sum();
+    let accepted_per_forward_pass_list = results
+        .iter()
+        .filter_map(|result| {
+            let forward_pass_count = result.tokens_count_output.checked_sub(result.speculator_accepted)?;
+            if forward_pass_count == 0 {
+                None
+            } else {
+                Some(result.speculator_accepted as f64 / forward_pass_count as f64)
+            }
+        })
+        .collect::<Vec<f64>>();
+    let acceptance_rate_list = results
+        .iter()
+        .filter(|result| result.speculator_proposed > 0)
+        .map(|result| 100.0 * result.speculator_accepted as f64 / result.speculator_proposed as f64)
+        .collect::<Vec<f64>>();
+    let accepted_per_forward_pass_metric = calculate_metric(&accepted_per_forward_pass_list);
+    let acceptance_rate_metric = calculate_metric(&acceptance_rate_list);
+
     let mut table = Table::new();
     table
         .load_preset(UTF8_FULL)
@@ -69,6 +89,11 @@ fn print_summary(results: &[BenchmarkResult]) -> Result<()> {
         .add_row(vec!["TTFT, s", time_to_first_token_metric.as_str()])
         .add_row(vec!["Prompt, t/s", prompt_tokens_per_second_metric.as_str()])
         .add_row(vec!["Generate, t/s", generate_tokens_per_second_metric.as_str()]);
+
+    if speculator_proposed_total > 0 {
+        table.add_row(vec!["Accepted / forward pass", accepted_per_forward_pass_metric.as_str()]);
+        table.add_row(vec!["Acceptance rate, %", acceptance_rate_metric.as_str()]);
+    }
 
     let Some(column) = table.column_mut(1) else {
         bail!("Benchmark summary table value column is missing");


### PR DESCRIPTION
The benchmark runner already drives `ChatSession`, but always with the default (no-op) speculator, so the speculator metrics that `output.stats` already carries (`speculator_proposed`/`speculator_accepted`, #272) are never exercised or reported.

This adds an optional typed `speculator` field to the benchmark task (`prompt_lookup` for now) so speculation can be measured end-to-end, and surfaces **Accepted / forward pass** (the #272 metric) and **Acceptance rate** in the summary table when a speculator is configured.

The field is `#[serde(default)]` → `None`, so existing task files parse and run unchanged — and the two extra rows only appear when a speculator is set, so non-speculative runs are not cluttered.

### Usage
```json
"speculator": { "kind": "prompt_lookup", "max_ngram_size": 3, "number_of_speculated_tokens": 15 }
```

### Output
Same copy-style prompt (Llama-3.2-1B, greedy), with vs without the field:

**Without `speculator` (unchanged):**
```
╭─────────────────┬───────────────────╮
│ Metric          ┆             Value │
╞═════════════════╪═══════════════════╡
│ Used memory, GB ┆     2.557 ± 0.000 │
│ TTFT, s         ┆     0.078 ± 0.001 │
│ Prompt, t/s     ┆ 1380.514 ± 17.711 │
│ Generate, t/s   ┆    69.946 ± 0.519 │
╰─────────────────┴───────────────────╯
```

**With `prompt_lookup` (n=3, k=15):**
```
╭─────────────────────────┬──────────────────╮
│ Metric                  ┆            Value │
╞═════════════════════════╪══════════════════╡
│ Used memory, GB         ┆    2.557 ± 0.000 │
│ TTFT, s                 ┆    0.084 ± 0.000 │
│ Prompt, t/s             ┆ 1279.186 ± 1.594 │
│ Generate, t/s           ┆  282.662 ± 0.674 │
│ Accepted / forward pass ┆    9.167 ± 0.000 │
│ Acceptance rate, %      ┆   91.667 ± 0.000 │
╰─────────────────────────┴──────────────────╯
```