### PR TITLE
Fix offline Mirai model cache resolution

### DIFF
--- a/crates/uzu/src/engine/mod.rs
+++ b/crates/uzu/src/engine/mod.rs
@@ -99,6 +99,7 @@ impl Engine {
         let registry = SharedAccess::new(MergedRegistry::new(vec![]));
         let storage_config = StorageConfig::new(device.clone(), None, "mirai".to_string())
             .with_download_manager_type(config.download_manager_type.into());
+        let storage_cache_path = storage_config.cache_path();
         logs::start(storage_config.cache_path(), &storage_config.log_name(), false);
 
         let storage = SharedAccess::new(Storage::new(tokio_handle, storage_config).await?);
@@ -126,6 +127,7 @@ impl Engine {
                     version: uzu_backend_version.clone(),
                 }],
                 include_traces: false,
+                cache_path: storage_cache_path,
             };
             let mirai_registry = Box::new(MiraiRegistry::new(mirai_registry_config)?);
 
@@ -419,11 +421,13 @@ impl Engine {
             return Some(local_external_path);
         }
         let storage = self.storage.lock().await;
+        let cache_model_path = storage.config.cache_model_path(model)?;
+        if StorageConfig::cache_path_has_model_files(&cache_model_path) {
+            return Some(cache_model_path.to_string_lossy().to_string());
+        }
         let state = storage.state(&model.identifier).await?;
         match state.phase {
-            DownloadPhase::Downloaded {} => {
-                storage.config.cache_model_path(model).map(|path| path.to_string_lossy().to_string())
-            },
+            DownloadPhase::Downloaded {} => Some(cache_model_path.to_string_lossy().to_string()),
             DownloadPhase::NotDownloaded {}
             | DownloadPhase::Downloading {}
             | DownloadPhase::Paused {}
@@ -554,6 +558,8 @@ impl Engine {
     async fn spawn_storage_listener(&self) {
         let mut stream = self.storage_subscribe().await;
         let callback = self.callback.clone();
+        let registry = self.registry.clone();
+        let storage = self.storage.clone();
         let telemetry = self.telemetry.lock().await.clone();
         tokio::spawn(async move {
             let mut last_phase: HashMap<String, DownloadPhase> = HashMap::new();
@@ -565,18 +571,32 @@ impl Engine {
                 let event = match (&previous, &state.phase) {
                     (prev, DownloadPhase::Downloading {}) if !matches!(prev, Some(DownloadPhase::Downloading {})) => {
                         Some(TelemetryEvent::ModelDownloadStarted {
-                            model_id: id,
+                            model_id: id.clone(),
                         })
                     },
                     (Some(DownloadPhase::Downloading {}), DownloadPhase::Downloaded {}) => {
                         Some(TelemetryEvent::ModelDownloadFinished {
-                            model_id: id,
+                            model_id: id.clone(),
                         })
                     },
                     _ => None,
                 };
                 if let Some(event) = event {
                     telemetry.report(event);
+                }
+                if matches!(state.phase, DownloadPhase::Downloaded {}) {
+                    let model = registry.lock().await.model_by_identifier(&id).await;
+                    match model {
+                        Ok(Some(model)) => {
+                            if let Err(error) = storage.lock().await.persist_model_metadata_if_cached(&model) {
+                                tracing::warn!(?error, model_id = %id, "failed to persist cached model metadata");
+                            }
+                        },
+                        Ok(None) => {},
+                        Err(error) => {
+                            tracing::warn!(?error, model_id = %id, "failed to resolve downloaded model metadata");
+                        },
+                    }
                 }
                 if let Some(callback) = callback.lock().await.as_ref().cloned() {
                     callback.on_event();

--- a/crates/uzu/src/registry/cached.rs
+++ b/crates/uzu/src/registry/cached.rs
@@ -37,15 +37,60 @@ impl Registry for CachedRegistry {
             if let Some(cached_models) = cached_models.as_ref() {
                 Ok(cached_models.clone())
             } else {
-                let models = match self.registry.models().await {
-                    Ok(models) => models.clone(),
-                    Err(_) => {
-                        vec![]
-                    },
-                };
+                let models = self.registry.models().await?;
                 *cached_models = Some(models.clone());
                 Ok(models)
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{future::Future, pin::Pin, sync::Arc};
+
+    use tokio::sync::Mutex;
+
+    use super::*;
+
+    struct FlakyRegistry {
+        calls: Arc<Mutex<usize>>,
+    }
+
+    impl Registry for FlakyRegistry {
+        type Error = RegistryError;
+
+        fn indentifier(&self) -> String {
+            "flaky".to_string()
+        }
+
+        fn models(&self) -> Pin<Box<dyn Future<Output = Result<Vec<Model>, RegistryError>> + Send + '_>> {
+            Box::pin(async {
+                let mut calls = self.calls.lock().await;
+                *calls += 1;
+                if *calls == 1 {
+                    Err(RegistryError::UnableToGetModels {
+                        message: "temporary failure".to_string(),
+                    })
+                } else {
+                    Ok(vec![])
+                }
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cached_registry_does_not_cache_errors() {
+        let calls = Arc::new(Mutex::new(0));
+        let registry = CachedRegistry::new(Box::new(FlakyRegistry {
+            calls: calls.clone(),
+        }));
+
+        let first_result = registry.models().await;
+        let second_result = registry.models().await;
+
+        assert!(first_result.is_err());
+        assert!(second_result.is_ok());
+        assert_eq!(*calls.lock().await, 2);
     }
 }

--- a/crates/uzu/src/registry/mirai/config.rs
+++ b/crates/uzu/src/registry/mirai/config.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use serde::{Deserialize, Serialize};
 
 use crate::device::Device;
@@ -16,6 +18,7 @@ pub struct Config {
     pub device: Device,
     pub backends: Vec<Backend>,
     pub include_traces: bool,
+    pub cache_path: PathBuf,
 }
 
 impl Config {
@@ -24,12 +27,14 @@ impl Config {
         device: Device,
         backends: Vec<Backend>,
         include_traces: bool,
+        cache_path: PathBuf,
     ) -> Self {
         Self {
             api_key,
             device,
             backends,
             include_traces,
+            cache_path,
         }
     }
 }

--- a/crates/uzu/src/registry/mirai/mod.rs
+++ b/crates/uzu/src/registry/mirai/mod.rs
@@ -1,8 +1,9 @@
 mod api;
 mod config;
+mod snapshot;
 mod types;
 
-use std::{future::Future, pin::Pin, time::Duration};
+use std::{collections::HashMap, future::Future, pin::Pin, time::Duration};
 
 pub use api::Endpoint;
 pub use config::{Backend, Config};
@@ -10,6 +11,7 @@ use indexmap::IndexMap;
 use nagare::api::{Client, Config as ClientConfig};
 use reqwest::header::AUTHORIZATION;
 use shoji::{traits::Registry as RegistryTrait, types::model::Model};
+use snapshot::{load_snapshot, save_snapshot, scan_model_metadata};
 pub use types::Response;
 
 use crate::registry::RegistryError;
@@ -47,21 +49,60 @@ impl RegistryTrait for Registry {
 
     fn models(&self) -> Pin<Box<dyn Future<Output = Result<Vec<Model>, RegistryError>> + Send + '_>> {
         Box::pin(async {
-            let response: Response = self
-                .client
-                .response(&Endpoint::FetchModels {
-                    device: self.config.device.clone(),
-                    backends: self.config.backends.clone(),
-                    include_traces: self.config.include_traces,
-                })
-                .await
-                .map_err(|error| RegistryError::UnableToGetModels {
-                    message: error.to_string(),
-                })?;
-            let models = response.models().ok_or(RegistryError::UnableToGetModels {
-                message: "Unable to extract from response".to_string(),
-            })?;
-            Ok(models)
+            match self.fetch_models().await {
+                Ok(response) => {
+                    if let Err(error) = save_snapshot(&self.config.cache_path, &response) {
+                        tracing::warn!(?error, "failed to save Mirai registry snapshot");
+                    }
+                    response.models().ok_or(RegistryError::UnableToGetModels {
+                        message: "Unable to extract from response".to_string(),
+                    })
+                },
+                Err(fetch_error) => {
+                    let mut models_by_identifier = HashMap::new();
+
+                    match load_snapshot(&self.config.cache_path) {
+                        Ok(response) => match response.models() {
+                            Some(models) => {
+                                for model in models {
+                                    models_by_identifier.insert(model.identifier.clone(), model);
+                                }
+                            },
+                            None => {
+                                tracing::warn!("failed to extract models from cached Mirai registry snapshot");
+                            },
+                        },
+                        Err(error) => {
+                            tracing::warn!(?error, "failed to load Mirai registry snapshot");
+                        },
+                    }
+
+                    for model in scan_model_metadata(&self.config.cache_path) {
+                        models_by_identifier.entry(model.identifier.clone()).or_insert(model);
+                    }
+
+                    if models_by_identifier.is_empty() {
+                        Err(fetch_error)
+                    } else {
+                        Ok(models_by_identifier.into_values().collect())
+                    }
+                },
+            }
         })
+    }
+}
+
+impl Registry {
+    async fn fetch_models(&self) -> Result<Response, RegistryError> {
+        self.client
+            .response(&Endpoint::FetchModels {
+                device: self.config.device.clone(),
+                backends: self.config.backends.clone(),
+                include_traces: self.config.include_traces,
+            })
+            .await
+            .map_err(|error| RegistryError::UnableToGetModels {
+                message: error.to_string(),
+            })
     }
 }

--- a/crates/uzu/src/registry/mirai/snapshot.rs
+++ b/crates/uzu/src/registry/mirai/snapshot.rs
@@ -1,0 +1,194 @@
+use std::{
+    fs::{create_dir_all, read_dir, read_to_string, rename, write},
+    path::{Path, PathBuf},
+};
+
+use shoji::types::model::Model;
+
+use crate::registry::{RegistryError, mirai::Response};
+
+pub fn snapshot_path(cache_path: &Path) -> PathBuf {
+    cache_path.join("registry").join("models.json")
+}
+
+pub fn load_snapshot(cache_path: &Path) -> Result<Response, RegistryError> {
+    let path = snapshot_path(cache_path);
+    let contents = read_to_string(&path).map_err(|error| RegistryError::UnableToGetModels {
+        message: format!("Unable to read Mirai registry snapshot at {}: {}", path.display(), error),
+    })?;
+    serde_json::from_str(&contents).map_err(|error| RegistryError::UnableToGetModels {
+        message: format!("Unable to parse Mirai registry snapshot at {}: {}", path.display(), error),
+    })
+}
+
+pub fn save_snapshot(
+    cache_path: &Path,
+    response: &Response,
+) -> Result<(), RegistryError> {
+    let path = snapshot_path(cache_path);
+    if let Some(parent) = path.parent() {
+        create_dir_all(parent).map_err(|error| RegistryError::UnableToGetModels {
+            message: format!("Unable to create Mirai registry snapshot directory at {}: {}", parent.display(), error),
+        })?;
+    }
+
+    let tmp_path = path.with_extension("json.tmp");
+    let contents = serde_json::to_vec_pretty(response).map_err(|error| RegistryError::UnableToGetModels {
+        message: format!("Unable to serialize Mirai registry snapshot: {}", error),
+    })?;
+    write(&tmp_path, contents).map_err(|error| RegistryError::UnableToGetModels {
+        message: format!("Unable to write Mirai registry snapshot at {}: {}", tmp_path.display(), error),
+    })?;
+    rename(&tmp_path, &path).map_err(|error| RegistryError::UnableToGetModels {
+        message: format!("Unable to replace Mirai registry snapshot at {}: {}", path.display(), error),
+    })
+}
+
+pub fn scan_model_metadata(cache_path: &Path) -> Vec<Model> {
+    let mirai_models_path = cache_path.join("models").join("mirai");
+    let Ok(entries) = read_dir(mirai_models_path) else {
+        return vec![];
+    };
+
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path().join("model.json");
+            let contents = read_to_string(&path).ok()?;
+            serde_json::from_str::<Model>(&contents)
+                .map_err(|error| {
+                    tracing::warn!(?error, path = %path.display(), "failed to parse cached Mirai model metadata");
+                })
+                .ok()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use shoji::types::{
+        basic::{File, Hash, HashMethod, Metadata, Repository},
+        model::{Model, ModelAccessibility, ModelBackend, ModelReference, ModelRegistry, ModelSpecialization},
+    };
+
+    use super::*;
+    use crate::registry::mirai::types::{Backend as ResponseBackend, Registry as ResponseRegistry, ResponseModel};
+
+    fn metadata(
+        identifier: &str,
+        name: &str,
+    ) -> Metadata {
+        Metadata {
+            identifier: identifier.to_string(),
+            name: name.to_string(),
+            description: None,
+            icons: vec![],
+        }
+    }
+
+    fn file() -> File {
+        File {
+            url: "https://example.com/model.safetensors".to_string(),
+            name: "model.safetensors".to_string(),
+            size: 1,
+            hashes: vec![Hash {
+                method: HashMethod::CRC32C,
+                value: "00000000".to_string(),
+            }],
+        }
+    }
+
+    fn model(
+        identifier: &str,
+        repo_id: &str,
+    ) -> Model {
+        Model {
+            identifier: identifier.to_string(),
+            registry: ModelRegistry {
+                identifier: "mirai".to_string(),
+                metadata: metadata("mirai-metadata", "Mirai"),
+            },
+            backends: vec![ModelBackend {
+                identifier: "uzu".to_string(),
+                version: "1.0".to_string(),
+                metadata: metadata("uzu-metadata", "Uzu"),
+            }],
+            family: None,
+            properties: None,
+            quantization: None,
+            specializations: vec![ModelSpecialization::Chat {}],
+            accessibility: ModelAccessibility::Local {
+                reference: ModelReference::Mirai {
+                    toolchain_version: "1.0".to_string(),
+                    repository: Some(Repository {
+                        identifier: repo_id.to_string(),
+                        commit_hash: None,
+                        paths: None,
+                    }),
+                    source_repository: None,
+                    files: vec![file()],
+                },
+            },
+        }
+    }
+
+    fn response() -> Response {
+        Response {
+            models: vec![ResponseModel {
+                id: "test-model".to_string(),
+                registry: ResponseRegistry {
+                    id: "mirai".to_string(),
+                    metadata_id: "mirai-metadata".to_string(),
+                },
+                backends: vec![ResponseBackend {
+                    id: "uzu".to_string(),
+                    version: "1.0".to_string(),
+                    metadata_id: "uzu-metadata".to_string(),
+                }],
+                family: None,
+                properties: None,
+                quantization: None,
+                specializations: vec![ModelSpecialization::Chat {}],
+                accessibility: ModelAccessibility::Local {
+                    reference: ModelReference::Mirai {
+                        toolchain_version: "1.0".to_string(),
+                        repository: Some(Repository {
+                            identifier: "trymirai/test-model".to_string(),
+                            commit_hash: None,
+                            paths: None,
+                        }),
+                        source_repository: None,
+                        files: vec![file()],
+                    },
+                },
+            }],
+            metadatas: vec![metadata("mirai-metadata", "Mirai"), metadata("uzu-metadata", "Uzu")],
+        }
+    }
+
+    #[test]
+    fn test_save_load_snapshot_roundtrip() {
+        let temp_dir = tempfile::tempdir().expect("temp dir must be created");
+        let response = response();
+
+        save_snapshot(temp_dir.path(), &response).expect("snapshot must save");
+        let loaded = load_snapshot(temp_dir.path()).expect("snapshot must load");
+
+        assert_eq!(loaded, response);
+        assert_eq!(loaded.models().expect("response must convert")[0].identifier, "test-model");
+    }
+
+    #[test]
+    fn test_scan_model_metadata_loads_cached_mirai_models() {
+        let temp_dir = tempfile::tempdir().expect("temp dir must be created");
+        let model = model("test-model", "trymirai/test-model");
+        let model_dir = temp_dir.path().join("models").join("mirai").join(model.cache_identifier());
+        std::fs::create_dir_all(&model_dir).expect("model dir must be created");
+        std::fs::write(model_dir.join("model.json"), serde_json::to_vec_pretty(&model).expect("model must serialize"))
+            .expect("model metadata must be written");
+
+        let models = scan_model_metadata(temp_dir.path());
+
+        assert_eq!(models, vec![model]);
+    }
+}

--- a/crates/uzu/src/registry/mirai/types.rs
+++ b/crates/uzu/src/registry/mirai/types.rs
@@ -202,8 +202,8 @@ impl ResponseModel {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct Response {
-    models: Vec<ResponseModel>,
-    metadatas: Vec<Metadata>,
+    pub(super) models: Vec<ResponseModel>,
+    pub(super) metadatas: Vec<Metadata>,
 }
 
 impl Response {

--- a/crates/uzu/src/storage/config.rs
+++ b/crates/uzu/src/storage/config.rs
@@ -1,4 +1,7 @@
-use std::path::PathBuf;
+use std::{
+    fs::read_dir,
+    path::{Path, PathBuf},
+};
 
 use download_manager::FileDownloadManagerType;
 use serde::{Deserialize, Serialize};
@@ -45,6 +48,26 @@ impl Config {
         let reference_name = model.reference_name()?;
         let checkpoint_version = model.checkpoint_version()?;
         Some(self.cache_models_path().join(reference_name).join(model.cache_identifier()).join(checkpoint_version))
+    }
+
+    pub fn cache_model_metadata_path(
+        &self,
+        model: &Model,
+    ) -> Option<PathBuf> {
+        let reference_name = model.reference_name()?;
+        Some(self.cache_models_path().join(reference_name).join(model.cache_identifier()).join("model.json"))
+    }
+
+    pub fn cache_path_has_model_files(path: &Path) -> bool {
+        path.exists()
+            && read_dir(path).is_ok_and(|entries| {
+                entries.flatten().any(|entry| {
+                    entry
+                        .file_name()
+                        .to_str()
+                        .is_some_and(|name| !name.ends_with(".resume_data") && !name.starts_with('.'))
+                })
+            })
     }
 
     pub fn log_name(&self) -> String {

--- a/crates/uzu/src/storage/mod.rs
+++ b/crates/uzu/src/storage/mod.rs
@@ -4,7 +4,7 @@ pub mod types;
 
 use std::{
     collections::{HashMap, HashSet},
-    fs::{create_dir_all, read_dir, remove_dir_all},
+    fs::{create_dir_all, remove_dir_all, write},
     sync::Arc,
 };
 
@@ -107,16 +107,20 @@ impl Storage {
 
         for model in models {
             let identifier = model.identifier.clone();
+            let cache_path = self.config.cache_model_path(&model).ok_or(StorageError::UnsupportedItem {
+                identifier: identifier.clone(),
+            })?;
+
+            if Config::cache_path_has_model_files(&cache_path) {
+                self.persist_model_metadata(&model)?;
+            }
+
             if items.contains_key(&identifier) {
                 continue;
             }
 
             let files = self.resolve_model_files(&model)?;
             let total_bytes: u64 = files.iter().map(|file| file.size as u64).sum();
-
-            let cache_path = self.config.cache_model_path(&model).ok_or(StorageError::UnsupportedItem {
-                identifier: identifier.clone(),
-            })?;
 
             let has_files_on_disk = cache_path.exists();
             let has_active_tasks = files.iter().any(|file| {
@@ -160,17 +164,9 @@ impl Storage {
 
                 if matches!(item_state.phase, DownloadPhase::NotDownloaded {})
                     && cache_path.exists()
-                    && let Ok(entries) = read_dir(&cache_path)
+                    && !Config::cache_path_has_model_files(&cache_path)
                 {
-                    let has_real_files = entries.flatten().any(|entry| {
-                        entry
-                            .file_name()
-                            .to_str()
-                            .is_some_and(|name| !name.ends_with(".resume_data") && !name.starts_with('.'))
-                    });
-                    if !has_real_files {
-                        let _ = remove_dir_all(&cache_path);
-                    }
+                    let _ = remove_dir_all(&cache_path);
                 }
 
                 item
@@ -252,6 +248,19 @@ impl Storage {
         })?;
         item.cancel().await
     }
+
+    pub fn persist_model_metadata_if_cached(
+        &self,
+        model: &Model,
+    ) -> Result<(), StorageError> {
+        let cache_path = self.config.cache_model_path(model).ok_or(StorageError::UnsupportedItem {
+            identifier: model.identifier.clone(),
+        })?;
+        if Config::cache_path_has_model_files(&cache_path) {
+            self.persist_model_metadata(model)?;
+        }
+        Ok(())
+    }
 }
 
 impl Storage {
@@ -285,5 +294,25 @@ impl Storage {
                 identifier: model.identifier.clone(),
             }),
         }
+    }
+
+    fn persist_model_metadata(
+        &self,
+        model: &Model,
+    ) -> Result<(), StorageError> {
+        let path = self.config.cache_model_metadata_path(model).ok_or(StorageError::UnsupportedItem {
+            identifier: model.identifier.clone(),
+        })?;
+        if let Some(parent) = path.parent() {
+            create_dir_all(parent).map_err(|error| StorageError::IO {
+                message: format!("Unable to create model metadata directory at {}: {}", parent.display(), error),
+            })?;
+        }
+        let contents = serde_json::to_vec_pretty(model).map_err(|error| StorageError::IO {
+            message: format!("Unable to serialize model metadata for {}: {}", model.identifier, error),
+        })?;
+        write(&path, contents).map_err(|error| StorageError::IO {
+            message: format!("Unable to write model metadata at {}: {}", path.display(), error),
+        })
     }
 }


### PR DESCRIPTION
I wanted to test inference while sitting on the airplane, but helaas pindakaas, it could not resolve the model without internet.

---
- Added caching capabilities for model metadata in the Mirai registry.
- Implemented snapshot loading and saving to persist registry state.
- Updated model fetching logic to utilize cached data when available.
- Introduced tests to ensure caching behavior does not store errors.
- Refactored storage configuration to support new cache paths and model metadata persistence.

@codex review

