### PR TITLE
Add --model argument to the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1638,6 +1638,14 @@ cargo run --release -p cli
 
 This launches an interactive app where you can browse, download, and interact with models.
 
+You can also preselect a model with `--model`, passing its identifier or repository id:
+
+```bash
+cargo run --release -p cli -- --model trymirai/Qwen3.5-4B-M
+```
+
+If the model is not downloaded yet, the CLI starts downloading it automatically.
+
 ## Benchmarks
 
 To run benchmarks:

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -6,6 +6,9 @@ mod bench;
 #[derive(Parser)]
 #[command(name = "cli", bin_name = "cli")]
 struct Cli {
+    /// Identifier of the model to start with (e.g. "Qwen/Qwen3-0.6B").
+    #[arg(long, value_name = "MODEL")]
+    model: Option<String>,
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -29,24 +32,24 @@ async fn main() -> Result<()> {
             task_path,
             output_path,
         }) => bench::run_bench(model_path, task_path, output_path)?,
-        None => run_interactive().await?,
+        None => run_interactive(cli.model).await?,
     }
 
     Ok(())
 }
 
 #[cfg(feature = "capability-cli")]
-async fn run_interactive() -> Result<()> {
+async fn run_interactive(model: Option<String>) -> Result<()> {
     use uzu::{cli::CliApplication, engine::EngineConfig};
 
     let engine_config = EngineConfig::default().with_application_identifier("com.trymirai.cli".to_string());
     let application = CliApplication::create(engine_config).await?;
-    application.run().await?;
+    application.run_with_model(model).await?;
 
     Ok(())
 }
 
 #[cfg(not(feature = "capability-cli"))]
-async fn run_interactive() -> Result<()> {
+async fn run_interactive(_model: Option<String>) -> Result<()> {
     Ok(())
 }

--- a/crates/uzu/src/cli/components/application.rs
+++ b/crates/uzu/src/cli/components/application.rs
@@ -20,6 +20,7 @@ pub struct ApplicationProps {
     pub engine: Option<Engine>,
     pub settings: Option<Settings>,
     pub theme: Option<Theme>,
+    pub model: Option<String>,
 }
 
 pub struct ModelState {
@@ -65,6 +66,36 @@ pub fn Application(
         model_state: None,
     });
     let (width, _) = hooks.use_terminal_size();
+
+    hooks.use_future({
+        let engine = state.read().engine.clone();
+        let initial_model = props.model.clone();
+        let mut state = state;
+        async move {
+            let Some(identifier) = initial_model else {
+                return;
+            };
+            match engine.model(identifier.clone()).await {
+                Ok(Some(model)) => {
+                    let summary = format!("Model: {}", model.name());
+                    state.write().model_state = Some(ModelState {
+                        model,
+                        download_state: DownloadState::not_downloaded(0),
+                        session_state: None,
+                    });
+                    state.write().history.push(HistoryCellType::CommandResult {
+                        result: summary,
+                    });
+                },
+                Ok(None) => state.write().history.push(HistoryCellType::CommandResult {
+                    result: format!("Unknown model: {}", identifier),
+                }),
+                Err(error) => state.write().history.push(HistoryCellType::CommandResult {
+                    result: format!("Failed to load model {}: {}", identifier, error),
+                }),
+            }
+        }
+    });
 
     let on_command = hooks.use_async_handler(move |text: String| async move {
         let mut state = state;

--- a/crates/uzu/src/cli/mod.rs
+++ b/crates/uzu/src/cli/mod.rs
@@ -39,18 +39,11 @@ impl CliApplication {
             engine,
         }
     }
-}
 
-#[bindings::export(Implementation)]
-impl CliApplication {
-    #[bindings::export(Method(Factory))]
-    pub async fn create(config: EngineConfig) -> Result<Self, CliError> {
-        let engine = Engine::new(config).await?;
-        Ok(Self::new(engine))
-    }
-
-    #[bindings::export(Method)]
-    pub async fn run(&self) -> Result<(), CliError> {
+    pub async fn run_with_model(
+        &self,
+        model: Option<String>,
+    ) -> Result<(), CliError> {
         if !std::io::stdout().is_terminal() {
             return Err(CliError::RenderingError {
                 message: "stdout is not a terminal".to_string(),
@@ -64,7 +57,7 @@ impl CliApplication {
         };
 
         element! {
-            Application(engine: Some(self.engine.clone()), settings: settings, theme: Some(theme))
+            Application(engine: Some(self.engine.clone()), settings: settings, theme: Some(theme), model: model)
         }
         .render_loop()
         .await
@@ -73,5 +66,19 @@ impl CliApplication {
         })?;
 
         Ok(())
+    }
+}
+
+#[bindings::export(Implementation)]
+impl CliApplication {
+    #[bindings::export(Method(Factory))]
+    pub async fn create(config: EngineConfig) -> Result<Self, CliError> {
+        let engine = Engine::new(config).await?;
+        Ok(Self::new(engine))
+    }
+
+    #[bindings::export(Method)]
+    pub async fn run(&self) -> Result<(), CliError> {
+        self.run_with_model(None).await
     }
 }

--- a/workspace/readme/template.md
+++ b/workspace/readme/template.md
@@ -119,6 +119,14 @@ cargo run --release -p cli
 
 This launches an interactive app where you can browse, download, and interact with models.
 
+You can also preselect a model with `--model`, passing its identifier or repository id:
+
+```bash
+cargo run --release -p cli -- --model trymirai/Qwen3.5-4B-M
+```
+
+If the model is not downloaded yet, the CLI starts downloading it automatically.
+
 ## Benchmarks
 
 To run benchmarks:


### PR DESCRIPTION
Adds a `--model <MODEL>` argument to the interactive CLI so a model can be preselected at launch instead of choosing it via the `/model` flow.