### PR TITLE
Fix HadamardTransform Slang kernel signature

### DIFF
--- a/crates/backend-uzu/src/backends/slang/hadamard_transform/hadamard_transform.slang
+++ b/crates/backend-uzu/src/backends/slang/hadamard_transform/hadamard_transform.slang
@@ -1,4 +1,5 @@
 import definitions;
+import generated.hadamard_order;
 
 [[Variants("T", "half, float")]]
 [[Public]] [[Kernel]] func HadamardTransform<T: __BuiltinFloatingPointType>(
@@ -6,6 +7,7 @@ import definitions;
   StructuredBuffer<int> factors,
   uint hidden_dim,
   uint batch_size,
+  [[Specialize]] HadamardTransformOrder transform_order,
   [[Groups("hidden_dim.div_ceil(32)")]] uint block_index,
   [[Groups("batch_size")]] uint batch_index,
   [[Threads("32")]] uint lane_index,


### PR DESCRIPTION
Adds the missing `transform_order` specialize parameter to the Slang `HadamardTransform` so its signature matches CPU/Metal. Without it, the build-script's cross-backend signature check fails under `--features webgpu`.