### PR TITLE
server: support OpenAI tool calling (non-streaming, Qwen-style)

### DIFF
--- a/crates/backend-uzu/src/inference/chat/bridging.rs
+++ b/crates/backend-uzu/src/inference/chat/bridging.rs
@@ -1,12 +1,12 @@
 use std::{path::Path, sync::Arc};
 
 use shoji::{
-    traits::backend::chat_message::Output as ChatMessageOutput,
+    traits::backend::chat_message::{Output as ChatMessageOutput, ToolCallState},
     types::{
         basic::{
             ContextLength as ShojiContextLength, Grammar as ShojiGrammar, ReasoningEffort,
             SamplingMethod as ShojiSamplingMethod, SamplingPolicy as ShojiSamplingPolicy,
-            SamplingSeed as ShojiSamplingSeed,
+            SamplingSeed as ShojiSamplingSeed, ToolCall, ToolDescription, Value,
         },
         session::chat::{
             ChatConfig as ShojiChatConfig, ChatMessage as ShojiMessage, ChatMessageList, ChatReplyConfig,
@@ -85,20 +85,69 @@ pub fn build_input_and_run_config(
     config: &ChatReplyConfig,
 ) -> (Input, RunConfig) {
     let input_messages = messages.iter().filter_map(build_message).collect();
-    let input = Input::Messages(input_messages);
+    let input = Input::Messages {
+        messages: input_messages,
+        tools: build_tools(messages),
+    };
     let run_config = build_run_config(messages, config);
     (input, run_config)
+}
+
+fn build_tools(messages: &Vec<ShojiMessage>) -> Vec<serde_json::Value> {
+    messages
+        .tool_namespaces()
+        .iter()
+        .flat_map(|namespace| namespace.tools.iter())
+        .map(|tool| match tool {
+            ToolDescription::Function {
+                tool_function,
+            } => {
+                let parameters = tool_function
+                    .parameters
+                    .as_ref()
+                    .and_then(|value| serde_json::from_str::<serde_json::Value>(&value.json).ok())
+                    .unwrap_or_else(|| serde_json::json!({}));
+                serde_json::json!({
+                    "type": "function",
+                    "function": {
+                        "name": tool_function.name,
+                        "description": tool_function.description,
+                        "parameters": parameters,
+                    }
+                })
+            },
+        })
+        .collect()
 }
 
 pub fn build_output(output: &Output) -> ChatMessageOutput {
     let text = output.text.parsed.response.clone();
     let reasoning = output.text.parsed.chain_of_thought.clone();
-    let finish_reason = output.finish_reason.as_ref().map(build_finish_reason);
+    let tool_calls: Vec<ToolCallState> = output
+        .text
+        .parsed
+        .tool_calls
+        .iter()
+        .map(|tool_call| {
+            ToolCallState::Finished(ToolCall {
+                identifier: None,
+                name: tool_call.name.clone(),
+                arguments: Value {
+                    json: tool_call.arguments.clone(),
+                },
+            })
+        })
+        .collect();
+    let finish_reason = if tool_calls.is_empty() {
+        output.finish_reason.as_ref().map(build_finish_reason)
+    } else {
+        Some(ShojiFinishReason::ToolCalls)
+    };
     let stats = build_stats(&output.stats);
     ChatMessageOutput {
         reasoning,
         text,
-        tool_calls: vec![],
+        tool_calls,
         finish_reason,
         stats,
     }

--- a/crates/backend-uzu/src/inference/classification/bridging.rs
+++ b/crates/backend-uzu/src/inference/classification/bridging.rs
@@ -26,7 +26,10 @@ pub fn build_input(messages: &[ShojiMessage]) -> Input {
             }
         })
         .collect();
-    Input::Messages(input_messages)
+    Input::Messages {
+        messages: input_messages,
+        tools: Vec::new(),
+    }
 }
 
 pub fn build_output(output: &ClassificationOutput) -> ShojiOutput {

--- a/crates/backend-uzu/src/session/helpers/input_processor.rs
+++ b/crates/backend-uzu/src/session/helpers/input_processor.rs
@@ -103,15 +103,21 @@ impl InputProcessor for InputProcessorDefault {
         environment.add_template(template_name, template.as_str()).map_err(Error::UnableToLoadPromptTemplate)?;
         let template = environment.get_template(template_name).map_err(Error::UnableToLoadPromptTemplate)?;
 
-        let result = template
-            .render(context!(
-                messages => messages,
-                add_generation_prompt => add_generation_prompt,
-                bos_token => bos_token,
-                eos_token => eos_token,
-                enable_thinking => enable_thinking
-            ))
-            .map_err(Error::UnableToRenderPromptTemplate)?;
+        let mut render_context = context!(
+            messages => messages,
+            add_generation_prompt => add_generation_prompt,
+            bos_token => bos_token,
+            eos_token => eos_token,
+            enable_thinking => enable_thinking
+        );
+        // Only expose `tools` when present: some templates (e.g. Llama 3.x) gate on
+        // `tools is not none`, so an empty list would wrongly enable tool-calling.
+        let tools = input.get_tools();
+        if !tools.is_empty() {
+            render_context = context!(tools => tools, ..render_context);
+        }
+
+        let result = template.render(render_context).map_err(Error::UnableToRenderPromptTemplate)?;
         Ok(result)
     }
 }

--- a/crates/backend-uzu/src/session/helpers/output_parser.rs
+++ b/crates/backend-uzu/src/session/helpers/output_parser.rs
@@ -1,9 +1,10 @@
 use regex::{Regex, RegexBuilder};
 
-use crate::session::types::{Error, ParsedText, Text};
+use crate::session::types::{Error, ParsedText, ParsedToolCall, Text};
 
 pub struct OutputParser {
     regex: Option<Regex>,
+    tool_call_regex: Regex,
 }
 
 impl OutputParser {
@@ -16,8 +17,10 @@ impl OutputParser {
             },
             None => None,
         };
+        let tool_call_regex = RegexBuilder::new(r"<tool_call>(.*?)</tool_call>").dot_matches_new_line(true).build()?;
         Ok(Self {
             regex,
+            tool_call_regex,
         })
     }
 
@@ -26,41 +29,71 @@ impl OutputParser {
         text: String,
         enable_thinking: bool,
     ) -> Text {
-        let parsed_text = match &self.regex {
-            Some(regex) => match regex.captures(&text) {
+        let tool_calls = self.extract_tool_calls(&text);
+        let stripped = self.tool_call_regex.replace_all(&text, "");
+        let body = stripped.trim();
+        let mut parsed_text = match &self.regex {
+            Some(regex) => match regex.captures(body) {
                 Some(captures) => {
                     let chain_of_thought = captures.name("chain_of_thought").map(|m| m.as_str().to_string());
                     let response = captures.name("response").map(|m| m.as_str().to_string());
                     if !enable_thinking {
                         ParsedText {
                             chain_of_thought: None,
-                            response: Some(response.unwrap_or_else(|| text.clone())),
+                            response: Some(response.unwrap_or_else(|| body.to_string())),
+                            tool_calls,
                         }
                     } else {
                         ParsedText {
                             chain_of_thought,
                             response,
+                            tool_calls,
                         }
                     }
                 },
                 None => ParsedText {
                     chain_of_thought: None,
-                    response: Some(text.clone()),
+                    response: Some(body.to_string()),
+                    tool_calls,
                 },
             },
             None => ParsedText {
                 chain_of_thought: None,
-                response: Some(text.clone()),
+                response: Some(body.to_string()),
+                tool_calls,
             },
         };
+        if parsed_text.response.as_deref().is_some_and(str::is_empty) {
+            parsed_text.response = None;
+        }
         Text {
-            original: text.clone(),
+            original: text,
             parsed: parsed_text,
         }
     }
 }
 
 impl OutputParser {
+    fn extract_tool_calls(
+        &self,
+        text: &str,
+    ) -> Vec<ParsedToolCall> {
+        self.tool_call_regex
+            .captures_iter(text)
+            .filter_map(|captures| {
+                let body = captures.get(1)?.as_str().trim();
+                let value: serde_json::Value = serde_json::from_str(body).ok()?;
+                let name = value.get("name")?.as_str()?.to_string();
+                let arguments =
+                    value.get("arguments").map(|arguments| arguments.to_string()).unwrap_or_else(|| "{}".to_string());
+                Some(ParsedToolCall {
+                    name,
+                    arguments,
+                })
+            })
+            .collect()
+    }
+
     // Needed because of differences in regex syntax between Python and Rust
     fn preprocess_regex_string(regex_str: String) -> String {
         let mut result = regex_str.clone();
@@ -112,5 +145,29 @@ mod tests {
         let parsed = parser.parse("Let me compute".to_string(), true).parsed;
         assert_eq!(parsed.chain_of_thought.as_deref(), Some("Let me compute"));
         assert_eq!(parsed.response, None);
+    }
+
+    #[uzu_test]
+    fn extracts_tool_call_and_clears_response() {
+        let parser = OutputParser::new(Some(QWEN_REGEX.to_string())).unwrap();
+        let parsed = parser
+            .parse(
+                "<think>need weather</think>\n<tool_call>\n{\"name\": \"get_weather\", \"arguments\": {\"city\": \"Paris\"}}\n</tool_call>".to_string(),
+                true,
+            )
+            .parsed;
+        assert_eq!(parsed.tool_calls.len(), 1);
+        assert_eq!(parsed.tool_calls[0].name, "get_weather");
+        assert_eq!(parsed.tool_calls[0].arguments, "{\"city\":\"Paris\"}");
+        assert_eq!(parsed.chain_of_thought.as_deref(), Some("need weather"));
+        assert_eq!(parsed.response, None);
+    }
+
+    #[uzu_test]
+    fn plain_response_has_no_tool_calls() {
+        let parser = OutputParser::new(Some(QWEN_REGEX.to_string())).unwrap();
+        let parsed = parser.parse("just text".to_string(), false).parsed;
+        assert!(parsed.tool_calls.is_empty());
+        assert_eq!(parsed.response.as_deref(), Some("just text"));
     }
 }

--- a/crates/backend-uzu/src/session/types/input.rs
+++ b/crates/backend-uzu/src/session/types/input.rs
@@ -3,7 +3,10 @@ use crate::session::types::{Message, Role};
 #[derive(Debug, Clone)]
 pub enum Input {
     Text(String),
-    Messages(Vec<Message>),
+    Messages {
+        messages: Vec<Message>,
+        tools: Vec<serde_json::Value>,
+    },
 }
 
 impl Input {
@@ -14,7 +17,20 @@ impl Input {
                 content: content.clone(),
                 reasoning_content: None,
             }],
-            Input::Messages(messages) => messages.clone(),
+            Input::Messages {
+                messages,
+                ..
+            } => messages.clone(),
+        }
+    }
+
+    pub fn get_tools(&self) -> &[serde_json::Value] {
+        match self {
+            Input::Messages {
+                tools,
+                ..
+            } => tools,
+            Input::Text(_) => &[],
         }
     }
 }

--- a/crates/backend-uzu/src/session/types/mod.rs
+++ b/crates/backend-uzu/src/session/types/mod.rs
@@ -11,4 +11,4 @@ pub use message::Message;
 pub use output::{FinishReason, Output};
 pub use role::Role;
 pub use stats::{RunStats, Stats, StepStats, TotalStats};
-pub use text::{ParsedText, Text};
+pub use text::{ParsedText, ParsedToolCall, Text};

--- a/crates/backend-uzu/src/session/types/text.rs
+++ b/crates/backend-uzu/src/session/types/text.rs
@@ -1,7 +1,14 @@
 #[derive(Debug, Clone)]
+pub struct ParsedToolCall {
+    pub name: String,
+    pub arguments: String,
+}
+
+#[derive(Debug, Clone)]
 pub struct ParsedText {
     pub chain_of_thought: Option<String>,
     pub response: Option<String>,
+    pub tool_calls: Vec<ParsedToolCall>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/backend-uzu/tests/session/chat_session/sampling_test.rs
+++ b/crates/backend-uzu/tests/session/chat_session/sampling_test.rs
@@ -27,7 +27,10 @@ fn run(
             .expect("load model");
     session
         .run(
-            Input::Messages(vec![Message::user(prompt.to_string())]),
+            Input::Messages {
+                messages: vec![Message::user(prompt.to_string())],
+                tools: Vec::new(),
+            },
             RunConfig::default().tokens_limit(48).enable_thinking(false).sampling_policy(policy),
             Some(|_: Output| true),
         )

--- a/crates/backend-uzu/tests/session/chat_session/thinking_toggle_test.rs
+++ b/crates/backend-uzu/tests/session/chat_session/thinking_toggle_test.rs
@@ -26,7 +26,10 @@ fn ask(
             .expect("load model");
     session
         .run(
-            Input::Messages(vec![Message::user(prompt.to_string())]),
+            Input::Messages {
+                messages: vec![Message::user(prompt.to_string())],
+                tools: Vec::new(),
+            },
             RunConfig::default().tokens_limit(256).enable_thinking(enable_thinking),
             Some(|_: Output| true),
         )
@@ -91,7 +94,10 @@ fn thinking_toggle_within_one_session() {
         messages.push(Message::user(prompt.to_string()));
         let output = session
             .run(
-                Input::Messages(messages.clone()),
+                Input::Messages {
+                    messages: messages.clone(),
+                    tools: Vec::new(),
+                },
                 RunConfig::default().tokens_limit(256).enable_thinking(enable_thinking),
                 Some(|_: Output| true),
             )

--- a/crates/backend-uzu/unit/session/chat_session.rs
+++ b/crates/backend-uzu/unit/session/chat_session.rs
@@ -161,7 +161,10 @@ fn run_scenario(
         messages.push(Message::user(user_prompt.clone()));
         println!("User > {}", user_prompt.clone());
 
-        let input = Input::Messages(messages.clone());
+        let input = Input::Messages {
+            messages: messages.clone(),
+            tools: Vec::new(),
+        };
         let output = session.run(input, RunConfig::default(), Some(|_: Output| true)).unwrap();
         messages.push(Message::assistant(
             output.text.parsed.response.clone().unwrap_or_default(),

--- a/crates/backend-uzu/unit/session/parameter/context_mode.rs
+++ b/crates/backend-uzu/unit/session/parameter/context_mode.rs
@@ -93,16 +93,19 @@ fn test_context_mode_static() {
     let parameter_city = "London".to_string();
 
     let decoding_config = build_decoding_config().with_context_mode(ContextMode::Static {
-        input: Input::Messages(vec![
-            Message::system("Always answer with one word or number, no punctuation".to_string()),
-            Message::user(
-                format!(
-                    "Name: {}\nAge: {}\nOccupation: {}\nCity: {}",
-                    parameter_name, parameter_age, parameter_occupation, parameter_city
-                )
-                .to_string(),
-            ),
-        ]),
+        input: Input::Messages {
+            messages: vec![
+                Message::system("Always answer with one word or number, no punctuation".to_string()),
+                Message::user(
+                    format!(
+                        "Name: {}\nAge: {}\nOccupation: {}\nCity: {}",
+                        parameter_name, parameter_age, parameter_occupation, parameter_city
+                    )
+                    .to_string(),
+                ),
+            ],
+            tools: Vec::new(),
+        },
     });
     let mut session = Session::new(get_test_model_path(), decoding_config).unwrap();
 

--- a/crates/benchmarks/src/runner/runner.rs
+++ b/crates/benchmarks/src/runner/runner.rs
@@ -52,7 +52,10 @@ impl Runner {
 
         let device = self.get_device_info();
 
-        let input = Input::Messages(self.task.messages.clone());
+        let input = Input::Messages {
+            messages: self.task.messages.clone(),
+            tools: Vec::new(),
+        };
 
         let warmup_config = RunConfig::default().tokens_limit(1);
         session.run(input.clone(), warmup_config, Option::<fn(Output) -> bool>::None)?;

--- a/crates/cli/src/server/chat_completions.rs
+++ b/crates/cli/src/server/chat_completions.rs
@@ -23,7 +23,7 @@ use uuid::Uuid;
 use uzu::{
     session::chat::{ChatSession, ChatSessionStreamChunk},
     types::{
-        basic::{Grammar, SamplingMethod},
+        basic::{Grammar, SamplingMethod, ToolCall, ToolDescription, ToolFunction, ToolNamespace, Value},
         session::chat::{ChatMessage, ChatReplyConfig, ChatReplyFinishReason, ChatReplyStats, ChatRole},
     },
 };
@@ -34,7 +34,23 @@ use crate::server::ServerState;
 pub struct OaiMessage {
     pub role: String,
     #[serde(default)]
-    pub content: String,
+    pub content: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<OaiToolCall>>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct OaiToolCall {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub function: OaiFunctionCall,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct OaiFunctionCall {
+    pub name: String,
+    pub arguments: String,
 }
 
 #[derive(Deserialize)]
@@ -58,6 +74,28 @@ pub struct ChatCompletionRequest {
     #[serde(default)]
     #[allow(dead_code)]
     pub model: Option<String>,
+    #[serde(default)]
+    pub tools: Option<Vec<OaiTool>>,
+    // Raw value (not typed) so an unsupported tool_choice is our 400, not Rocket's 422.
+    #[serde(default)]
+    pub tool_choice: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+pub struct OaiTool {
+    #[serde(rename = "type")]
+    #[allow(dead_code)]
+    pub kind: String,
+    pub function: OaiToolFunction,
+}
+
+#[derive(Deserialize)]
+pub struct OaiToolFunction {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub parameters: Option<serde_json::Value>,
 }
 
 #[derive(Deserialize)]
@@ -162,14 +200,64 @@ fn now_unix() -> i64 {
     SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs() as i64).unwrap_or(0)
 }
 
-fn to_chat_messages(messages: &[OaiMessage]) -> Vec<ChatMessage> {
-    messages
+fn to_tool_namespaces(tools: &[OaiTool]) -> Vec<ToolNamespace> {
+    if tools.is_empty() {
+        return Vec::new();
+    }
+    let descriptions = tools
+        .iter()
+        .map(|tool| ToolDescription::Function {
+            tool_function: ToolFunction {
+                name: tool.function.name.clone(),
+                description: tool.function.description.clone().unwrap_or_default(),
+                parameters: tool.function.parameters.clone().map(Value::from),
+                return_definition: None,
+            },
+        })
+        .collect();
+    vec![ToolNamespace {
+        name: "functions".to_string(),
+        description: None,
+        tools: descriptions,
+    }]
+}
+
+fn to_oai_tool_calls(tool_calls: &[ToolCall]) -> Option<Vec<OaiToolCall>> {
+    if tool_calls.is_empty() {
+        return None;
+    }
+    Some(
+        tool_calls
+            .iter()
+            .map(|tool_call| OaiToolCall {
+                id: tool_call.identifier.clone().unwrap_or_else(|| format!("call_{}", Uuid::new_v4().simple())),
+                kind: "function".to_string(),
+                function: OaiFunctionCall {
+                    name: tool_call.name.clone(),
+                    arguments: serde_json::to_string(&tool_call.arguments).unwrap_or_else(|_| "{}".to_string()),
+                },
+            })
+            .collect(),
+    )
+}
+
+fn to_chat_messages(
+    messages: &[OaiMessage],
+    tool_namespaces: Vec<ToolNamespace>,
+) -> Vec<ChatMessage> {
+    let mut chat_messages: Vec<ChatMessage> = messages
         .iter()
         .map(|message| {
             let role = ChatRole::from_str(&message.role).unwrap_or(ChatRole::User {});
-            ChatMessage::for_role(role).with_text(message.content.clone())
+            ChatMessage::for_role(role).with_text(message.content.clone().unwrap_or_default())
         })
-        .collect()
+        .collect();
+    if !tool_namespaces.is_empty()
+        && let Some(first) = chat_messages.first_mut()
+    {
+        *first = first.clone().with_tool_namespaces(tool_namespaces);
+    }
+    chat_messages
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -204,18 +292,73 @@ impl ResponseFormatError {
     }
 }
 
-fn request_error_response(error: ResponseFormatError) -> ChatCompletionResult {
+fn bad_request(
+    message: String,
+    param: &str,
+    code: &str,
+) -> ChatCompletionResult {
     ChatCompletionResult::Error(status::Custom(
         Status::BadRequest,
         Json(OaiErrorResponse {
             error: OaiError {
-                message: error.message(),
+                message,
                 kind: "invalid_request_error".to_string(),
-                param: Some("response_format".to_string()),
-                code: Some(error.code().to_string()),
+                param: Some(param.to_string()),
+                code: Some(code.to_string()),
             },
         }),
     ))
+}
+
+fn request_error_response(error: ResponseFormatError) -> ChatCompletionResult {
+    bad_request(error.message(), "response_format", error.code())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ToolRequestError {
+    StreamingUnsupported,
+    UnsupportedToolChoice,
+}
+
+impl ToolRequestError {
+    fn message(&self) -> &'static str {
+        match self {
+            ToolRequestError::StreamingUnsupported => "tool calling is not supported with stream: true yet",
+            ToolRequestError::UnsupportedToolChoice => "tool_choice values other than \"auto\" are not supported yet",
+        }
+    }
+
+    fn param(&self) -> &'static str {
+        match self {
+            ToolRequestError::StreamingUnsupported => "stream",
+            ToolRequestError::UnsupportedToolChoice => "tool_choice",
+        }
+    }
+
+    fn code(&self) -> &'static str {
+        match self {
+            ToolRequestError::StreamingUnsupported => "unsupported_streaming_tools",
+            ToolRequestError::UnsupportedToolChoice => "unsupported_tool_choice",
+        }
+    }
+}
+
+// Tools only support the default `auto` choice, non-streaming, for now; reject the rest
+// with a 400 instead of silently emitting tool calls the response path cannot deliver.
+fn ensure_tools_supported(request: &ChatCompletionRequest) -> Result<(), ToolRequestError> {
+    let has_tools = request.tools.as_ref().is_some_and(|tools| !tools.is_empty());
+    if !has_tools {
+        return Ok(());
+    }
+    if let Some(choice) = &request.tool_choice
+        && choice.as_str() != Some("auto")
+    {
+        return Err(ToolRequestError::UnsupportedToolChoice);
+    }
+    if request.stream.unwrap_or(false) {
+        return Err(ToolRequestError::StreamingUnsupported);
+    }
+    Ok(())
 }
 
 fn with_response_format_grammar(
@@ -310,7 +453,8 @@ fn error_response(
             index: 0,
             message: OaiMessage {
                 role: "assistant".to_string(),
-                content: format!("Error: {message}"),
+                content: Some(format!("Error: {message}")),
+                tool_calls: None,
             },
             finish_reason: "stop".to_string(),
         }],
@@ -356,24 +500,34 @@ async fn run_blocking(
 
     match session.reply(messages, config).await {
         Ok(replies) => match replies.last() {
-            Some(reply) => ChatCompletionResponse {
-                id,
-                object: "chat.completion".to_string(),
-                created,
-                model,
-                choices: vec![ChatCompletionChoice {
-                    index: 0,
-                    message: OaiMessage {
-                        role: "assistant".to_string(),
-                        content: reply.message.text().unwrap_or_default(),
-                    },
-                    finish_reason: reply
-                        .finish_reason
-                        .as_ref()
-                        .map(map_finish_reason)
-                        .unwrap_or_else(|| "stop".to_string()),
-                }],
-                usage: usage_from_stats(&reply.stats),
+            Some(reply) => {
+                let tool_calls = to_oai_tool_calls(&reply.message.tool_calls());
+                let text = reply.message.text().unwrap_or_default();
+                let content = if text.is_empty() && tool_calls.is_some() {
+                    None
+                } else {
+                    Some(text)
+                };
+                ChatCompletionResponse {
+                    id,
+                    object: "chat.completion".to_string(),
+                    created,
+                    model,
+                    choices: vec![ChatCompletionChoice {
+                        index: 0,
+                        message: OaiMessage {
+                            role: "assistant".to_string(),
+                            content,
+                            tool_calls,
+                        },
+                        finish_reason: reply
+                            .finish_reason
+                            .as_ref()
+                            .map(map_finish_reason)
+                            .unwrap_or_else(|| "stop".to_string()),
+                    }],
+                    usage: usage_from_stats(&reply.stats),
+                }
             },
             None => error_response(id, model, created, "No response generated"),
         },
@@ -510,7 +664,11 @@ pub async fn handle_chat_completions(
         Ok(config) => config,
         Err(error) => return request_error_response(error),
     };
-    let messages = to_chat_messages(&request.messages);
+    if let Err(error) = ensure_tools_supported(&request) {
+        return bad_request(error.message().to_string(), error.param(), error.code());
+    }
+    let tool_namespaces = to_tool_namespaces(request.tools.as_deref().unwrap_or(&[]));
+    let messages = to_chat_messages(&request.messages, tool_namespaces);
 
     if is_stream {
         let session = Arc::clone(&state.session);

--- a/crates/cli/unit/server/chat_completions_test.rs
+++ b/crates/cli/unit/server/chat_completions_test.rs
@@ -149,3 +149,103 @@ fn response_format_composes_with_sampling_options() {
         }
     );
 }
+
+#[test]
+fn tools_map_to_function_namespace() {
+    let request = request(
+        r#"{"messages":[],"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather","parameters":{"type":"object"}}}]}"#,
+    );
+    let namespaces = to_tool_namespaces(request.tools.as_deref().unwrap_or(&[]));
+    assert_eq!(namespaces.len(), 1);
+    assert_eq!(namespaces[0].name, "functions");
+    assert_eq!(namespaces[0].tools.len(), 1);
+    let ToolDescription::Function {
+        tool_function,
+    } = &namespaces[0].tools[0];
+    assert_eq!(tool_function.name, "get_weather");
+    assert_eq!(tool_function.description, "Get weather");
+    assert!(tool_function.parameters.is_some());
+}
+
+#[test]
+fn absent_tools_produce_no_namespaces() {
+    assert!(to_tool_namespaces(request(r#"{"messages":[]}"#).tools.as_deref().unwrap_or(&[])).is_empty());
+}
+
+#[test]
+fn tool_calls_map_to_openai_shape() {
+    let tool_calls = vec![ToolCall {
+        identifier: Some("call_1".to_string()),
+        name: "get_weather".to_string(),
+        arguments: Value::from(serde_json::json!({ "city": "Paris" })),
+    }];
+    let mapped = to_oai_tool_calls(&tool_calls).expect("tool calls present");
+    assert_eq!(mapped.len(), 1);
+    assert_eq!(mapped[0].id, "call_1");
+    assert_eq!(mapped[0].kind, "function");
+    assert_eq!(mapped[0].function.name, "get_weather");
+    assert_eq!(mapped[0].function.arguments, r#"{"city":"Paris"}"#);
+}
+
+#[test]
+fn no_tool_calls_serialize_to_none() {
+    assert!(to_oai_tool_calls(&[]).is_none());
+}
+
+#[test]
+fn tools_with_auto_tool_choice_are_supported() {
+    assert!(
+        ensure_tools_supported(&request(
+            r#"{"messages":[],"tools":[{"type":"function","function":{"name":"f","parameters":{"type":"object"}}}]}"#
+        ))
+        .is_ok()
+    );
+    assert!(
+        ensure_tools_supported(&request(
+            r#"{"messages":[],"tools":[{"type":"function","function":{"name":"f","parameters":{"type":"object"}}}],"tool_choice":"auto"}"#
+        ))
+        .is_ok()
+    );
+}
+
+#[test]
+fn absent_tools_skip_tool_validation() {
+    // No tools: a stray tool_choice or stream must not trigger a tool error.
+    assert!(ensure_tools_supported(&request(r#"{"messages":[],"tool_choice":"none","stream":true}"#)).is_ok());
+}
+
+#[test]
+fn streaming_with_tools_is_rejected() {
+    assert_eq!(
+        ensure_tools_supported(&request(
+            r#"{"messages":[],"stream":true,"tools":[{"type":"function","function":{"name":"f","parameters":{"type":"object"}}}]}"#
+        )),
+        Err(ToolRequestError::StreamingUnsupported)
+    );
+}
+
+#[test]
+fn unsupported_tool_choice_is_rejected() {
+    for body in [
+        r#"{"messages":[],"tools":[{"type":"function","function":{"name":"f","parameters":{"type":"object"}}}],"tool_choice":"none"}"#,
+        r#"{"messages":[],"tools":[{"type":"function","function":{"name":"f","parameters":{"type":"object"}}}],"tool_choice":"required"}"#,
+        r#"{"messages":[],"tools":[{"type":"function","function":{"name":"f","parameters":{"type":"object"}}}],"tool_choice":{"type":"function","function":{"name":"f"}}}"#,
+    ] {
+        assert_eq!(
+            ensure_tools_supported(&request(body)),
+            Err(ToolRequestError::UnsupportedToolChoice),
+            "expected UnsupportedToolChoice for {body}"
+        );
+    }
+}
+
+#[test]
+fn tool_namespaces_attach_to_first_message() {
+    let request = request(
+        r#"{"messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"f","parameters":{"type":"object"}}}]}"#,
+    );
+    let namespaces = to_tool_namespaces(request.tools.as_deref().unwrap_or(&[]));
+    let messages = to_chat_messages(&request.messages, namespaces);
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].tool_namespaces().len(), 1);
+}


### PR DESCRIPTION
Adds OpenAI tool calling to the local chat-completions server (non-streaming) — first of a small series.

**Why:** OpenAI-compatible agentic clients need `tools` in the request and `tool_calls` in the response to drive a local uzu server; today the server silently ignores both.

**What:**
- server (`chat_completions.rs`): parse `tools`, build a `ToolNamespace`, attach it to the conversation; emit `tool_calls` and `finish_reason: "tool_calls"` (content is `null` when only tool calls are present).
- backend (`backend-uzu`): feed `tools` into the model's prompt template (the stock Qwen3 template already has the `{% if tools %}` branch) and parse the model's `<tool_call>…</tool_call>` output into `Output.tool_calls`.

**Scope / follow-ups:** non-streaming only; output parsing targets the ChatML `<tool_call>` format for now. The `role:"tool"` round-trip, streaming deltas, `tool_choice`, and more model formats are separate PRs.

**Tested:** unit tests for request→namespace, `<tool_call>` parsing, and response serialization; verified end-to-end with a local model (Qwen3-0.6B) returning a `get_weather` tool call.
