### PR TITLE
OpenAI Server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,6 +326,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +357,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "atomic"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
 
 [[package]]
 name = "atomic"
@@ -666,6 +694,12 @@ dependencies = [
  "serde",
  "sysinfo",
 ]
+
+[[package]]
+name = "binascii"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
 
 [[package]]
 name = "bindgen"
@@ -1117,8 +1151,12 @@ dependencies = [
  "clap",
  "comfy-table",
  "indicatif",
+ "rocket",
+ "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
+ "uuid",
  "uzu",
 ]
 
@@ -1156,7 +1194,7 @@ dependencies = [
  "serde_json",
  "syn 2.0.117",
  "toml 1.1.2+spec-1.1.0",
- "toml_edit",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -1305,6 +1343,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1371,7 +1420,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -1830,6 +1879,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "devise"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d90b0c4c777a2cad215e3c7be59ac7c15adf45cf76317009b7d096d46f651d"
+dependencies = [
+ "devise_codegen",
+ "devise_core",
+]
+
+[[package]]
+name = "devise_codegen"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71b28680d8be17a570a2334922518be6adc3f58ecc880cbb404eaeb8624fd867"
+dependencies = [
+ "devise_core",
+ "quote",
+]
+
+[[package]]
+name = "devise_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b035a542cf7abf01f2e3c4d5a7acbaebfefe120ae4efc7bde3df98186e4b8af7"
+dependencies = [
+ "bitflags 2.11.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2154,6 +2236,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic 0.6.1",
+ "pear",
+ "serde",
+ "toml 0.8.23",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2359,6 +2455,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.48.0",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2479,6 +2588,25 @@ checksum = "be136d9dacc2a13cc70bb6c8f902b414fb2641f8db1314637c6b7933411a8f82"
 
 [[package]]
 name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
@@ -2488,7 +2616,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.1",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -2605,6 +2733,17 @@ checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
@@ -2615,12 +2754,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -2631,8 +2781,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2656,6 +2806,30 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
@@ -2664,9 +2838,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.14",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -2682,8 +2856,8 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.1",
+ "hyper 1.10.1",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
@@ -2703,14 +2877,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2965,6 +3139,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3049,6 +3229,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3462,6 +3653,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "loop9"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3711,7 +3917,7 @@ dependencies = [
  "bitflags 2.11.1",
  "bytesize",
  "crc32c",
- "http",
+ "http 1.4.1",
  "httparse",
  "serde_json",
  "shoji",
@@ -3776,6 +3982,25 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.4.1",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "tokio",
+ "tokio-util",
+ "version_check",
 ]
 
 [[package]]
@@ -4433,6 +4658,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4653,7 +4901,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -4687,6 +4935,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -4889,7 +5150,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4927,7 +5188,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5385,10 +5646,10 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -5430,11 +5691,11 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.14",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -5525,6 +5786,88 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rocket"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a516907296a31df7dc04310e7043b61d71954d703b603cc6867a026d7e72d73f"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "atomic 0.5.3",
+ "binascii",
+ "bytes",
+ "either",
+ "figment",
+ "futures",
+ "indexmap 2.14.0",
+ "log",
+ "memchr",
+ "multer",
+ "num_cpus",
+ "parking_lot",
+ "pin-project-lite",
+ "rand 0.8.6",
+ "ref-cast",
+ "rocket_codegen",
+ "rocket_http",
+ "serde",
+ "serde_json",
+ "state",
+ "tempfile",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "ubyte",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
+name = "rocket_codegen"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "575d32d7ec1a9770108c879fc7c47815a80073f96ca07ff9525a94fcede1dd46"
+dependencies = [
+ "devise",
+ "glob",
+ "indexmap 2.14.0",
+ "proc-macro2",
+ "quote",
+ "rocket_http",
+ "syn 2.0.117",
+ "unicode-xid",
+ "version_check",
+]
+
+[[package]]
+name = "rocket_http"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e274915a20ee3065f611c044bd63c40757396b6dbc057d6046aec27f14f882b9"
+dependencies = [
+ "cookie",
+ "either",
+ "futures",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "indexmap 2.14.0",
+ "log",
+ "memchr",
+ "pear",
+ "percent-encoding",
+ "pin-project-lite",
+ "ref-cast",
+ "serde",
+ "smallvec",
+ "stable-pattern",
+ "state",
+ "time",
+ "tokio",
+ "uncased",
 ]
 
 [[package]]
@@ -5829,6 +6172,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5978,6 +6327,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -6218,6 +6576,16 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
@@ -6225,6 +6593,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spm_precompiled"
@@ -6239,10 +6613,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable-pattern"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4564168c00635f88eaed410d5efa8131afa8d8699a612c80c455a0ba05c21045"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "state"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8c4a4445d81357df8b1a650d0d0d6fbbbfe99d064aa5e02f3e4022061476d8"
+dependencies = [
+ "loom",
+]
 
 [[package]]
 name = "static_assertions"
@@ -6414,7 +6806,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -6783,7 +7175,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -6837,13 +7229,25 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
- "serde_spanned",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -6858,11 +7262,20 @@ checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
- "serde_spanned",
+ "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -6881,6 +7294,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -6904,6 +7331,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -6935,8 +7368,8 @@ dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "pin-project-lite",
  "tower",
  "tower-layer",
@@ -7081,6 +7514,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "ubyte"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f720def6ce1ee2fc44d40ac9ed6d3a59c361c80a75a7aa8e75bb9baed31cf2ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7091,6 +7533,16 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "serde",
+ "version_check",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -7396,7 +7848,7 @@ version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
- "atomic",
+ "atomic 0.6.1",
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
@@ -7843,6 +8295,15 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
@@ -8015,6 +8476,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -8063,6 +8539,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -8081,6 +8563,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -8096,6 +8584,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8129,6 +8623,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -8144,6 +8644,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8165,6 +8671,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -8180,6 +8692,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8221,9 +8739,9 @@ dependencies = [
  "base64 0.22.1",
  "deadpool",
  "futures",
- "http",
+ "http 1.4.1",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-util",
  "log",
  "once_cell",
@@ -8360,6 +8878,15 @@ name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+dependencies = [
+ "is-terminal",
+]
 
 [[package]]
 name = "yoke"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -28,7 +28,11 @@ anyhow.workspace = true
 clap.workspace = true
 comfy-table.workspace = true
 indicatif.workspace = true
+serde.workspace = true
 serde_json.workspace = true
+rocket.workspace = true
+uuid.workspace = true
+tokio-stream.workspace = true
 
 [lints]
 workspace = true

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -21,15 +21,11 @@ enum Commands {
         task_path: String,
         output_path: String,
     },
-    /// Start an OpenAI-compatible HTTP server for a single model.
     Server {
-        /// Model identifier (e.g. "Qwen/Qwen3-0.6B") or path to a local model folder.
         #[arg(long, value_name = "MODEL")]
         model: String,
-        /// Port to listen on.
         #[arg(long, default_value_t = 8000)]
         port: u16,
-        /// Host address to bind to.
         #[arg(long, default_value = "127.0.0.1")]
         host: String,
     },

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 
 mod bench;
+mod server;
 
 #[derive(Parser)]
 #[command(name = "cli", bin_name = "cli")]
@@ -20,6 +21,18 @@ enum Commands {
         task_path: String,
         output_path: String,
     },
+    /// Start an OpenAI-compatible HTTP server for a single model.
+    Server {
+        /// Model identifier (e.g. "Qwen/Qwen3-0.6B") or path to a local model folder.
+        #[arg(long, value_name = "MODEL")]
+        model: String,
+        /// Port to listen on.
+        #[arg(long, default_value_t = 8000)]
+        port: u16,
+        /// Host address to bind to.
+        #[arg(long, default_value = "127.0.0.1")]
+        host: String,
+    },
 }
 
 #[tokio::main]
@@ -32,6 +45,11 @@ async fn main() -> Result<()> {
             task_path,
             output_path,
         }) => bench::run_bench(model_path, task_path, output_path)?,
+        Some(Commands::Server {
+            model,
+            port,
+            host,
+        }) => server::run_server(model, host, port).await?,
         None => run_interactive(cli.model).await?,
     }
 

--- a/crates/cli/src/server/chat_completions.rs
+++ b/crates/cli/src/server/chat_completions.rs
@@ -29,10 +29,6 @@ use uzu::{
 
 use crate::server::ServerState;
 
-// ---------------------------------------------------------------------------
-// OpenAI-compatible request / response types
-// ---------------------------------------------------------------------------
-
 #[derive(Serialize, Deserialize, Clone)]
 pub struct OaiMessage {
     pub role: String,
@@ -110,10 +106,6 @@ struct ChatCompletionChunk {
     usage: Option<ChatCompletionUsage>,
 }
 
-// ---------------------------------------------------------------------------
-// Responder: either a JSON body or an SSE stream
-// ---------------------------------------------------------------------------
-
 pub enum ChatCompletionResult {
     Json(Json<ChatCompletionResponse>),
     Stream(EventStream<Pin<Box<dyn Stream<Item = Event> + Send>>>),
@@ -130,10 +122,6 @@ impl<'r> Responder<'r, 'r> for ChatCompletionResult {
         }
     }
 }
-
-// ---------------------------------------------------------------------------
-// Mapping helpers
-// ---------------------------------------------------------------------------
 
 fn now_unix() -> i64 {
     SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs() as i64).unwrap_or(0)
@@ -153,12 +141,10 @@ fn build_reply_config(request: &ChatCompletionRequest) -> ChatReplyConfig {
     let token_limit = request.max_completion_tokens.or(request.max_tokens);
     let config = ChatReplyConfig::default().with_token_limit(token_limit);
 
-    // temperature <= 0 -> deterministic greedy decoding.
     if request.temperature.is_some_and(|temperature| temperature <= 0.0) {
         return config.with_sampling_method(SamplingMethod::Greedy {});
     }
 
-    // Any sampling parameter present -> stochastic; otherwise keep the model default.
     if request.temperature.is_some() || request.top_p.is_some() || request.top_k.is_some() {
         return config.with_sampling_method(SamplingMethod::Stochastic {
             temperature: request.temperature,
@@ -237,10 +223,6 @@ fn chunk_json(
     serde_json::to_string(&chunk).unwrap_or_default()
 }
 
-// ---------------------------------------------------------------------------
-// Generation
-// ---------------------------------------------------------------------------
-
 async fn run_blocking(
     session: Arc<Mutex<ChatSession>>,
     messages: Vec<ChatMessage>,
@@ -307,7 +289,6 @@ async fn run_stream(
         return;
     }
 
-    // Initial chunk announcing the assistant role.
     let _ = sender.send(Event::data(chunk_json(
         &id,
         &model,
@@ -335,7 +316,6 @@ async fn run_stream(
                     continue;
                 };
                 let text = reply.message.text().unwrap_or_default();
-                // Stream chunks carry cumulative text; emit only the new, char-boundary-safe tail.
                 let start = (emitted..=text.len()).find(|&index| text.is_char_boundary(index)).unwrap_or(text.len());
                 if text.len() > start {
                     let delta = text[start..].to_string();
@@ -352,7 +332,7 @@ async fn run_stream(
                         None,
                     )));
                     if sent.is_err() {
-                        return; // client disconnected
+                        return;
                     }
                 }
                 if let Some(reason) = &reply.finish_reason {
@@ -395,10 +375,6 @@ async fn run_stream(
     }
     let _ = sender.send(Event::data("[DONE]"));
 }
-
-// ---------------------------------------------------------------------------
-// Route
-// ---------------------------------------------------------------------------
 
 #[allow(private_interfaces)]
 #[post("/chat/completions", format = "json", data = "<request>")]

--- a/crates/cli/src/server/chat_completions.rs
+++ b/crates/cli/src/server/chat_completions.rs
@@ -1,0 +1,429 @@
+use std::{
+    pin::Pin,
+    str::FromStr,
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use rocket::{
+    Request, State,
+    futures::Stream,
+    post,
+    response::{
+        Responder,
+        stream::{Event, EventStream},
+    },
+    serde::json::Json,
+};
+use serde::{Deserialize, Serialize};
+use tokio::sync::{Mutex, mpsc};
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use uuid::Uuid;
+use uzu::{
+    session::chat::{ChatSession, ChatSessionStreamChunk},
+    types::{
+        basic::SamplingMethod,
+        session::chat::{ChatMessage, ChatReplyConfig, ChatReplyFinishReason, ChatReplyStats, ChatRole},
+    },
+};
+
+use crate::server::ServerState;
+
+// ---------------------------------------------------------------------------
+// OpenAI-compatible request / response types
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct OaiMessage {
+    pub role: String,
+    #[serde(default)]
+    pub content: String,
+}
+
+#[derive(Deserialize)]
+pub struct ChatCompletionRequest {
+    pub messages: Vec<OaiMessage>,
+    #[serde(default)]
+    pub stream: Option<bool>,
+    #[serde(default)]
+    pub max_tokens: Option<u32>,
+    #[serde(default)]
+    pub max_completion_tokens: Option<u32>,
+    #[serde(default)]
+    pub temperature: Option<f64>,
+    #[serde(default)]
+    pub top_p: Option<f64>,
+    #[serde(default)]
+    pub top_k: Option<i64>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub model: Option<String>,
+}
+
+#[derive(Serialize, Clone)]
+pub struct ChatCompletionChoice {
+    pub index: u32,
+    pub message: OaiMessage,
+    pub finish_reason: String,
+}
+
+#[derive(Serialize, Clone, Default)]
+pub struct ChatCompletionUsage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
+}
+
+#[derive(Serialize, Clone)]
+pub struct ChatCompletionResponse {
+    pub id: String,
+    pub object: String,
+    pub created: i64,
+    pub model: String,
+    pub choices: Vec<ChatCompletionChoice>,
+    pub usage: ChatCompletionUsage,
+}
+
+#[derive(Serialize)]
+struct StreamDelta {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    role: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<String>,
+}
+
+#[derive(Serialize)]
+struct StreamChoice {
+    index: u32,
+    delta: StreamDelta,
+    finish_reason: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ChatCompletionChunk {
+    id: String,
+    object: String,
+    created: i64,
+    model: String,
+    choices: Vec<StreamChoice>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    usage: Option<ChatCompletionUsage>,
+}
+
+// ---------------------------------------------------------------------------
+// Responder: either a JSON body or an SSE stream
+// ---------------------------------------------------------------------------
+
+pub enum ChatCompletionResult {
+    Json(Json<ChatCompletionResponse>),
+    Stream(EventStream<Pin<Box<dyn Stream<Item = Event> + Send>>>),
+}
+
+impl<'r> Responder<'r, 'r> for ChatCompletionResult {
+    fn respond_to(
+        self,
+        request: &'r Request<'_>,
+    ) -> rocket::response::Result<'r> {
+        match self {
+            ChatCompletionResult::Json(json) => json.respond_to(request),
+            ChatCompletionResult::Stream(stream) => stream.respond_to(request),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mapping helpers
+// ---------------------------------------------------------------------------
+
+fn now_unix() -> i64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs() as i64).unwrap_or(0)
+}
+
+fn to_chat_messages(messages: &[OaiMessage]) -> Vec<ChatMessage> {
+    messages
+        .iter()
+        .map(|message| {
+            let role = ChatRole::from_str(&message.role).unwrap_or(ChatRole::User {});
+            ChatMessage::for_role(role).with_text(message.content.clone())
+        })
+        .collect()
+}
+
+fn build_reply_config(request: &ChatCompletionRequest) -> ChatReplyConfig {
+    let token_limit = request.max_completion_tokens.or(request.max_tokens);
+    let config = ChatReplyConfig::default().with_token_limit(token_limit);
+
+    // temperature <= 0 -> deterministic greedy decoding.
+    if request.temperature.is_some_and(|temperature| temperature <= 0.0) {
+        return config.with_sampling_method(SamplingMethod::Greedy {});
+    }
+
+    // Any sampling parameter present -> stochastic; otherwise keep the model default.
+    if request.temperature.is_some() || request.top_p.is_some() || request.top_k.is_some() {
+        return config.with_sampling_method(SamplingMethod::Stochastic {
+            temperature: request.temperature,
+            top_k: request.top_k,
+            top_p: request.top_p,
+            min_p: None,
+        });
+    }
+
+    config
+}
+
+fn map_finish_reason(finish_reason: &ChatReplyFinishReason) -> String {
+    match finish_reason {
+        ChatReplyFinishReason::Stop | ChatReplyFinishReason::Cancelled => "stop",
+        ChatReplyFinishReason::Length | ChatReplyFinishReason::ContextLimitReached => "length",
+        ChatReplyFinishReason::ToolCalls => "tool_calls",
+        ChatReplyFinishReason::Rejected => "content_filter",
+    }
+    .to_string()
+}
+
+fn usage_from_stats(stats: &ChatReplyStats) -> ChatCompletionUsage {
+    let prompt_tokens = stats.tokens_count_input.unwrap_or(0);
+    let completion_tokens = stats.tokens_count_output.unwrap_or(0);
+    ChatCompletionUsage {
+        prompt_tokens,
+        completion_tokens,
+        total_tokens: prompt_tokens + completion_tokens,
+    }
+}
+
+fn error_response(
+    id: String,
+    model: String,
+    created: i64,
+    message: &str,
+) -> ChatCompletionResponse {
+    ChatCompletionResponse {
+        id,
+        object: "chat.completion".to_string(),
+        created,
+        model,
+        choices: vec![ChatCompletionChoice {
+            index: 0,
+            message: OaiMessage {
+                role: "assistant".to_string(),
+                content: format!("Error: {message}"),
+            },
+            finish_reason: "stop".to_string(),
+        }],
+        usage: ChatCompletionUsage::default(),
+    }
+}
+
+fn chunk_json(
+    id: &str,
+    model: &str,
+    created: i64,
+    delta: StreamDelta,
+    finish_reason: Option<String>,
+    usage: Option<ChatCompletionUsage>,
+) -> String {
+    let chunk = ChatCompletionChunk {
+        id: id.to_string(),
+        object: "chat.completion.chunk".to_string(),
+        created,
+        model: model.to_string(),
+        choices: vec![StreamChoice {
+            index: 0,
+            delta,
+            finish_reason,
+        }],
+        usage,
+    };
+    serde_json::to_string(&chunk).unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
+// Generation
+// ---------------------------------------------------------------------------
+
+async fn run_blocking(
+    session: Arc<Mutex<ChatSession>>,
+    messages: Vec<ChatMessage>,
+    config: ChatReplyConfig,
+    id: String,
+    model: String,
+    created: i64,
+) -> ChatCompletionResponse {
+    let session = session.lock().await;
+    if let Err(error) = session.reset().await {
+        return error_response(id, model, created, &error.to_string());
+    }
+
+    match session.reply(messages, config).await {
+        Ok(replies) => match replies.last() {
+            Some(reply) => ChatCompletionResponse {
+                id,
+                object: "chat.completion".to_string(),
+                created,
+                model,
+                choices: vec![ChatCompletionChoice {
+                    index: 0,
+                    message: OaiMessage {
+                        role: "assistant".to_string(),
+                        content: reply.message.text().unwrap_or_default(),
+                    },
+                    finish_reason: reply
+                        .finish_reason
+                        .as_ref()
+                        .map(map_finish_reason)
+                        .unwrap_or_else(|| "stop".to_string()),
+                }],
+                usage: usage_from_stats(&reply.stats),
+            },
+            None => error_response(id, model, created, "No response generated"),
+        },
+        Err(error) => error_response(id, model, created, &error.to_string()),
+    }
+}
+
+async fn run_stream(
+    session: Arc<Mutex<ChatSession>>,
+    messages: Vec<ChatMessage>,
+    config: ChatReplyConfig,
+    id: String,
+    model: String,
+    created: i64,
+    sender: mpsc::UnboundedSender<Event>,
+) {
+    let session = session.lock().await;
+    if let Err(error) = session.reset().await {
+        let _ = sender.send(Event::data(chunk_json(
+            &id,
+            &model,
+            created,
+            StreamDelta {
+                role: None,
+                content: Some(format!("Error: {error}")),
+            },
+            Some("stop".to_string()),
+            None,
+        )));
+        let _ = sender.send(Event::data("[DONE]"));
+        return;
+    }
+
+    // Initial chunk announcing the assistant role.
+    let _ = sender.send(Event::data(chunk_json(
+        &id,
+        &model,
+        created,
+        StreamDelta {
+            role: Some("assistant".to_string()),
+            content: None,
+        },
+        None,
+        None,
+    )));
+
+    let stream = session.reply_with_stream(messages, config).await;
+    let mut emitted = 0usize;
+    let mut finish_reason = "stop".to_string();
+    let mut usage = ChatCompletionUsage::default();
+    let mut errored = false;
+
+    while let Some(chunk) = stream.next().await {
+        match chunk {
+            ChatSessionStreamChunk::Replies {
+                replies,
+            } => {
+                let Some(reply) = replies.last() else {
+                    continue;
+                };
+                let text = reply.message.text().unwrap_or_default();
+                // Stream chunks carry cumulative text; emit only the new, char-boundary-safe tail.
+                let start = (emitted..=text.len()).find(|&index| text.is_char_boundary(index)).unwrap_or(text.len());
+                if text.len() > start {
+                    let delta = text[start..].to_string();
+                    emitted = text.len();
+                    let sent = sender.send(Event::data(chunk_json(
+                        &id,
+                        &model,
+                        created,
+                        StreamDelta {
+                            role: None,
+                            content: Some(delta),
+                        },
+                        None,
+                        None,
+                    )));
+                    if sent.is_err() {
+                        return; // client disconnected
+                    }
+                }
+                if let Some(reason) = &reply.finish_reason {
+                    finish_reason = map_finish_reason(reason);
+                }
+                usage = usage_from_stats(&reply.stats);
+            },
+            ChatSessionStreamChunk::Error {
+                error,
+            } => {
+                errored = true;
+                let _ = sender.send(Event::data(chunk_json(
+                    &id,
+                    &model,
+                    created,
+                    StreamDelta {
+                        role: None,
+                        content: Some(format!("Error: {error}")),
+                    },
+                    Some("stop".to_string()),
+                    None,
+                )));
+                break;
+            },
+        }
+    }
+
+    if !errored {
+        let _ = sender.send(Event::data(chunk_json(
+            &id,
+            &model,
+            created,
+            StreamDelta {
+                role: None,
+                content: None,
+            },
+            Some(finish_reason),
+            Some(usage),
+        )));
+    }
+    let _ = sender.send(Event::data("[DONE]"));
+}
+
+// ---------------------------------------------------------------------------
+// Route
+// ---------------------------------------------------------------------------
+
+#[allow(private_interfaces)]
+#[post("/chat/completions", format = "json", data = "<request>")]
+pub async fn handle_chat_completions(
+    request: Json<ChatCompletionRequest>,
+    state: &State<ServerState>,
+) -> ChatCompletionResult {
+    let request = request.into_inner();
+    let id = format!("chatcmpl-{}", Uuid::new_v4().simple());
+    let created = now_unix();
+    let model = state.model_name.clone();
+    let is_stream = request.stream.unwrap_or(false);
+
+    let messages = to_chat_messages(&request.messages);
+    let config = build_reply_config(&request);
+
+    if is_stream {
+        let session = Arc::clone(&state.session);
+        let (sender, receiver) = mpsc::unbounded_channel::<Event>();
+        rocket::tokio::spawn(run_stream(session, messages, config, id, model, created, sender));
+        let body: Pin<Box<dyn Stream<Item = Event> + Send>> = Box::pin(UnboundedReceiverStream::new(receiver));
+        ChatCompletionResult::Stream(EventStream::from(body))
+    } else {
+        let session = Arc::clone(&state.session);
+        let response = run_blocking(session, messages, config, id, model, created).await;
+        ChatCompletionResult::Json(Json(response))
+    }
+}

--- a/crates/cli/src/server/mod.rs
+++ b/crates/cli/src/server/mod.rs
@@ -1,0 +1,9 @@
+pub mod chat_completions;
+pub mod models;
+pub mod runner;
+pub mod state;
+
+pub use chat_completions::handle_chat_completions;
+pub use models::handle_models;
+pub use runner::run_server;
+pub use state::ServerState;

--- a/crates/cli/src/server/models.rs
+++ b/crates/cli/src/server/models.rs
@@ -1,0 +1,31 @@
+use rocket::{State, get, serde::json::Json};
+use serde::{Deserialize, Serialize};
+
+use crate::server::ServerState;
+
+#[derive(Serialize, Deserialize)]
+pub struct Model {
+    pub id: String,
+    pub object: String,
+    pub created: u64,
+    pub owned_by: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ModelsResponse {
+    pub object: String,
+    pub data: Vec<Model>,
+}
+
+#[get("/models")]
+pub fn handle_models(state: &State<ServerState>) -> Json<ModelsResponse> {
+    Json(ModelsResponse {
+        object: "list".to_string(),
+        data: vec![Model {
+            id: state.model_name.clone(),
+            object: "model".to_string(),
+            created: 0,
+            owned_by: "uzu".to_string(),
+        }],
+    })
+}

--- a/crates/cli/src/server/runner.rs
+++ b/crates/cli/src/server/runner.rs
@@ -11,12 +11,6 @@ use uzu::{
 
 use crate::server::{ServerState, handle_chat_completions, handle_models};
 
-/// Start an OpenAI-compatible HTTP server for a single model.
-///
-/// `model` is a registry identifier (e.g. `Qwen/Qwen3-0.6B`, downloaded on
-/// demand) or a path to a local model folder. The model is resolved, downloaded
-/// if necessary, and a [`ChatSession`](uzu::session::chat::ChatSession) is held
-/// for the lifetime of the server.
 pub async fn run_server(
     model: String,
     host: String,

--- a/crates/cli/src/server/runner.rs
+++ b/crates/cli/src/server/runner.rs
@@ -1,0 +1,75 @@
+use std::{net::IpAddr, sync::Arc, time::Duration};
+
+use anyhow::{Context, Result, bail};
+use indicatif::{ProgressBar, ProgressStyle};
+use rocket::{Config, config::LogLevel, routes};
+use tokio::sync::Mutex;
+use uzu::{
+    engine::{Engine, EngineConfig},
+    types::session::chat::ChatConfig,
+};
+
+use crate::server::{ServerState, handle_chat_completions, handle_models};
+
+/// Start an OpenAI-compatible HTTP server for a single model.
+///
+/// `model` is a registry identifier (e.g. `Qwen/Qwen3-0.6B`, downloaded on
+/// demand) or a path to a local model folder. The model is resolved, downloaded
+/// if necessary, and a [`ChatSession`](uzu::session::chat::ChatSession) is held
+/// for the lifetime of the server.
+pub async fn run_server(
+    model: String,
+    host: String,
+    port: u16,
+) -> Result<()> {
+    let engine_config = EngineConfig::default().with_application_identifier("com.trymirai.cli".to_string());
+    let engine = Engine::new(engine_config).await.context("Failed to create engine")?;
+
+    let resolved = match engine.model(model.clone()).await? {
+        Some(model) => model,
+        None => engine.model_by_path(model.clone()).await?.with_context(|| format!("Model not found: {model}"))?,
+    };
+
+    let spinner = ProgressBar::new_spinner();
+    spinner.enable_steady_tick(Duration::from_millis(100));
+    spinner.set_style(ProgressStyle::default_spinner().template("{spinner:.green} {msg}").unwrap());
+    spinner.set_message(format!("Preparing model: {}", resolved.identifier));
+    let downloader = engine.download(&resolved).await.context("Failed to start model download")?;
+    while let Some(update) = downloader.next().await {
+        spinner.set_message(format!("Downloading {}: {:.0}%", resolved.identifier, update.progress() * 100.0));
+    }
+    spinner.finish_with_message(format!("Loaded: {}", resolved.identifier));
+
+    let session =
+        engine.chat(resolved.clone(), ChatConfig::default()).await.context("Failed to create chat session")?;
+    let model_name = resolved.identifier.clone();
+    let state = ServerState {
+        model_name: model_name.clone(),
+        session: Arc::new(Mutex::new(session)),
+    };
+
+    let address: IpAddr = host.parse().with_context(|| format!("Invalid host: {host}"))?;
+    let config = Config {
+        port,
+        address,
+        log_level: LogLevel::Off,
+        ..Config::default()
+    };
+
+    println!("🚀 OpenAI-compatible server for model: {model_name}");
+    println!("🌐 Available at: http://{host}:{port}");
+    println!("📝 Endpoints:");
+    println!("   POST /v1/chat/completions (or /chat/completions)");
+    println!("   GET  /v1/models           (or /models)");
+
+    let rocket = rocket::custom(config)
+        .manage(state)
+        .mount("/", routes![handle_chat_completions, handle_models])
+        .mount("/v1", routes![handle_chat_completions, handle_models]);
+
+    if let Err(error) = rocket.launch().await {
+        bail!("Server error: {error}");
+    }
+
+    Ok(())
+}

--- a/crates/cli/src/server/state.rs
+++ b/crates/cli/src/server/state.rs
@@ -1,0 +1,15 @@
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+use uzu::session::chat::ChatSession;
+
+/// Shared state for the OpenAI-compatible server.
+///
+/// A single [`ChatSession`] is loaded at startup and shared across all
+/// requests. OpenAI semantics are stateless (each request carries the full
+/// conversation), so handlers `reset()` the session before each request. The
+/// `Mutex` serializes generation, since a `ChatSession` rejects concurrent runs.
+pub struct ServerState {
+    pub model_name: String,
+    pub session: Arc<Mutex<ChatSession>>,
+}

--- a/crates/cli/src/server/state.rs
+++ b/crates/cli/src/server/state.rs
@@ -3,12 +3,6 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use uzu::session::chat::ChatSession;
 
-/// Shared state for the OpenAI-compatible server.
-///
-/// A single [`ChatSession`] is loaded at startup and shared across all
-/// requests. OpenAI semantics are stateless (each request carries the full
-/// conversation), so handlers `reset()` the session before each request. The
-/// `Mutex` serializes generation, since a `ChatSession` rejects concurrent runs.
 pub struct ServerState {
     pub model_name: String,
     pub session: Arc<Mutex<ChatSession>>,


### PR DESCRIPTION
**Once installed** (the `mirai` command wraps the bundled `cli`):
```bash
mirai server --model Qwen/Qwen3-0.6B
```

**Flags:** `--model <id-or-path>` (required), `--port` (default `8000`), `--host` (default `127.0.0.1`). `--model` takes a registry identifier (auto-downloaded) or a local model folder path.

It prints a banner when ready:
```
🚀 OpenAI-compatible server for model: alibaba:qwen3:0.6b
🌐 Available at: http://127.0.0.1:8000
```

## Hit it

```bash
# list model
curl -s http://localhost:8000/v1/models | jq

# non-streaming
curl -s http://localhost:8000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"qwen","messages":[{"role":"user","content":"What is 2+2?"}]}' | jq

# streaming (SSE)
curl -N http://localhost:8000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"qwen","stream":true,"messages":[{"role":"user","content":"Count to 5"}]}'
```