### PR TITLE
Support BuildPathMatrix kernels

### DIFF
--- a/crates/backend-uzu/src/backends/cpu/kernel/gdn_tree_verify/mod.rs
+++ b/crates/backend-uzu/src/backends/cpu/kernel/gdn_tree_verify/mod.rs
@@ -1,0 +1,1 @@
+pub mod path_matrix;

--- a/crates/backend-uzu/src/backends/cpu/kernel/gdn_tree_verify/path_matrix.rs
+++ b/crates/backend-uzu/src/backends/cpu/kernel/gdn_tree_verify/path_matrix.rs
@@ -1,0 +1,32 @@
+use proc_macros::kernel;
+
+#[kernel(BuildPathMatrix)]
+pub fn build_path_matrix(
+    parent: *const i32,
+    path_matrix: *mut u8,
+    batch_size: u32,
+    tree_size: u32,
+) {
+    let batch_size = batch_size as usize;
+    let tree_size = tree_size as usize;
+
+    unsafe {
+        for batch in 0..batch_size {
+            for row in 0..tree_size {
+                let base = batch * tree_size * tree_size + row * tree_size;
+                for col in 0..tree_size {
+                    *path_matrix.add(base + col) = 0;
+                }
+
+                let mut cur = row as i32;
+                for _ in 0..tree_size {
+                    if cur < 0 {
+                        break;
+                    }
+                    *path_matrix.add(base + cur as usize) = 1;
+                    cur = *parent.add(batch * tree_size + cur as usize);
+                }
+            }
+        }
+    }
+}

--- a/crates/backend-uzu/src/backends/cpu/kernel/mod.rs
+++ b/crates/backend-uzu/src/backends/cpu/kernel/mod.rs
@@ -6,6 +6,7 @@ mod audio;
 mod delta_net;
 mod embedding;
 mod gated_act_mul;
+mod gdn_tree_verify;
 mod hadamard_transform;
 mod kv_cache_update;
 mod layer_norm;

--- a/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/path_matrix.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/path_matrix.metal
@@ -1,0 +1,36 @@
+#include <metal_stdlib>
+#include "../common/dsl.h"
+
+using namespace metal;
+
+#define ROWS_PER_THREADGROUP 128
+
+// parent:      [B, T] int32, root = -1, parent[i] < i
+// path_matrix: [B, T, T] uint8, inclusive ancestor matrix
+PUBLIC KERNEL(BuildPathMatrix)(
+    const device int32_t* parent,
+    device uint8_t* path_matrix,
+    constant const uint& batch_size,
+    constant const uint& tree_size,
+    const uint row_group_id GROUPS((batch_size * tree_size).div_ceil(ROWS_PER_THREADGROUP)),
+    const uint row_in_group THREADS(ROWS_PER_THREADGROUP)
+) {
+  const uint row_id = row_group_id * ROWS_PER_THREADGROUP + row_in_group;
+  if (row_id >= batch_size * tree_size) {
+    return;
+  }
+
+  const uint batch = row_id / tree_size;
+  const uint row = row_id - batch * tree_size;
+  const uint base = batch * tree_size * tree_size + row * tree_size;
+
+  for (uint col = 0; col < tree_size; ++col) {
+    path_matrix[base + col] = 0;
+  }
+
+  int cur = int(row);
+  for (uint steps = 0; cur >= 0 && steps < tree_size; ++steps) {
+    path_matrix[base + uint(cur)] = 1;
+    cur = parent[batch * tree_size + uint(cur)];
+  }
+}

--- a/crates/backend-uzu/unit/backends/common/kernel/mod.rs
+++ b/crates/backend-uzu/unit/backends/common/kernel/mod.rs
@@ -10,6 +10,7 @@ mod layer_norm_test;
 mod logit_soft_cap_test;
 mod matmul;
 mod moe;
+mod path_matrix_test;
 mod pooling;
 mod qk_unpack_test;
 mod qkv_norm_test;

--- a/crates/backend-uzu/unit/backends/common/kernel/path_matrix_test.rs
+++ b/crates/backend-uzu/unit/backends/common/kernel/path_matrix_test.rs
@@ -1,0 +1,54 @@
+use proc_macros::uzu_test;
+use test_runner::for_each_non_cpu_backend;
+
+use crate::{
+    array::ArrayContextExt,
+    backends::{
+        common::{Backend, Context, Encoder, Kernels, kernel::BuildPathMatrixKernel},
+        cpu::Cpu,
+    },
+    data_type::DataType,
+    tests::helpers::allocation_to_vec,
+};
+
+fn get_output<B: Backend>(
+    parent: &[i32],
+    batch_size: u32,
+    tree_size: u32,
+) -> Vec<u8> {
+    let context = B::Context::new().expect("Failed to create Context");
+    let kernel = <<B as Backend>::Kernels as Kernels>::BuildPathMatrixKernel::new(&context)
+        .expect("Failed to create BuildPathMatrixKernel");
+
+    let parent = context.create_array_from(&[parent.len()], parent);
+    let mut path_matrix = context
+        .create_array_uninitialized(&[(batch_size * tree_size * tree_size) as usize], DataType::U8)
+        .into_allocation();
+
+    let mut encoder = Encoder::new(context.as_ref()).expect("Failed to create encoder");
+    kernel.encode(parent.allocation(), &mut path_matrix, batch_size, tree_size, &mut encoder);
+    encoder.end_encoding().submit().wait_until_completed().unwrap();
+
+    allocation_to_vec(&path_matrix)
+}
+
+fn chain_parent(tree_size: usize) -> Vec<i32> {
+    let mut parent = vec![-1; tree_size];
+    for i in 1..tree_size {
+        parent[i] = (i - 1) as i32;
+    }
+    parent
+}
+
+#[uzu_test]
+fn test_build_path_matrix_matches_cpu() {
+    for tree_size in [5, 129, 257] {
+        let parent = chain_parent(tree_size);
+        let expected = get_output::<Cpu>(&parent, 1, tree_size as u32);
+
+        for_each_non_cpu_backend!(|B| {
+            let output = get_output::<B>(&parent, 1, tree_size as u32);
+            assert_eq!(output, expected, "backend {} tree_size {tree_size}", std::any::type_name::<B>());
+        });
+    }
+}


### PR DESCRIPTION
For upcoming GDNTreeVerify kernels.

One interesting thing to try is since this is a trivial computation, may be interesting to see if we could use CPU for this case and hope GPU can find inputs and outputs of/from this kernel in System level cache