### PR TITLE
cli: honor OpenAI response_format in chat completions

### DIFF
--- a/crates/cli/src/server/chat_completions.rs
+++ b/crates/cli/src/server/chat_completions.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 use uzu::{
     session::chat::{ChatSession, ChatSessionStreamChunk},
     types::{
-        basic::SamplingMethod,
+        basic::{Grammar, SamplingMethod},
         session::chat::{ChatMessage, ChatReplyConfig, ChatReplyFinishReason, ChatReplyStats, ChatRole},
     },
 };
@@ -52,8 +52,25 @@ pub struct ChatCompletionRequest {
     #[serde(default)]
     pub top_k: Option<i64>,
     #[serde(default)]
+    pub response_format: Option<ResponseFormat>,
+    #[serde(default)]
     #[allow(dead_code)]
     pub model: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ResponseFormat {
+    Text,
+    JsonObject,
+    JsonSchema {
+        json_schema: JsonSchemaFormat,
+    },
+}
+
+#[derive(Deserialize)]
+pub struct JsonSchemaFormat {
+    pub schema: serde_json::Value,
 }
 
 #[derive(Serialize, Clone)]
@@ -139,20 +156,31 @@ fn to_chat_messages(messages: &[OaiMessage]) -> Vec<ChatMessage> {
 
 fn build_reply_config(request: &ChatCompletionRequest) -> ChatReplyConfig {
     let token_limit = request.max_completion_tokens.or(request.max_tokens);
-    let config = ChatReplyConfig::default().with_token_limit(token_limit);
+    let mut config = ChatReplyConfig::default().with_token_limit(token_limit);
 
     if request.temperature.is_some_and(|temperature| temperature <= 0.0) {
-        return config.with_sampling_method(SamplingMethod::Greedy {});
-    }
-
-    if request.temperature.is_some() || request.top_p.is_some() || request.top_k.is_some() {
-        return config.with_sampling_method(SamplingMethod::Stochastic {
+        config = config.with_sampling_method(SamplingMethod::Greedy {});
+    } else if request.temperature.is_some() || request.top_p.is_some() || request.top_k.is_some() {
+        config = config.with_sampling_method(SamplingMethod::Stochastic {
             temperature: request.temperature,
             top_k: request.top_k,
             top_p: request.top_p,
             min_p: None,
         });
     }
+
+    config = match &request.response_format {
+        Some(ResponseFormat::JsonObject) => config.with_grammar(Some(Grammar::JsonAny {})),
+        Some(ResponseFormat::JsonSchema {
+            json_schema,
+        }) => match serde_json::to_string(&json_schema.schema) {
+            Ok(schema) => config.with_grammar(Some(Grammar::JsonSchema {
+                schema,
+            })),
+            Err(_) => config,
+        },
+        Some(ResponseFormat::Text) | None => config,
+    };
 
     config
 }
@@ -401,5 +429,69 @@ pub async fn handle_chat_completions(
         let session = Arc::clone(&state.session);
         let response = run_blocking(session, messages, config, id, model, created).await;
         ChatCompletionResult::Json(Json(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(json: &str) -> ChatCompletionRequest {
+        serde_json::from_str(json).expect("valid request json")
+    }
+
+    #[test]
+    fn response_format_maps_to_grammar() {
+        // Absent response_format leaves generation unconstrained.
+        assert!(build_reply_config(&request(r#"{"messages":[]}"#)).grammar.is_none());
+
+        // "text" is the OpenAI default: also unconstrained.
+        assert!(build_reply_config(&request(r#"{"messages":[],"response_format":{"type":"text"}}"#)).grammar.is_none());
+
+        // "json_object" constrains to any valid JSON.
+        assert_eq!(
+            build_reply_config(&request(r#"{"messages":[],"response_format":{"type":"json_object"}}"#)).grammar,
+            Some(Grammar::JsonAny {})
+        );
+
+        // "json_schema" forwards the schema verbatim as a JSON string.
+        let config = build_reply_config(&request(
+            r#"{"messages":[],"response_format":{"type":"json_schema","json_schema":{"name":"p","schema":{"type":"object"}}}}"#,
+        ));
+        assert_eq!(
+            config.grammar,
+            Some(Grammar::JsonSchema {
+                schema: r#"{"type":"object"}"#.to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn response_format_composes_with_sampling_options() {
+        let stochastic = build_reply_config(&request(
+            r#"{"messages":[],"temperature":0.7,"top_p":0.9,"top_k":40,"response_format":{"type":"json_object"}}"#,
+        ));
+        assert_eq!(stochastic.grammar, Some(Grammar::JsonAny {}));
+        assert_eq!(
+            stochastic.sampling_policy,
+            uzu::types::basic::SamplingPolicy::Custom {
+                method: SamplingMethod::Stochastic {
+                    temperature: Some(0.7),
+                    top_k: Some(40),
+                    top_p: Some(0.9),
+                    min_p: None,
+                },
+            }
+        );
+
+        let greedy =
+            build_reply_config(&request(r#"{"messages":[],"temperature":0,"response_format":{"type":"json_object"}}"#));
+        assert_eq!(greedy.grammar, Some(Grammar::JsonAny {}));
+        assert_eq!(
+            greedy.sampling_policy,
+            uzu::types::basic::SamplingPolicy::Custom {
+                method: SamplingMethod::Greedy {},
+            }
+        );
     }
 }

--- a/crates/cli/src/server/chat_completions.rs
+++ b/crates/cli/src/server/chat_completions.rs
@@ -71,6 +71,8 @@ pub enum ResponseFormat {
 #[derive(Deserialize)]
 pub struct JsonSchemaFormat {
     pub schema: serde_json::Value,
+    #[serde(default)]
+    pub strict: Option<bool>,
 }
 
 #[derive(Serialize, Clone)]
@@ -154,7 +156,41 @@ fn to_chat_messages(messages: &[OaiMessage]) -> Vec<ChatMessage> {
         .collect()
 }
 
-fn build_reply_config(request: &ChatCompletionRequest) -> ChatReplyConfig {
+#[derive(Debug, PartialEq, Eq)]
+enum ResponseFormatError {
+    GrammarUnsupported,
+    NonStrictJsonSchemaUnsupported,
+    JsonSchemaSerializationFailed,
+}
+
+impl ResponseFormatError {
+    fn message(&self) -> &'static str {
+        match self {
+            ResponseFormatError::GrammarUnsupported => {
+                "response_format with JSON constraints requires building mirai server with capability-grammar"
+            },
+            ResponseFormatError::NonStrictJsonSchemaUnsupported => {
+                "response_format json_schema requires json_schema.strict=true; non-strict JSON schemas are not supported"
+            },
+            ResponseFormatError::JsonSchemaSerializationFailed => {
+                "response_format json_schema.schema could not be serialized"
+            },
+        }
+    }
+}
+
+fn with_response_format_grammar(
+    config: ChatReplyConfig,
+    grammar: Grammar,
+) -> Result<ChatReplyConfig, ResponseFormatError> {
+    if !cfg!(feature = "capability-grammar") {
+        return Err(ResponseFormatError::GrammarUnsupported);
+    }
+
+    Ok(config.with_grammar(Some(grammar)))
+}
+
+fn build_reply_config(request: &ChatCompletionRequest) -> Result<ChatReplyConfig, ResponseFormatError> {
     let token_limit = request.max_completion_tokens.or(request.max_tokens);
     let mut config = ChatReplyConfig::default().with_token_limit(token_limit);
 
@@ -170,19 +206,27 @@ fn build_reply_config(request: &ChatCompletionRequest) -> ChatReplyConfig {
     }
 
     config = match &request.response_format {
-        Some(ResponseFormat::JsonObject) => config.with_grammar(Some(Grammar::JsonAny {})),
+        Some(ResponseFormat::JsonObject) => with_response_format_grammar(config, Grammar::JsonAny {})?,
         Some(ResponseFormat::JsonSchema {
             json_schema,
-        }) => match serde_json::to_string(&json_schema.schema) {
-            Ok(schema) => config.with_grammar(Some(Grammar::JsonSchema {
-                schema,
-            })),
-            Err(_) => config,
+        }) => {
+            if json_schema.strict != Some(true) {
+                return Err(ResponseFormatError::NonStrictJsonSchemaUnsupported);
+            }
+
+            let schema = serde_json::to_string(&json_schema.schema)
+                .map_err(|_| ResponseFormatError::JsonSchemaSerializationFailed)?;
+            with_response_format_grammar(
+                config,
+                Grammar::JsonSchema {
+                    schema,
+                },
+            )?
         },
         Some(ResponseFormat::Text) | None => config,
     };
 
-    config
+    Ok(config)
 }
 
 fn map_finish_reason(finish_reason: &ChatReplyFinishReason) -> String {
@@ -416,8 +460,11 @@ pub async fn handle_chat_completions(
     let model = state.model_name.clone();
     let is_stream = request.stream.unwrap_or(false);
 
+    let config = match build_reply_config(&request) {
+        Ok(config) => config,
+        Err(error) => return ChatCompletionResult::Json(Json(error_response(id, model, created, error.message()))),
+    };
     let messages = to_chat_messages(&request.messages);
-    let config = build_reply_config(&request);
 
     if is_stream {
         let session = Arc::clone(&state.session);
@@ -440,37 +487,82 @@ mod tests {
         serde_json::from_str(json).expect("valid request json")
     }
 
-    #[test]
-    fn response_format_maps_to_grammar() {
-        // Absent response_format leaves generation unconstrained.
-        assert!(build_reply_config(&request(r#"{"messages":[]}"#)).grammar.is_none());
+    fn reply_config(json: &str) -> ChatReplyConfig {
+        build_reply_config(&request(json)).expect("valid reply config")
+    }
 
-        // "text" is the OpenAI default: also unconstrained.
-        assert!(build_reply_config(&request(r#"{"messages":[],"response_format":{"type":"text"}}"#)).grammar.is_none());
-
-        // "json_object" constrains to any valid JSON.
-        assert_eq!(
-            build_reply_config(&request(r#"{"messages":[],"response_format":{"type":"json_object"}}"#)).grammar,
-            Some(Grammar::JsonAny {})
-        );
-
-        // "json_schema" forwards the schema verbatim as a JSON string.
-        let config = build_reply_config(&request(
-            r#"{"messages":[],"response_format":{"type":"json_schema","json_schema":{"name":"p","schema":{"type":"object"}}}}"#,
-        ));
-        assert_eq!(
-            config.grammar,
-            Some(Grammar::JsonSchema {
-                schema: r#"{"type":"object"}"#.to_string(),
-            })
-        );
+    fn reply_config_error(json: &str) -> ResponseFormatError {
+        build_reply_config(&request(json)).expect_err("invalid reply config")
     }
 
     #[test]
+    fn response_format_maps_to_grammar() {
+        // Absent response_format leaves generation unconstrained.
+        assert!(reply_config(r#"{"messages":[]}"#).grammar.is_none());
+
+        // "text" is the OpenAI default: also unconstrained.
+        assert!(reply_config(r#"{"messages":[],"response_format":{"type":"text"}}"#).grammar.is_none());
+
+        #[cfg(feature = "capability-grammar")]
+        {
+            // "json_object" constrains to any valid JSON.
+            assert_eq!(
+                reply_config(r#"{"messages":[],"response_format":{"type":"json_object"}}"#).grammar,
+                Some(Grammar::JsonAny {})
+            );
+
+            // Strict "json_schema" forwards the schema verbatim as a JSON string.
+            let config = reply_config(
+                r#"{"messages":[],"response_format":{"type":"json_schema","json_schema":{"name":"p","strict":true,"schema":{"type":"object"}}}}"#,
+            );
+            assert_eq!(
+                config.grammar,
+                Some(Grammar::JsonSchema {
+                    schema: r#"{"type":"object"}"#.to_string(),
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn response_format_rejects_grammar_without_capability() {
+        #[cfg(not(feature = "capability-grammar"))]
+        {
+            assert_eq!(
+                reply_config_error(r#"{"messages":[],"response_format":{"type":"json_object"}}"#),
+                ResponseFormatError::GrammarUnsupported
+            );
+            assert_eq!(
+                reply_config_error(
+                    r#"{"messages":[],"response_format":{"type":"json_schema","json_schema":{"strict":true,"schema":{"type":"object"}}}}"#
+                ),
+                ResponseFormatError::GrammarUnsupported
+            );
+        }
+    }
+
+    #[test]
+    fn response_format_rejects_non_strict_json_schema() {
+        assert_eq!(
+            reply_config_error(
+                r#"{"messages":[],"response_format":{"type":"json_schema","json_schema":{"schema":{"type":"object"}}}}"#
+            ),
+            ResponseFormatError::NonStrictJsonSchemaUnsupported
+        );
+        assert_eq!(
+            reply_config_error(
+                r#"{"messages":[],"response_format":{"type":"json_schema","json_schema":{"strict":false,"schema":{"type":"object"}}}}"#
+            ),
+            ResponseFormatError::NonStrictJsonSchemaUnsupported
+        );
+    }
+
+    #[cfg(feature = "capability-grammar")]
+    #[test]
     fn response_format_composes_with_sampling_options() {
-        let stochastic = build_reply_config(&request(
+        let stochastic = reply_config(
             r#"{"messages":[],"temperature":0.7,"top_p":0.9,"top_k":40,"response_format":{"type":"json_object"}}"#,
-        ));
+        );
         assert_eq!(stochastic.grammar, Some(Grammar::JsonAny {}));
         assert_eq!(
             stochastic.sampling_policy,
@@ -484,8 +576,7 @@ mod tests {
             }
         );
 
-        let greedy =
-            build_reply_config(&request(r#"{"messages":[],"temperature":0,"response_format":{"type":"json_object"}}"#));
+        let greedy = reply_config(r#"{"messages":[],"temperature":0,"response_format":{"type":"json_object"}}"#);
         assert_eq!(greedy.grammar, Some(Grammar::JsonAny {}));
         assert_eq!(
             greedy.sampling_policy,

--- a/crates/cli/src/server/chat_completions.rs
+++ b/crates/cli/src/server/chat_completions.rs
@@ -163,6 +163,8 @@ enum ResponseFormatError {
     JsonSchemaSerializationFailed,
 }
 
+const JSON_OBJECT_SCHEMA: &str = r#"{"type":"object"}"#;
+
 impl ResponseFormatError {
     fn message(&self) -> &'static str {
         match self {
@@ -206,7 +208,12 @@ fn build_reply_config(request: &ChatCompletionRequest) -> Result<ChatReplyConfig
     }
 
     config = match &request.response_format {
-        Some(ResponseFormat::JsonObject) => with_response_format_grammar(config, Grammar::JsonAny {})?,
+        Some(ResponseFormat::JsonObject) => with_response_format_grammar(
+            config,
+            Grammar::JsonSchema {
+                schema: JSON_OBJECT_SCHEMA.to_string(),
+            },
+        )?,
         Some(ResponseFormat::JsonSchema {
             json_schema,
         }) => {
@@ -293,6 +300,44 @@ fn chunk_json(
         usage,
     };
     serde_json::to_string(&chunk).unwrap_or_default()
+}
+
+fn stream_error_response(
+    id: String,
+    model: String,
+    created: i64,
+    message: &str,
+) -> ChatCompletionResult {
+    let (sender, receiver) = mpsc::unbounded_channel::<Event>();
+    let _ = sender.send(Event::data(chunk_json(
+        &id,
+        &model,
+        created,
+        StreamDelta {
+            role: None,
+            content: Some(format!("Error: {message}")),
+        },
+        Some("stop".to_string()),
+        None,
+    )));
+    let _ = sender.send(Event::data("[DONE]"));
+    let body: Pin<Box<dyn Stream<Item = Event> + Send>> = Box::pin(UnboundedReceiverStream::new(receiver));
+    ChatCompletionResult::Stream(EventStream::from(body))
+}
+
+fn response_format_error_response(
+    id: String,
+    model: String,
+    created: i64,
+    is_stream: bool,
+    error: ResponseFormatError,
+) -> ChatCompletionResult {
+    let message = error.message();
+    if is_stream {
+        stream_error_response(id, model, created, message)
+    } else {
+        ChatCompletionResult::Json(Json(error_response(id, model, created, message)))
+    }
 }
 
 async fn run_blocking(
@@ -462,7 +507,7 @@ pub async fn handle_chat_completions(
 
     let config = match build_reply_config(&request) {
         Ok(config) => config,
-        Err(error) => return ChatCompletionResult::Json(Json(error_response(id, model, created, error.message()))),
+        Err(error) => return response_format_error_response(id, model, created, is_stream, error),
     };
     let messages = to_chat_messages(&request.messages);
 
@@ -505,10 +550,12 @@ mod tests {
 
         #[cfg(feature = "capability-grammar")]
         {
-            // "json_object" constrains to any valid JSON.
+            // "json_object" constrains to a top-level JSON object.
             assert_eq!(
                 reply_config(r#"{"messages":[],"response_format":{"type":"json_object"}}"#).grammar,
-                Some(Grammar::JsonAny {})
+                Some(Grammar::JsonSchema {
+                    schema: JSON_OBJECT_SCHEMA.to_string(),
+                })
             );
 
             // Strict "json_schema" forwards the schema verbatim as a JSON string.
@@ -557,13 +604,43 @@ mod tests {
         );
     }
 
+    #[test]
+    fn response_format_errors_match_requested_response_shape() {
+        match response_format_error_response(
+            "chatcmpl-test".to_string(),
+            "model".to_string(),
+            0,
+            false,
+            ResponseFormatError::GrammarUnsupported,
+        ) {
+            ChatCompletionResult::Json(_) => {},
+            ChatCompletionResult::Stream(_) => panic!("non-stream errors should return JSON responses"),
+        }
+
+        match response_format_error_response(
+            "chatcmpl-test".to_string(),
+            "model".to_string(),
+            0,
+            true,
+            ResponseFormatError::GrammarUnsupported,
+        ) {
+            ChatCompletionResult::Stream(_) => {},
+            ChatCompletionResult::Json(_) => panic!("stream errors should return streaming responses"),
+        }
+    }
+
     #[cfg(feature = "capability-grammar")]
     #[test]
     fn response_format_composes_with_sampling_options() {
         let stochastic = reply_config(
             r#"{"messages":[],"temperature":0.7,"top_p":0.9,"top_k":40,"response_format":{"type":"json_object"}}"#,
         );
-        assert_eq!(stochastic.grammar, Some(Grammar::JsonAny {}));
+        assert_eq!(
+            stochastic.grammar,
+            Some(Grammar::JsonSchema {
+                schema: JSON_OBJECT_SCHEMA.to_string(),
+            })
+        );
         assert_eq!(
             stochastic.sampling_policy,
             uzu::types::basic::SamplingPolicy::Custom {
@@ -577,7 +654,12 @@ mod tests {
         );
 
         let greedy = reply_config(r#"{"messages":[],"temperature":0,"response_format":{"type":"json_object"}}"#);
-        assert_eq!(greedy.grammar, Some(Grammar::JsonAny {}));
+        assert_eq!(
+            greedy.grammar,
+            Some(Grammar::JsonSchema {
+                schema: JSON_OBJECT_SCHEMA.to_string(),
+            })
+        );
         assert_eq!(
             greedy.sampling_policy,
             uzu::types::basic::SamplingPolicy::Custom {


### PR DESCRIPTION
Summary:
- parse OpenAI-compatible response_format in /chat/completions requests
- map json_object to Grammar::JsonAny and json_schema.schema to Grammar::JsonSchema
- keep grammar when temperature/top_p/top_k select a custom sampling method

Tests:
- cargo test -p cli response_format --no-default-features --features backend-cpu,capability-grammar,capability-cli
- cargo test -p cli response_format --no-default-features --features backend-cpu,capability-cli