### PR TITLE
Support BuildTreeGram Kernel

### DIFF
--- a/crates/backend-uzu/benches/gram.rs
+++ b/crates/backend-uzu/benches/gram.rs
@@ -1,0 +1,162 @@
+use std::time::Duration;
+
+use backend_uzu::{
+    array::ArrayContextExt,
+    backends::{
+        common::{Allocation, Backend, Context, Encoder, Kernels, kernel::BuildTreeGramKernel},
+        metal::Metal,
+    },
+    data_type::DataType,
+};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use half::bf16;
+
+const K_HEADS: usize = 16;
+const VALUE_HEADS: usize = 48;
+const HEAD_K_DIM: usize = 128;
+const TREE_SIZES: &[usize] = &[33, 49, 64];
+const BATCH_SIZES: &[usize] = &[1, 2, 4, 8];
+
+struct TreeGramBuffers {
+    q: Allocation<Metal>,
+    k: Allocation<Metal>,
+    trie: Allocation<Metal>,
+    prefix: Allocation<Metal>,
+    beta: Allocation<Metal>,
+    a_mat: Allocation<Metal>,
+    qkd: Allocation<Metal>,
+    ainv: Allocation<Metal>,
+}
+
+fn reranker_like_trie(
+    batch_size: usize,
+    tree_size: usize,
+) -> Vec<u32> {
+    let mut trie = Vec::with_capacity(batch_size * tree_size * 3);
+    for b in 0..batch_size {
+        let mut children = vec![Vec::<usize>::new(); tree_size];
+        let mut child_count = vec![0usize; tree_size];
+        for node in 1..tree_size {
+            let mut parent = (node - 1) / 2;
+            if child_count[parent] >= 2 {
+                parent = node.saturating_sub(2 + (b + node) % node);
+            }
+            children[parent].push(node);
+            child_count[parent] += 1;
+        }
+
+        fn dfs(
+            node: usize,
+            children: &[Vec<usize>],
+            trie: &mut [[u32; 3]],
+            next: &mut u32,
+            depth: u32,
+        ) {
+            let start = *next;
+            *next += 1;
+            let mut end = start;
+            for &child in &children[node] {
+                dfs(child, children, trie, next, depth + 1);
+                end = end.max(trie[child][1]);
+            }
+            trie[node] = [start, end, depth];
+        }
+
+        let mut batch_trie = vec![[0u32; 3]; tree_size];
+        let mut next = 0;
+        dfs(0, &children, &mut batch_trie, &mut next, 0);
+        for node in batch_trie {
+            trie.extend_from_slice(&node);
+        }
+    }
+    trie
+}
+
+fn make_buffers(
+    context: &<Metal as Backend>::Context,
+    batch_size: usize,
+    tree_size: usize,
+) -> (TreeGramBuffers, f32) {
+    let qk_len = batch_size * tree_size * K_HEADS * HEAD_K_DIM;
+    let head_len = batch_size * tree_size * VALUE_HEADS;
+    let out_len = batch_size * VALUE_HEADS * tree_size * tree_size;
+    let trie = reranker_like_trie(batch_size, tree_size);
+    let q = (0..qk_len).map(|i| bf16::from_f32(((i as f32 * 0.017).sin() * 0.2) + 0.01)).collect::<Vec<_>>();
+    let k = (0..qk_len).map(|i| bf16::from_f32(((i as f32 * 0.019).cos() * 0.18) - 0.02)).collect::<Vec<_>>();
+    let prefix = (0..head_len)
+        .map(|i| -((i % tree_size) as f32) * 0.01 - ((i % VALUE_HEADS) as f32) * 0.003)
+        .collect::<Vec<_>>();
+    let beta = (0..head_len).map(|i| 0.25 + ((i as f32 * 0.013).sin() + 1.0) * 0.2).collect::<Vec<_>>();
+    let scale = (HEAD_K_DIM as f32).sqrt().recip();
+    (
+        TreeGramBuffers {
+            q: context.create_array_from(&[q.len()], &q).into_allocation(),
+            k: context.create_array_from(&[k.len()], &k).into_allocation(),
+            trie: context.create_array_from(&[trie.len()], &trie).into_allocation(),
+            prefix: context.create_array_from(&[prefix.len()], &prefix).into_allocation(),
+            beta: context.create_array_from(&[beta.len()], &beta).into_allocation(),
+            a_mat: context.create_array_uninitialized(&[out_len], DataType::F32).into_allocation(),
+            qkd: context.create_array_uninitialized(&[out_len], DataType::F32).into_allocation(),
+            ainv: context.create_array_uninitialized(&[out_len], DataType::F32).into_allocation(),
+        },
+        scale,
+    )
+}
+
+fn bench_build_tree_gram(c: &mut Criterion) {
+    let context = <Metal as Backend>::Context::new().expect("metal context");
+    let kernel_paths = if context.supports_mxu() {
+        &[("Simdgroup", false), ("MXU", true)][..]
+    } else {
+        &[("Simdgroup", false)][..]
+    };
+
+    for &(kernel_path, use_mxu) in kernel_paths {
+        let kernel =
+            <<Metal as Backend>::Kernels as Kernels>::BuildTreeGramKernel::new(&context, DataType::BF16, use_mxu)
+                .expect("BuildTreeGramKernel");
+        let mut group = c.benchmark_group(format!("Metal/Kernel/GDNTreeVerify/BuildTreeGram/{kernel_path}"));
+        group.sample_size(10).warm_up_time(Duration::from_millis(100)).measurement_time(Duration::from_millis(500));
+
+        for &batch_size in BATCH_SIZES {
+            for &tree_size in TREE_SIZES {
+                let (mut buffers, scale) = make_buffers(&context, batch_size, tree_size);
+                let gram_flops = 4 * batch_size * VALUE_HEADS * tree_size * tree_size * HEAD_K_DIM;
+                let inverse_flops = batch_size * VALUE_HEADS * (tree_size * tree_size * tree_size - tree_size) / 3;
+                group.throughput(Throughput::Elements((gram_flops + inverse_flops) as u64));
+                group.bench_function(
+                    BenchmarkId::from_parameter(format!(
+                        "B{batch_size}_T{tree_size}_Hg{K_HEADS}_HV{VALUE_HEADS}_K{HEAD_K_DIM}"
+                    )),
+                    |bencher| {
+                        bencher.iter(|| {
+                            let mut encoder = Encoder::new(context.as_ref()).expect("encoder");
+                            kernel.encode(
+                                &buffers.q,
+                                &buffers.k,
+                                &buffers.trie,
+                                &buffers.prefix,
+                                &buffers.beta,
+                                &mut buffers.a_mat,
+                                &mut buffers.qkd,
+                                &mut buffers.ainv,
+                                scale,
+                                batch_size as u32,
+                                tree_size as u32,
+                                K_HEADS as u32,
+                                VALUE_HEADS as u32,
+                                HEAD_K_DIM as u32,
+                                &mut encoder,
+                            );
+                            encoder.end_encoding().submit().wait_until_completed().unwrap();
+                        });
+                    },
+                );
+            }
+        }
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_build_tree_gram);
+criterion_main!(benches);

--- a/crates/backend-uzu/src/backends/cpu/kernel/gdn_tree_verify/gram.rs
+++ b/crates/backend-uzu/src/backends/cpu/kernel/gdn_tree_verify/gram.rs
@@ -3,20 +3,6 @@ use num_traits::Float;
 use proc_macros::kernel;
 
 use crate::{array::ArrayElement, backends::common::gpu_types::trie::TrieNode};
-
-// K1 — tree gram + masked decay + inverse.
-//
-// Inputs
-//   q, k        : [B, T, Hg, K]      Hg = k-heads; value-head hv -> hk = hv / (HV/Hg)
-//   trie        : [B, T]      TrieNode DFS intervals
-//   prefix      : [B, T, HV]  f32    G  = path cumsum of log-decay   (from K0)
-//   beta        : [B, T, HV]  f32    sigmoid gate                    (from K0)
-// Outputs
-//   a_mat : [B, HV, T, T] f32   strictly-lower   A[i,j]   = beta_i * exp(G_i-G_j) * (k_i . k_j),  j PROPER ancestor of i
-//   qkd   : [B, HV, T, T] f32   inclusive        QKD[i,j] = exp(G_i-G_j) * scale * (q_i . k_j),   j ancestor-or-self of i
-//   ainv  : [B, HV, T, T] f32   (I + A)^-1
-//
-// scale = 1/sqrt(K). exp(G_i-G_j) <= 1 for real ancestor pairs; clamp masked-out junk before exp if you fuse the mask.
 #[kernel(BuildTreeGram)]
 #[variants(T, f32, bf16)]
 #[variants(USE_MXU, false)]
@@ -50,7 +36,6 @@ pub fn build_tree_gram<T: ArrayElement + Float, const USE_MXU: bool>(
             let mat_base = (batch * value_heads + hv) * tree_size * tree_size;
             let trie_base = batch * tree_size;
 
-            // Step 1-3: grams + decay + masks -> a_mat, qkd.
             for i in 0..tree_size {
                 let row_idx = i as u32;
                 let prefix_i = unsafe { *prefix.add((batch * tree_size + i) * value_heads + hv) };
@@ -79,7 +64,6 @@ pub fn build_tree_gram<T: ArrayElement + Float, const USE_MXU: bool>(
                     }
                     let prefix_j = unsafe { *prefix.add((batch * tree_size + j) * value_heads + hv) };
                     let dexp = (prefix_i - prefix_j).exp();
-                    // strict = proper ancestor (drops the diagonal); incl keeps it.
                     unsafe {
                         *a_mat.add(out) = if i != j {
                             beta_i * dexp * kk

--- a/crates/backend-uzu/src/backends/cpu/kernel/gdn_tree_verify/gram.rs
+++ b/crates/backend-uzu/src/backends/cpu/kernel/gdn_tree_verify/gram.rs
@@ -1,0 +1,121 @@
+use half::{bf16, f16};
+use num_traits::Float;
+use proc_macros::kernel;
+
+use crate::{array::ArrayElement, backends::common::gpu_types::trie::TrieNode};
+
+// K1 — tree gram + masked decay + diagonal inverse.
+//
+// Inputs
+//   q, k        : [B, T, Hg, K]      Hg = k-heads; value-head hv -> hk = hv / (HV/Hg)
+//   trie        : [B, T]      TrieNode DFS intervals
+//   prefix      : [B, T, HV]  f32    G  = path cumsum of log-decay   (from K0)
+//   beta        : [B, T, HV]  f32    sigmoid gate                    (from K0)
+// Outputs
+//   a_mat : [B, HV, T, T] f32   strictly-lower   A[i,j]   = beta_i * exp(G_i-G_j) * (k_i . k_j),  j PROPER ancestor of i
+//   qkd   : [B, HV, T, T] f32   inclusive        QKD[i,j] = exp(G_i-G_j) * scale * (q_i . k_j),   j ancestor-or-self of i
+//   ainv  : [B, HV, T, T] f32   (I + A)^-1       single chunk => full inverse, no block merge
+//
+// scale = 1/sqrt(K). exp(G_i-G_j) <= 1 for real ancestor pairs; clamp masked-out junk before exp if you fuse the mask.
+#[kernel(BuildTreeGram)]
+#[variants(T, f32, f16, bf16)]
+pub fn build_tree_gram<T: ArrayElement + Float>(
+    q: *const T,
+    k: *const T,
+    trie: *const TrieNode,
+    prefix: *const f32,
+    beta: *const f32,
+    a_mat: *mut f32,
+    qkd: *mut f32,
+    ainv: *mut f32,
+    scale: f32,
+    batch_size: u32,
+    tree_size: u32,
+    k_heads: u32,
+    value_heads: u32,
+    head_k_dim: u32,
+) {
+    let batch_size = batch_size as usize;
+    let tree_size = tree_size as usize;
+    let k_heads = k_heads as usize;
+    let value_heads = value_heads as usize;
+    let head_k_dim = head_k_dim as usize;
+    let groups_per_head = value_heads / k_heads;
+
+    for batch in 0..batch_size {
+        for hv in 0..value_heads {
+            let hk = hv / groups_per_head;
+            let mat_base = (batch * value_heads + hv) * tree_size * tree_size;
+            let trie_base = batch * tree_size;
+
+            // Step 1-3: grams + decay + masks -> a_mat, qkd.
+            for i in 0..tree_size {
+                let row_idx = i as u32;
+                let prefix_i = unsafe { *prefix.add((batch * tree_size + i) * value_heads + hv) };
+                let beta_i = unsafe { *beta.add((batch * tree_size + i) * value_heads + hv) };
+                let row_off = ((batch * tree_size + i) * k_heads + hk) * head_k_dim;
+                for j in 0..tree_size {
+                    let out = mat_base + i * tree_size + j;
+                    let node = unsafe { *trie.add(trie_base + j) };
+                    let incl = row_idx >= node.trie_start && row_idx <= node.trie_end;
+                    if !incl {
+                        unsafe {
+                            *a_mat.add(out) = 0.0;
+                            *qkd.add(out) = 0.0;
+                        }
+                        continue;
+                    }
+                    let col_off = ((batch * tree_size + j) * k_heads + hk) * head_k_dim;
+                    let mut kk = 0.0f32;
+                    let mut qk = 0.0f32;
+                    for d in 0..head_k_dim {
+                        let ki = unsafe { (*k.add(row_off + d)).to_f32().unwrap() };
+                        let kj = unsafe { (*k.add(col_off + d)).to_f32().unwrap() };
+                        let qi = unsafe { (*q.add(row_off + d)).to_f32().unwrap() };
+                        kk += ki * kj;
+                        qk += qi * kj;
+                    }
+                    let prefix_j = unsafe { *prefix.add((batch * tree_size + j) * value_heads + hv) };
+                    let dexp = (prefix_i - prefix_j).exp();
+                    // strict = proper ancestor (drops the diagonal); incl keeps it.
+                    unsafe {
+                        *a_mat.add(out) = if i != j {
+                            beta_i * dexp * kk
+                        } else {
+                            0.0
+                        };
+                        *qkd.add(out) = dexp * scale * qk;
+                    }
+                }
+            }
+
+            // Step 4: ainv[batch,hv] = (I + A)^-1, reusing the A block just written.
+            // I+A is unit-lower-triangular -> exact forward substitution:
+            //   X = I;  X[i,j] = -sum_{k=j..i-1} A[i,k] * X[k,j]   (j < i)
+            for i in 0..tree_size {
+                for j in 0..tree_size {
+                    unsafe {
+                        *ainv.add(mat_base + i * tree_size + j) = if i == j {
+                            1.0
+                        } else {
+                            0.0
+                        };
+                    }
+                }
+            }
+            for i in 0..tree_size {
+                for j in 0..i {
+                    let mut s = 0.0f32;
+                    for kx in j..i {
+                        unsafe {
+                            s += *a_mat.add(mat_base + i * tree_size + kx) * *ainv.add(mat_base + kx * tree_size + j);
+                        }
+                    }
+                    unsafe {
+                        *ainv.add(mat_base + i * tree_size + j) = -s;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/backend-uzu/src/backends/cpu/kernel/gdn_tree_verify/gram.rs
+++ b/crates/backend-uzu/src/backends/cpu/kernel/gdn_tree_verify/gram.rs
@@ -19,7 +19,8 @@ use crate::{array::ArrayElement, backends::common::gpu_types::trie::TrieNode};
 // scale = 1/sqrt(K). exp(G_i-G_j) <= 1 for real ancestor pairs; clamp masked-out junk before exp if you fuse the mask.
 #[kernel(BuildTreeGram)]
 #[variants(T, f32, f16, bf16)]
-pub fn build_tree_gram<T: ArrayElement + Float>(
+#[variants(USE_MXU, false)]
+pub fn build_tree_gram<T: ArrayElement + Float, const USE_MXU: bool>(
     q: *const T,
     k: *const T,
     trie: *const TrieNode,
@@ -89,32 +90,38 @@ pub fn build_tree_gram<T: ArrayElement + Float>(
                 }
             }
 
-            // Step 4: ainv[batch,hv] = (I + A)^-1, reusing the A block just written.
-            // I+A is unit-lower-triangular -> exact forward substitution:
-            //   X = I;  X[i,j] = -sum_{k=j..i-1} A[i,k] * X[k,j]   (j < i)
-            for i in 0..tree_size {
-                for j in 0..tree_size {
-                    unsafe {
-                        *ainv.add(mat_base + i * tree_size + j) = if i == j {
-                            1.0
-                        } else {
-                            0.0
-                        };
-                    }
+            invert_tree_gram_matrix(a_mat, ainv, mat_base, tree_size);
+        }
+    }
+}
+
+fn invert_tree_gram_matrix(
+    a_mat: *const f32,
+    ainv: *mut f32,
+    mat_base: usize,
+    tree_size: usize,
+) {
+    for i in 0..tree_size {
+        for j in 0..tree_size {
+            unsafe {
+                *ainv.add(mat_base + i * tree_size + j) = if i == j {
+                    1.0
+                } else {
+                    0.0
+                };
+            }
+        }
+    }
+    for i in 0..tree_size {
+        for j in 0..i {
+            let mut s = 0.0f32;
+            for kx in j..i {
+                unsafe {
+                    s += *a_mat.add(mat_base + i * tree_size + kx) * *ainv.add(mat_base + kx * tree_size + j);
                 }
             }
-            for i in 0..tree_size {
-                for j in 0..i {
-                    let mut s = 0.0f32;
-                    for kx in j..i {
-                        unsafe {
-                            s += *a_mat.add(mat_base + i * tree_size + kx) * *ainv.add(mat_base + kx * tree_size + j);
-                        }
-                    }
-                    unsafe {
-                        *ainv.add(mat_base + i * tree_size + j) = -s;
-                    }
-                }
+            unsafe {
+                *ainv.add(mat_base + i * tree_size + j) = -s;
             }
         }
     }

--- a/crates/backend-uzu/src/backends/cpu/kernel/gdn_tree_verify/gram.rs
+++ b/crates/backend-uzu/src/backends/cpu/kernel/gdn_tree_verify/gram.rs
@@ -1,4 +1,4 @@
-use half::{bf16, f16};
+use half::bf16;
 use num_traits::Float;
 use proc_macros::kernel;
 
@@ -18,7 +18,7 @@ use crate::{array::ArrayElement, backends::common::gpu_types::trie::TrieNode};
 //
 // scale = 1/sqrt(K). exp(G_i-G_j) <= 1 for real ancestor pairs; clamp masked-out junk before exp if you fuse the mask.
 #[kernel(BuildTreeGram)]
-#[variants(T, f32, f16, bf16)]
+#[variants(T, f32, bf16)]
 #[variants(USE_MXU, false)]
 pub fn build_tree_gram<T: ArrayElement + Float, const USE_MXU: bool>(
     q: *const T,

--- a/crates/backend-uzu/src/backends/cpu/kernel/gdn_tree_verify/gram.rs
+++ b/crates/backend-uzu/src/backends/cpu/kernel/gdn_tree_verify/gram.rs
@@ -4,7 +4,7 @@ use proc_macros::kernel;
 
 use crate::{array::ArrayElement, backends::common::gpu_types::trie::TrieNode};
 
-// K1 — tree gram + masked decay + diagonal inverse.
+// K1 — tree gram + masked decay + inverse.
 //
 // Inputs
 //   q, k        : [B, T, Hg, K]      Hg = k-heads; value-head hv -> hk = hv / (HV/Hg)
@@ -14,7 +14,7 @@ use crate::{array::ArrayElement, backends::common::gpu_types::trie::TrieNode};
 // Outputs
 //   a_mat : [B, HV, T, T] f32   strictly-lower   A[i,j]   = beta_i * exp(G_i-G_j) * (k_i . k_j),  j PROPER ancestor of i
 //   qkd   : [B, HV, T, T] f32   inclusive        QKD[i,j] = exp(G_i-G_j) * scale * (q_i . k_j),   j ancestor-or-self of i
-//   ainv  : [B, HV, T, T] f32   (I + A)^-1       single chunk => full inverse, no block merge
+//   ainv  : [B, HV, T, T] f32   (I + A)^-1
 //
 // scale = 1/sqrt(K). exp(G_i-G_j) <= 1 for real ancestor pairs; clamp masked-out junk before exp if you fuse the mask.
 #[kernel(BuildTreeGram)]
@@ -41,6 +41,7 @@ pub fn build_tree_gram<T: ArrayElement + Float, const USE_MXU: bool>(
     let k_heads = k_heads as usize;
     let value_heads = value_heads as usize;
     let head_k_dim = head_k_dim as usize;
+
     let groups_per_head = value_heads / k_heads;
 
     for batch in 0..batch_size {

--- a/crates/backend-uzu/src/backends/cpu/kernel/gdn_tree_verify/mod.rs
+++ b/crates/backend-uzu/src/backends/cpu/kernel/gdn_tree_verify/mod.rs
@@ -1,1 +1,2 @@
+pub mod gram;
 pub mod prefix_beta;

--- a/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/gram.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/gram.metal
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#include "../common/defines.h"
 #include "../common/dsl.h"
 #include "../common/thread_context.h"
 #include "../generated/trie.h"
@@ -10,8 +11,8 @@ using namespace metal;
 using namespace uzu::matmul;
 using namespace uzu::trie;
 
-#define TREE_GRAM_ROW_TILE 16
-#define TREE_GRAM_COL_TILE 32
+#define TREE_GRAM_ROW_TILE 16u
+#define TREE_GRAM_COL_TILE 32u
 #define TREE_GRAM_THREADS METAL_SIMD_SIZE
 
 METAL_FUNC void invert_tree_gram_diagonal_block(
@@ -71,21 +72,19 @@ PUBLIC KERNEL(BuildTreeGram)(
   const uint trie_base = batch_idx * tree_size;
   const uint mat_base = (batch_idx * value_heads + value_head_idx) * tree_size * tree_size;
 
-  const uint col_tiles = (tree_size + TREE_GRAM_COL_TILE - 1) / TREE_GRAM_COL_TILE;
+  const uint col_tiles = div_ceil(tree_size, TREE_GRAM_COL_TILE);
   const uint row_tile_idx = tile_idx / col_tiles;
   const uint col_tile_idx = tile_idx - row_tile_idx * col_tiles;
   const uint row_base = row_tile_idx * TREE_GRAM_ROW_TILE;
   const uint col_base = col_tile_idx * TREE_GRAM_COL_TILE;
-  const uint row_tile_size = TREE_GRAM_ROW_TILE;
-  const uint col_tile_size = TREE_GRAM_COL_TILE;
   const ushort lane = thread_context.simd_lane_id;
 
   if (row_base >= tree_size) {
     return;
   }
 
-  const uint tile_rows = min(row_tile_size, tree_size - row_base);
-  const uint tile_cols = min(col_tile_size, tree_size - col_base);
+  const uint tile_rows = min(TREE_GRAM_ROW_TILE, tree_size - row_base);
+  const uint tile_cols = min(TREE_GRAM_COL_TILE, tree_size - col_base);
   const uint tile_base = mat_base + row_base * tree_size + col_base;
 
   if (col_base >= row_base + TREE_GRAM_ROW_TILE) {
@@ -139,7 +138,7 @@ PUBLIC KERNEL(BuildTreeGram)(
 
   const bool has_diag = col_base <= row_base && row_base < col_base + TREE_GRAM_COL_TILE;
   const uint diag_col_offset = has_diag ? row_base - col_base : 0;
-  const uint diag_size = min(row_tile_size, tree_size - row_base);
+  const uint diag_size = min(TREE_GRAM_ROW_TILE, tree_size - row_base);
 
   if (thread_idx < TREE_GRAM_COL_TILE) {
     const uint col_token = col_base + thread_idx;

--- a/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/gram.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/gram.metal
@@ -25,6 +25,18 @@ METAL_FUNC void invert_tree_gram_diagonal_block(
     const uint thread_idx
 );
 
+// Build tree gram matrices for one (batch, value-head) tile.
+//
+// q, k:   [B, T, Hg, K], with key head hk = hv / (HV / Hg)
+// trie:   [B, T] DFS intervals; col is an ancestor of row when row is in col's interval
+// prefix: [B, T, HV] path log-decay prefix from BuildPrefixBeta
+// beta:   [B, T, HV] sigmoid gate from BuildPrefixBeta
+//
+// a_mat[row, col] = beta[row] * exp(prefix[row] - prefix[col]) * dot(k[row], k[col])
+//                   for proper ancestors only
+// qkd[row, col]   = scale * exp(prefix[row] - prefix[col]) * dot(q[row], k[col])
+//                   for ancestor-or-self
+// ainv            = (I + A)^-1 for each diagonal block
 template <typename T, bool USE_MXU>
 VARIANTS(T, float, bfloat)
 VARIANTS(USE_MXU, false, true)

--- a/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/gram.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/gram.metal
@@ -14,13 +14,138 @@ using namespace uzu::trie;
 #define TREE_GRAM_ROW_TILE 16
 #define TREE_GRAM_COL_TILE 32
 #define TREE_GRAM_MAT_THREADS METAL_SIMD_SIZE
-#define TREE_GRAM_AINV_THREADS 64
-#define TREE_GRAM_FUSED_SIMDGROUPS 4
-#define TREE_GRAM_FUSED_THREADS (TREE_GRAM_FUSED_SIMDGROUPS * METAL_SIMD_SIZE)
-#define TREE_GRAM_LOWER_SIZE (TREE_GRAM_MAX_T * (TREE_GRAM_MAX_T + 1) / 2)
 
-// The Rust BuildTreeGramMetalKernel wrapper dispatches BuildTreeGramMat then BuildTreeGramAinv.
-// This public entry keeps the CPU/Metal DSL kernel lists aligned.
+template <bool USE_MXU, bool RELAXED_MXU>
+// Multiplies a <=16x16 Neumann tile. MXU needs a 16x32 N tile, so only that
+// path pads the RHS/result through scratch before copying the valid 16x16 part.
+METAL_FUNC void tree_gram_neumann_matmul16(
+    threadgroup float* lhs_tile,
+    int lhs_stride,
+    threadgroup float* rhs_tile,
+    int rhs_stride,
+    threadgroup float* dst_tile,
+    int dst_stride,
+    threadgroup float* mxu_rhs_tile_16x32,
+    threadgroup float* mxu_dst_tile_16x32,
+    ushort lane,
+    short valid_rows,
+    short valid_cols
+) {
+  if constexpr (USE_MXU) {
+    using Ops = MxuFragmentOps<RELAXED_MXU>;
+    using AccFragment = Fragment<float, 1, 2, Ops>;
+    using LeftFragment = OperandFragment<float, 1, 1, Ops>;
+    using RightFragment = OperandFragment<float, 1, 2, Ops>;
+
+    for (uint idx = lane; idx < 16 * 32; idx += METAL_SIMD_SIZE) {
+      const uint r = idx / 32;
+      const uint c = idx - r * 32;
+      mxu_rhs_tile_16x32[idx] = c < 16 ? rhs_tile[r * rhs_stride + c] : 0.0f;
+      mxu_dst_tile_16x32[idx] = 0.0f;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    AccFragment acc;
+    LeftFragment left_frag;
+    RightFragment right_frag;
+    left_frag.load_from(lane, fragment_source(lhs_tile, lhs_stride).bounded(valid_rows, short(16)));
+    right_frag.load_from(lane, fragment_source(mxu_rhs_tile_16x32, 32).bounded(short(16), short(32)));
+    fragment_mm(acc, left_frag, right_frag);
+    acc.store(lane, mxu_dst_tile_16x32, 32);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint idx = lane; idx < 16 * 16; idx += METAL_SIMD_SIZE) {
+      const uint r = idx / 16;
+      const uint c = idx - r * 16;
+      if (r < uint(valid_rows) && c < uint(valid_cols)) {
+        dst_tile[r * dst_stride + c] = mxu_dst_tile_16x32[r * 32 + c];
+      }
+    }
+  } else {
+    using Ops = SimdgroupFragmentOps;
+    using AccFragment = Fragment<float, 2, 2, Ops>;
+    using LeftFragment = OperandFragment<float, 2, 2, Ops>;
+    using RightFragment = OperandFragment<float, 2, 2, Ops>;
+    AccFragment acc;
+    LeftFragment left_frag;
+    RightFragment right_frag;
+    acc.clear();
+    left_frag.load_from(lane, fragment_source(lhs_tile, lhs_stride).bounded(valid_rows, short(16)));
+    right_frag.load_from(lane, fragment_source(rhs_tile, rhs_stride).bounded(short(16), valid_cols));
+    fragment_mma(acc, left_frag, right_frag);
+    acc.store_safe(lane, dst_tile, dst_stride, short2(valid_cols, valid_rows));
+  }
+}
+
+template <bool USE_MXU>
+METAL_FUNC void invert_tree_gram_diag_neumann_tile(
+    threadgroup float* neumann_power_tile,
+    threadgroup float* inverse_tile,
+    threadgroup float* product_tile,
+    threadgroup float* mxu_scratch,
+    device float* ainv,
+    ulong mat_base,
+    uint tree_size,
+    uint block_start,
+    uint block_size,
+    uint tid
+) {
+  for (uint covered_power = 1; covered_power < block_size - 1; covered_power = covered_power * 2 + 1) {
+    if (tid < METAL_SIMD_SIZE) {
+      // Strict MXU precision is intentional here; relaxed precision fails the
+      // repeated-squaring Ainv accuracy check.
+      tree_gram_neumann_matmul16<USE_MXU, false>(
+          neumann_power_tile,
+          16,
+          neumann_power_tile,
+          16,
+          product_tile,
+          16,
+          mxu_scratch,
+          mxu_scratch + 16 * 32,
+          ushort(tid),
+          short(block_size),
+          short(block_size)
+      );
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint idx = tid; idx < 16 * 16; idx += TREE_GRAM_MAT_THREADS) {
+      const uint r = idx / 16;
+      const uint c = idx - r * 16;
+      neumann_power_tile[r * 16 + c] = product_tile[r * 16 + c];
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (tid < METAL_SIMD_SIZE) {
+      tree_gram_neumann_matmul16<USE_MXU, false>(
+          inverse_tile,
+          16,
+          neumann_power_tile,
+          16,
+          product_tile,
+          16,
+          mxu_scratch,
+          mxu_scratch + 16 * 32,
+          ushort(tid),
+          short(block_size),
+          short(block_size)
+      );
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint idx = tid; idx < block_size * block_size; idx += TREE_GRAM_MAT_THREADS) {
+      const uint r = idx / block_size;
+      const uint c = idx - r * block_size;
+      const uint i = block_start + r;
+      const uint j = block_start + c;
+      inverse_tile[r * 16 + c] += product_tile[r * 16 + c];
+      ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = inverse_tile[r * 16 + c];
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+}
+
 template <typename T, bool USE_MXU>
 VARIANTS(T, float, half, bfloat)
 VARIANTS(USE_MXU, false, true)
@@ -39,106 +164,16 @@ PUBLIC KERNEL(BuildTreeGram)(
     constant const uint& k_heads,
     constant const uint& value_heads,
     constant const uint& head_k_dim,
-    const uint tid THREADS(1)
-) {}
-
-template <bool USE_MASK>
-METAL_FUNC void invert_tree_gram_matrix(
-    threadgroup const float* a_shared,
-    threadgroup float* x_shared,
-    threadgroup ulong* row_mask_shared,
-    const device TrieNode* trie,
-    device float* ainv,
-    ulong mat_base,
-    ulong trie_base,
-    uint tree_size,
-    uint tid
-) {
-  for (uint idx = tid; idx < tree_size * tree_size; idx += TREE_GRAM_FUSED_THREADS) {
-    const uint i = idx / tree_size;
-    const uint j = idx - i * tree_size;
-    ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = i == j ? 1.0f : 0.0f;
-  }
-  for (uint i = tid; i < tree_size; i += TREE_GRAM_FUSED_THREADS) {
-    x_shared[(i * (i + 1)) / 2 + i] = 1.0f;
-  }
-  if constexpr (USE_MASK) {
-    for (uint i = tid; i < tree_size; i += TREE_GRAM_FUSED_THREADS) {
-      ulong mask = 0;
-      for (uint j = 0; j < tree_size; ++j) {
-        const TrieNode node = trie[trie_base + (ulong)j];
-        if (i != j && i >= node.trie_start && i <= node.trie_end) {
-          mask |= ulong(1) << j;
-        }
-      }
-      row_mask_shared[i] = mask;
-    }
-  }
-  threadgroup_barrier(mem_flags::mem_threadgroup);
-
-  constexpr uint GROUP_WIDTH = 8;
-  constexpr uint GROUPS = TREE_GRAM_FUSED_THREADS / GROUP_WIDTH;
-  const uint group_id = tid / GROUP_WIDTH;
-  const uint group_lane = tid & (GROUP_WIDTH - 1);
-  for (uint i = 1; i < tree_size; ++i) {
-    const uint row_lower_base = (i * (i + 1)) / 2;
-    const ulong row_mask = USE_MASK ? row_mask_shared[i] : ~ulong(0);
-    for (uint j = group_id; j < i; j += GROUPS) {
-      if (((row_mask >> j) & 1) != 0) {
-        float sum = 0.0f;
-        for (uint m = j + group_lane; m < i; m += GROUP_WIDTH) {
-          if (((row_mask >> m) & 1) != 0) {
-            sum += a_shared[i * TREE_GRAM_MAX_T + m] * x_shared[(m * (m + 1)) / 2 + j];
-          }
-        }
-        sum += simd_shuffle_xor(sum, 1);
-        sum += simd_shuffle_xor(sum, 2);
-        sum += simd_shuffle_xor(sum, 4);
-        if (group_lane == 0) {
-          const float v = -sum;
-          x_shared[row_lower_base + j] = v;
-          ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = v;
-        }
-      }
-    }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-  }
-}
-
-// K1: tree gram + masked decay.
-//
-// Inputs:
-//   q, k   : [B, T, Hg, K]     value head hv maps to key head hk = hv / (HV / Hg)
-//   trie   : [B, T]            Euler intervals for ancestor tests
-//   prefix : [B, T, HV] float  G = path cumsum of log-decay from K0
-//   beta   : [B, T, HV] float  sigmoid gate from K0
-//
-// Outputs:
-//   A[i,j,hv]   = (i != j && trie[j] contains i) ? beta[i,hv] * exp(prefix[i,hv] - prefix[j,hv]) * dot(k[i,hk],
-//   k[j,hk]) : 0 QKD[i,j,hv] = trie[j] contains i ? exp(prefix[i,hv] - prefix[j,hv]) * scale * dot(q[i,hk], k[j,hk]) :
-//   0
-template <typename T, bool USE_MXU>
-VARIANTS(T, float, half, bfloat)
-VARIANTS(USE_MXU, false, true)
-PUBLIC KERNEL(BuildTreeGramMat)(
-    const device T* q,
-    const device T* k,
-    const device TrieNode* trie,
-    const device float* prefix,
-    const device float* beta,
-    device float* a_mat,
-    device float* qkd,
-    constant const float& scale,
-    constant const uint& batch_size,
-    constant const uint& tree_size,
-    constant const uint& k_heads,
-    constant const uint& value_heads,
-    constant const uint& head_k_dim,
     threadgroup float row_prefix_shared[TREE_GRAM_MAX_T],
     threadgroup float row_beta_shared[TREE_GRAM_MAX_T],
     threadgroup float col_prefix_shared[TREE_GRAM_COL_TILE],
     threadgroup uint col_start_shared[TREE_GRAM_COL_TILE],
     threadgroup uint col_end_shared[TREE_GRAM_COL_TILE],
+    threadgroup float a_tile_shared[TREE_GRAM_ROW_TILE * TREE_GRAM_COL_TILE],
+    threadgroup float neumann_power_shared[16 * 16],
+    threadgroup float neumann_inverse_shared[16 * 16],
+    threadgroup float neumann_product_shared[16 * 16],
+    threadgroup float mxu_neumann_scratch[16 * 32 * 2],
     const ThreadContext thread_context,
     const uint batch_idx GROUPS(batch_size),
     const uint hv GROUPS(value_heads),
@@ -149,7 +184,7 @@ PUBLIC KERNEL(BuildTreeGramMat)(
     return;
   }
 
-  using Ops = metal::conditional_t<USE_MXU, MxuFragmentOps, SimdgroupFragmentOps>;
+  using Ops = metal::conditional_t<USE_MXU, MxuFragmentOps<>, SimdgroupFragmentOps>;
   constexpr ushort ROW_FRAGMENTS = TREE_GRAM_ROW_TILE / Ops::FRAGMENT_ROWS;
   constexpr ushort COL_FRAGMENTS = TREE_GRAM_COL_TILE / Ops::FRAGMENT_COLS;
   using InputType = metal::conditional_t<USE_MXU, T, float>;
@@ -256,261 +291,58 @@ PUBLIC KERNEL(BuildTreeGramMat)(
     return scale * exp(prefix_i - prefix_j) * qk_dot;
   });
 
-  const short2 tile_dims = short2(
-      short(min(uint(TREE_GRAM_COL_TILE), tree_size - col_base)),
-      short(min(uint(TREE_GRAM_ROW_TILE), tree_size - row_base))
-  );
+  const uint tile_rows = min(uint(TREE_GRAM_ROW_TILE), tree_size - row_base);
+  const uint tile_cols = min(uint(TREE_GRAM_COL_TILE), tree_size - col_base);
+  const short2 tile_dims = short2(short(tile_cols), short(tile_rows));
   kk_acc.store_safe(
       lane,
       a_mat + mat_base + (ulong)row_base * (ulong)tree_size + (ulong)col_base,
       int(tree_size),
       tile_dims
   );
+  kk_acc.store_safe(lane, a_tile_shared, TREE_GRAM_COL_TILE, tile_dims);
   qk_acc.store_safe(
       lane,
       qkd + mat_base + (ulong)row_base * (ulong)tree_size + (ulong)col_base,
       int(tree_size),
       tile_dims
   );
-}
 
-template <typename T, bool USE_MXU, bool USE_MASK>
-VARIANTS(T, float, half, bfloat)
-VARIANTS(USE_MXU, false, true)
-VARIANTS(USE_MASK, false, true)
-PUBLIC KERNEL(BuildTreeGramFused)(
-    const device T* q,
-    const device T* k,
-    const device TrieNode* trie,
-    const device float* prefix,
-    const device float* beta,
-    device float* a_mat,
-    device float* qkd,
-    device float* ainv,
-    constant const float& scale,
-    constant const uint& batch_size,
-    constant const uint& tree_size,
-    constant const uint& k_heads,
-    constant const uint& value_heads,
-    constant const uint& head_k_dim,
-    threadgroup float a_shared[TREE_GRAM_MAX_T * TREE_GRAM_MAX_T],
-    threadgroup float x_shared[TREE_GRAM_LOWER_SIZE],
-    threadgroup ulong row_mask_shared[TREE_GRAM_MAX_T],
-    threadgroup float row_prefix_shared[TREE_GRAM_MAX_T],
-    threadgroup float row_beta_shared[TREE_GRAM_MAX_T],
-    threadgroup float col_prefix_shared[TREE_GRAM_COL_TILE],
-    threadgroup uint col_start_shared[TREE_GRAM_COL_TILE],
-    threadgroup uint col_end_shared[TREE_GRAM_COL_TILE],
-    const ThreadContext thread_context,
-    const uint batch_idx GROUPS(batch_size),
-    const uint hv GROUPS(value_heads),
-    const uint tid THREADS(TREE_GRAM_FUSED_THREADS)
-) {
-  if (tree_size > TREE_GRAM_MAX_T) {
-    return;
-  }
-
-  using Ops = metal::conditional_t<USE_MXU, MxuFragmentOps, SimdgroupFragmentOps>;
-  constexpr ushort ROW_FRAGMENTS = TREE_GRAM_ROW_TILE / Ops::FRAGMENT_ROWS;
-  constexpr ushort COL_FRAGMENTS = TREE_GRAM_COL_TILE / Ops::FRAGMENT_COLS;
-  using InputType = metal::conditional_t<USE_MXU, T, float>;
-  using AccFragment = Fragment<float, ROW_FRAGMENTS, COL_FRAGMENTS, Ops>;
-  using LeftFragment = OperandFragment<InputType, ROW_FRAGMENTS, 1, Ops>;
-  using RightFragment = OperandFragment<InputType, 1, COL_FRAGMENTS, Ops, ReadTranspose>;
-
-  const uint groups_per_head = value_heads / k_heads;
-  const uint hk = hv / groups_per_head;
-  const ulong qk_head_base = (((ulong)batch_idx * (ulong)tree_size) * (ulong)k_heads + (ulong)hk) * (ulong)head_k_dim;
-  const uint qk_row_stride = k_heads * head_k_dim;
-  const ulong prefix_base = ((ulong)batch_idx * (ulong)tree_size) * (ulong)value_heads + (ulong)hv;
-  const ulong trie_base = (ulong)batch_idx * (ulong)tree_size;
-  const ulong mat_base = ((ulong)batch_idx * (ulong)value_heads + (ulong)hv) * (ulong)tree_size * (ulong)tree_size;
-
-  const uint row_base = thread_context.simdgroup_index * TREE_GRAM_ROW_TILE;
-  const ushort lane = thread_context.simd_lane_id;
-
-  for (uint i = tid; i < tree_size; i += TREE_GRAM_FUSED_THREADS) {
-    row_prefix_shared[i] = prefix[prefix_base + (ulong)i * (ulong)value_heads];
-    row_beta_shared[i] = beta[prefix_base + (ulong)i * (ulong)value_heads];
+  for (uint idx = tid; idx < tile_rows * tile_cols; idx += TREE_GRAM_MAT_THREADS) {
+    const uint i = row_base + idx / tile_cols;
+    const uint j = col_base + idx % tile_cols;
+    ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = i == j ? 1.0f : 0.0f;
   }
   threadgroup_barrier(mem_flags::mem_threadgroup);
 
-  for (uint col_base = 0; col_base < tree_size; col_base += TREE_GRAM_COL_TILE) {
-    if (tid < TREE_GRAM_COL_TILE) {
-      const uint j = col_base + tid;
-      if (j < tree_size) {
-        const TrieNode node = trie[trie_base + (ulong)j];
-        col_prefix_shared[tid] = prefix[prefix_base + (ulong)j * (ulong)value_heads];
-        col_start_shared[tid] = node.trie_start;
-        col_end_shared[tid] = node.trie_end;
-      } else {
-        col_prefix_shared[tid] = 0.0f;
-        col_start_shared[tid] = 1;
-        col_end_shared[tid] = 0;
+  if (col_base <= row_base && row_base < col_base + TREE_GRAM_COL_TILE) {
+    const uint diag_col = row_base - col_base;
+    const uint block_size = min(uint(16), tree_size - row_base);
+    for (uint idx = tid; idx < 16 * 16; idx += TREE_GRAM_MAT_THREADS) {
+      const uint r = idx / 16;
+      const uint c = idx - r * 16;
+      const uint i = row_base + r;
+      const uint j = row_base + c;
+      const bool in_block = r < block_size && c < block_size;
+      const float neg_a = in_block && c < r ? -a_tile_shared[r * TREE_GRAM_COL_TILE + diag_col + c] : 0.0f;
+      neumann_power_shared[idx] = neg_a;
+      neumann_inverse_shared[idx] = in_block && r == c ? 1.0f : neg_a;
+      if (in_block) {
+        ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = neumann_inverse_shared[idx];
       }
     }
     threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    AccFragment kk_acc;
-    AccFragment qk_acc;
-    kk_acc.clear();
-    qk_acc.clear();
-
-    for (uint k_base = 0; k_base < head_k_dim; k_base += Ops::FRAGMENT_ROWS) {
-      const uint k_rem = head_k_dim - k_base;
-      const ushort valid_k_cols = ushort(min(k_rem, uint(Ops::FRAGMENT_ROWS)));
-
-      if (row_base < tree_size) {
-        LeftFragment k_left;
-        LeftFragment q_left;
-        RightFragment k_right;
-
-        const short row_limit = short(max(int(0), int(tree_size) - int(row_base)));
-        const short col_limit = short(max(int(0), int(tree_size) - int(col_base)));
-
-        const device T* k_rows = k + qk_head_base + (ulong)row_base * (ulong)qk_row_stride + (ulong)k_base;
-        const device T* q_rows = q + qk_head_base + (ulong)row_base * (ulong)qk_row_stride + (ulong)k_base;
-        const device T* k_col_ptr = k + qk_head_base + (ulong)col_base * (ulong)qk_row_stride + (ulong)k_base;
-
-        k_left.load_from(lane, fragment_source(k_rows, int(qk_row_stride)).bounded(row_limit, short(valid_k_cols)));
-        q_left.load_from(lane, fragment_source(q_rows, int(qk_row_stride)).bounded(row_limit, short(valid_k_cols)));
-        k_right.load_from(lane, fragment_source(k_col_ptr, int(qk_row_stride)).bounded(col_limit, short(valid_k_cols)));
-
-        fragment_mma(kk_acc, k_left, k_right);
-        fragment_mma(qk_acc, q_left, k_right);
-      }
-    }
-
-    if (row_base < tree_size) {
-      kk_acc.map_coords(lane, [&](short row, short col, float kk) {
-        const uint i = row_base + uint(row);
-        const uint j = col_base + uint(col);
-        if (i >= tree_size || j >= tree_size) {
-          return 0.0f;
-        }
-        const bool incl = i >= col_start_shared[col] && i <= col_end_shared[col];
-        const float prefix_i = row_prefix_shared[i];
-        const float prefix_j = col_prefix_shared[col];
-        const float beta_i = row_beta_shared[i];
-        if (!incl || i == j) {
-          return 0.0f;
-        }
-        return beta_i * exp(prefix_i - prefix_j) * kk;
-      });
-
-      qk_acc.map_coords(lane, [&](short row, short col, float qk_dot) {
-        const uint i = row_base + uint(row);
-        const uint j = col_base + uint(col);
-        if (i >= tree_size || j >= tree_size) {
-          return 0.0f;
-        }
-        const bool incl = i >= col_start_shared[col] && i <= col_end_shared[col];
-        const float prefix_i = row_prefix_shared[i];
-        const float prefix_j = col_prefix_shared[col];
-        if (!incl) {
-          return 0.0f;
-        }
-        return scale * exp(prefix_i - prefix_j) * qk_dot;
-      });
-
-      const short2 tile_dims = short2(
-          short(min(uint(TREE_GRAM_COL_TILE), tree_size - col_base)),
-          short(min(uint(TREE_GRAM_ROW_TILE), tree_size - row_base))
-      );
-      kk_acc.store_safe(
-          lane,
-          a_mat + mat_base + (ulong)row_base * (ulong)tree_size + (ulong)col_base,
-          int(tree_size),
-          tile_dims
-      );
-      kk_acc.store_safe(lane, a_shared + row_base * TREE_GRAM_MAX_T + col_base, TREE_GRAM_MAX_T, tile_dims);
-      qk_acc.store_safe(
-          lane,
-          qkd + mat_base + (ulong)row_base * (ulong)tree_size + (ulong)col_base,
-          int(tree_size),
-          tile_dims
-      );
-    }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-  }
-
-  threadgroup_barrier(mem_flags::mem_threadgroup);
-  invert_tree_gram_matrix<
-      USE_MASK>(a_shared, x_shared, row_mask_shared, trie, ainv, mat_base, trie_base, tree_size, tid);
-}
-
-// K2: inverse columns of (I + A), split by column block.
-template <uint COL_BLOCK, bool USE_MASK>
-VARIANTS(COL_BLOCK, 4, 8, 16, 32)
-VARIANTS(USE_MASK, false, true)
-PUBLIC KERNEL(BuildTreeGramAinv)(
-    const device float* a_mat,
-    const device TrieNode* trie,
-    device float* ainv,
-    constant const uint& batch_size,
-    constant const uint& tree_size,
-    constant const uint& value_heads,
-    threadgroup float a_shared[TREE_GRAM_MAX_T * TREE_GRAM_MAX_T],
-    threadgroup float x_shared[TREE_GRAM_MAX_T * COL_BLOCK],
-    threadgroup ulong row_mask_shared[TREE_GRAM_MAX_T],
-    const uint batch_idx GROUPS(batch_size),
-    const uint hv GROUPS(value_heads),
-    const uint col_block_idx GROUPS(tree_size.div_ceil(COL_BLOCK)),
-    const uint tid THREADS(TREE_GRAM_AINV_THREADS)
-) {
-  if (tree_size > TREE_GRAM_MAX_T) {
-    return;
-  }
-
-  const ulong mat_base = ((ulong)batch_idx * (ulong)value_heads + (ulong)hv) * (ulong)tree_size * (ulong)tree_size;
-  const ulong trie_base = (ulong)batch_idx * (ulong)tree_size;
-  const uint col_base = col_block_idx * COL_BLOCK;
-
-  for (uint idx = tid; idx < tree_size * tree_size; idx += TREE_GRAM_AINV_THREADS) {
-    const uint i = idx / tree_size;
-    const uint j = idx - i * tree_size;
-    a_shared[i * TREE_GRAM_MAX_T + j] = a_mat[mat_base + (ulong)i * (ulong)tree_size + (ulong)j];
-  }
-  for (uint idx = tid; idx < tree_size * COL_BLOCK; idx += TREE_GRAM_AINV_THREADS) {
-    const uint i = idx / COL_BLOCK;
-    const uint local_j = idx - i * COL_BLOCK;
-    const uint j = col_base + local_j;
-    const float v = j < tree_size && i == j ? 1.0f : 0.0f;
-    x_shared[idx] = v;
-    if (j < tree_size) {
-      ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = v;
-    }
-  }
-  if constexpr (USE_MASK) {
-    for (uint i = tid; i < tree_size; i += TREE_GRAM_AINV_THREADS) {
-      ulong mask = 0;
-      for (uint j = 0; j < tree_size; ++j) {
-        const TrieNode node = trie[trie_base + (ulong)j];
-        if (i != j && i >= node.trie_start && i <= node.trie_end) {
-          mask |= ulong(1) << j;
-        }
-      }
-      row_mask_shared[i] = mask;
-    }
-  }
-  threadgroup_barrier(mem_flags::mem_threadgroup);
-
-  for (uint i = 1; i < tree_size; ++i) {
-    const ulong row_mask = USE_MASK ? row_mask_shared[i] : ~ulong(0);
-    for (uint local_j = tid; local_j < COL_BLOCK; local_j += TREE_GRAM_AINV_THREADS) {
-      const uint j = col_base + local_j;
-      if (j < i && j < tree_size && ((row_mask >> j) & 1) != 0) {
-        float sum = 0.0f;
-        for (uint m = j; m < i; ++m) {
-          if (((row_mask >> m) & 1) != 0) {
-            sum += a_shared[i * TREE_GRAM_MAX_T + m] * x_shared[m * COL_BLOCK + local_j];
-          }
-        }
-        const float v = -sum;
-        x_shared[i * COL_BLOCK + local_j] = v;
-        ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = v;
-      }
-    }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
+    invert_tree_gram_diag_neumann_tile<USE_MXU>(
+        neumann_power_shared,
+        neumann_inverse_shared,
+        neumann_product_shared,
+        mxu_neumann_scratch,
+        ainv,
+        mat_base,
+        tree_size,
+        row_base,
+        block_size,
+        tid
+    );
   }
 }

--- a/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/gram.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/gram.metal
@@ -1,0 +1,189 @@
+#include <metal_stdlib>
+#include "../common/dsl.h"
+#include "../common/thread_context.h"
+#include "../generated/trie.h"
+#include "../matmul/common/fragment.h"
+#include "../matmul/common/mxu_fragment_ops.h"
+
+using namespace metal;
+using namespace uzu::matmul;
+using namespace uzu::trie;
+
+#define TREE_GRAM_MAX_T 64
+#define TREE_GRAM_ROW_TILE 16
+#define TREE_GRAM_COL_TILE 32
+#define TREE_GRAM_SIMDGROUPS 4
+#define TREE_GRAM_THREADS (TREE_GRAM_SIMDGROUPS * METAL_SIMD_SIZE)
+
+// K1: tree gram + masked decay + diagonal inverse.
+//
+// Inputs:
+//   q, k   : [B, T, Hg, K]     value head hv maps to key head hk = hv / (HV / Hg)
+//   trie   : [B, T]            Euler intervals for ancestor tests
+//   prefix : [B, T, HV] float  G = path cumsum of log-decay from K0
+//   beta   : [B, T, HV] float  sigmoid gate from K0
+//
+// Let M[i,j] = trie[j].trie_start <= i <= trie[j].trie_end.
+// Let D[i,j,hv] = exp(prefix[i,hv] - prefix[j,hv]).
+// Let KK[i,j,hv] = dot(k[i,hk], k[j,hk]).
+// Let QK[i,j,hv] = scale * dot(q[i,hk], k[j,hk]).
+//
+// Outputs:
+//   A[i,j,hv]   = (i != j && M[i,j]) ? beta[i,hv] * D[i,j,hv] * KK[i,j,hv] : 0
+//   QKD[i,j,hv] = M[i,j] ? D[i,j,hv] * QK[i,j,hv] : 0
+//   AINV[hv]    = (I + A[hv])^-1
+//
+// Since A is strictly lower triangular:
+//   AINV[i,i] = 1
+//   AINV[i,j] = -sum_{m=j}^{i-1} A[i,m] * AINV[m,j], for j < i
+//   AINV[i,j] = 0, for j > i
+template <typename T>
+VARIANTS(T, float, half, bfloat)
+PUBLIC KERNEL(BuildTreeGram)(
+    const device T* q,
+    const device T* k,
+    const device TrieNode* trie,
+    const device float* prefix,
+    const device float* beta,
+    device float* a_mat,
+    device float* qkd,
+    device float* ainv,
+    constant const float& scale,
+    constant const uint& batch_size,
+    constant const uint& tree_size,
+    constant const uint& k_heads,
+    constant const uint& value_heads,
+    constant const uint& head_k_dim,
+    threadgroup float a_shared[TREE_GRAM_MAX_T * TREE_GRAM_MAX_T],
+    const ThreadContext thread_context,
+    const uint batch_idx GROUPS(batch_size),
+    const uint hv GROUPS(value_heads),
+    const uint tid THREADS(TREE_GRAM_THREADS)
+) {
+  if (tree_size > TREE_GRAM_MAX_T) {
+    return;
+  }
+
+  using AccFragment = Fragment<float, 1, 2, MxuFragmentOps>;
+  using LeftFragment = OperandFragment<T, 1, 1, MxuFragmentOps>;
+  using RightFragment = OperandFragment<T, 1, 2, MxuFragmentOps, ReadTranspose>;
+
+  const uint groups_per_head = value_heads / k_heads;
+  const uint hk = hv / groups_per_head;
+  const ulong qk_head_base =
+      (((ulong)batch_idx * (ulong)tree_size) * (ulong)k_heads + (ulong)hk) * (ulong)head_k_dim;
+  const uint qk_row_stride = k_heads * head_k_dim;
+  const ulong prefix_base = ((ulong)batch_idx * (ulong)tree_size) * (ulong)value_heads + (ulong)hv;
+  const ulong trie_base = (ulong)batch_idx * (ulong)tree_size;
+  const ulong mat_base = ((ulong)batch_idx * (ulong)value_heads + (ulong)hv) * (ulong)tree_size * (ulong)tree_size;
+
+  const uint row_base = thread_context.simdgroup_index * TREE_GRAM_ROW_TILE;
+  const ushort lane = thread_context.simd_lane_id;
+
+  if (row_base < tree_size) {
+    for (uint col_base = 0; col_base < tree_size; col_base += TREE_GRAM_COL_TILE) {
+    AccFragment kk_acc;
+    AccFragment qk_acc;
+    kk_acc.clear();
+    qk_acc.clear();
+
+    for (uint k_base = 0; k_base < head_k_dim; k_base += MxuFragmentOps::FRAGMENT_ROWS) {
+      const uint k_rem = head_k_dim - k_base;
+      const ushort valid_k_cols = ushort(min(k_rem, uint(MxuFragmentOps::FRAGMENT_ROWS)));
+
+      LeftFragment k_left;
+      LeftFragment q_left;
+      RightFragment k_right;
+
+      const device T* k_rows = k + qk_head_base + (ulong)row_base * (ulong)qk_row_stride + (ulong)k_base;
+      const device T* q_rows = q + qk_head_base + (ulong)row_base * (ulong)qk_row_stride + (ulong)k_base;
+      const device T* k_col_ptr = k + qk_head_base + (ulong)col_base * (ulong)qk_row_stride + (ulong)k_base;
+
+      const short row_limit = short(max(int(0), int(tree_size) - int(row_base)));
+      const short col_limit = short(max(int(0), int(tree_size) - int(col_base)));
+
+      k_left.load_from(lane, fragment_source(k_rows, int(qk_row_stride)).bounded(row_limit, short(valid_k_cols)));
+      q_left.load_from(lane, fragment_source(q_rows, int(qk_row_stride)).bounded(row_limit, short(valid_k_cols)));
+      k_right.load_from(lane, fragment_source(k_col_ptr, int(qk_row_stride)).bounded(col_limit, short(valid_k_cols)));
+
+      fragment_mma(kk_acc, k_left, k_right);
+      fragment_mma(qk_acc, q_left, k_right);
+    }
+
+    kk_acc.map_coords(lane, [&](short row, short col, float kk) {
+      const uint i = row_base + uint(row);
+      const uint j = col_base + uint(col);
+      if (i >= tree_size || j >= tree_size) {
+        return 0.0f;
+      }
+      const TrieNode node = trie[trie_base + (ulong)j];
+      const bool incl = i >= node.trie_start && i <= node.trie_end;
+      if (!incl || i == j) {
+        return 0.0f;
+      }
+      const float prefix_i = prefix[prefix_base + (ulong)i * (ulong)value_heads];
+      const float prefix_j = prefix[prefix_base + (ulong)j * (ulong)value_heads];
+      const float beta_i = beta[prefix_base + (ulong)i * (ulong)value_heads];
+      return beta_i * exp(prefix_i - prefix_j) * kk;
+    });
+
+    qk_acc.map_coords(lane, [&](short row, short col, float qk_dot) {
+      const uint i = row_base + uint(row);
+      const uint j = col_base + uint(col);
+      if (i >= tree_size || j >= tree_size) {
+        return 0.0f;
+      }
+      const TrieNode node = trie[trie_base + (ulong)j];
+      const bool incl = i >= node.trie_start && i <= node.trie_end;
+      if (!incl) {
+        return 0.0f;
+      }
+      const float prefix_i = prefix[prefix_base + (ulong)i * (ulong)value_heads];
+      const float prefix_j = prefix[prefix_base + (ulong)j * (ulong)value_heads];
+      return scale * exp(prefix_i - prefix_j) * qk_dot;
+    });
+
+      const short2 tile_dims = short2(
+          short(min(uint(TREE_GRAM_COL_TILE), tree_size - col_base)),
+          short(min(uint(TREE_GRAM_ROW_TILE), tree_size - row_base))
+      );
+      kk_acc.store_safe(
+          lane,
+          a_mat + mat_base + (ulong)row_base * (ulong)tree_size + (ulong)col_base,
+          int(tree_size),
+          tile_dims
+      );
+      kk_acc.store_safe(
+          lane,
+          a_shared + row_base * TREE_GRAM_MAX_T + col_base,
+          TREE_GRAM_MAX_T,
+          tile_dims
+      );
+      qk_acc.store_safe(
+          lane,
+          qkd + mat_base + (ulong)row_base * (ulong)tree_size + (ulong)col_base,
+          int(tree_size),
+          tile_dims
+      );
+    }
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (tid == 0) {
+    for (uint i = 0; i < tree_size; ++i) {
+      for (uint j = 0; j < tree_size; ++j) {
+        ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = i == j ? 1.0f : 0.0f;
+      }
+    }
+    for (uint i = 0; i < tree_size; ++i) {
+      for (uint j = 0; j < i; ++j) {
+        float sum = 0.0f;
+        for (uint m = j; m < i; ++m) {
+          sum += a_shared[i * TREE_GRAM_MAX_T + m] * ainv[mat_base + (ulong)m * (ulong)tree_size + (ulong)j];
+        }
+        ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = -sum;
+      }
+    }
+  }
+}

--- a/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/gram.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/gram.metal
@@ -168,21 +168,27 @@ PUBLIC KERNEL(BuildTreeGram)(
   }
   threadgroup_barrier(mem_flags::mem_threadgroup);
 
-  kk_acc.zip_map_coords(lane, qk_acc, [&](ushort local_row, ushort local_col, float kk, float qk_dot) {
-    const uint row_idx = row_token[local_row];
-    const uint col_idx = col_base + local_col;
-    const bool in_subtree = row_idx >= col_trie_start[local_col] && row_idx <= col_trie_end[local_col];
-    const float decay = exp(row_prefix[local_row] - col_prefix[local_col]);
-    const float a_value = in_subtree && row_idx != col_idx ? row_beta[local_row] * decay * kk : 0.0f;
-    const float qkd_value = in_subtree ? scale * decay * qk_dot : 0.0f;
-    if (has_diag && local_row < diag_size && local_col >= diag_col_offset) {
-      const uint diag_col = local_col - diag_col_offset;
-      if (diag_col < diag_size) {
-        diag_a_tile[local_row * TREE_GRAM_ROW_TILE + diag_col] = a_value;
-      }
-    }
-    return float2(a_value, qkd_value);
-  });
+  AccFragment::zip_for_each_coord(
+      lane,
+      [&](ushort local_row, ushort local_col, thread float& kk, thread float& qk_dot) {
+        const uint row_idx = row_token[local_row];
+        const uint col_idx = col_base + local_col;
+        const bool in_subtree = row_idx >= col_trie_start[local_col] && row_idx <= col_trie_end[local_col];
+        const float decay = exp(row_prefix[local_row] - col_prefix[local_col]);
+        const float a_value = in_subtree && row_idx != col_idx ? row_beta[local_row] * decay * kk : 0.0f;
+        const float qkd_value = in_subtree ? scale * decay * qk_dot : 0.0f;
+        if (has_diag && local_row < diag_size && local_col >= diag_col_offset) {
+          const uint diag_col = local_col - diag_col_offset;
+          if (diag_col < diag_size) {
+            diag_a_tile[local_row * TREE_GRAM_ROW_TILE + diag_col] = a_value;
+          }
+        }
+        kk = a_value;
+        qk_dot = qkd_value;
+      },
+      kk_acc,
+      qk_acc
+  );
 
   const short2 tile_dims = short2(tile_cols, tile_rows);
   device float* a_tile = a_mat + tile_base;

--- a/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/gram.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/gram.metal
@@ -10,141 +10,9 @@ using namespace metal;
 using namespace uzu::matmul;
 using namespace uzu::trie;
 
-#define TREE_GRAM_MAX_T 64
 #define TREE_GRAM_ROW_TILE 16
 #define TREE_GRAM_COL_TILE 32
-#define TREE_GRAM_MAT_THREADS METAL_SIMD_SIZE
-
-template <bool USE_MXU, bool RELAXED_MXU>
-// Multiplies a <=16x16 Neumann tile. MXU needs a 16x32 N tile, so only that
-// path pads the RHS/result through scratch before copying the valid 16x16 part.
-METAL_FUNC void tree_gram_neumann_matmul16(
-    threadgroup float* lhs_tile,
-    int lhs_stride,
-    threadgroup float* rhs_tile,
-    int rhs_stride,
-    threadgroup float* dst_tile,
-    int dst_stride,
-    threadgroup float* mxu_rhs_tile_16x32,
-    threadgroup float* mxu_dst_tile_16x32,
-    ushort lane,
-    short valid_rows,
-    short valid_cols
-) {
-  if constexpr (USE_MXU) {
-    using Ops = MxuFragmentOps<RELAXED_MXU>;
-    using AccFragment = Fragment<float, 1, 2, Ops>;
-    using LeftFragment = OperandFragment<float, 1, 1, Ops>;
-    using RightFragment = OperandFragment<float, 1, 2, Ops>;
-
-    for (uint idx = lane; idx < 16 * 32; idx += METAL_SIMD_SIZE) {
-      const uint r = idx / 32;
-      const uint c = idx - r * 32;
-      mxu_rhs_tile_16x32[idx] = c < 16 ? rhs_tile[r * rhs_stride + c] : 0.0f;
-      mxu_dst_tile_16x32[idx] = 0.0f;
-    }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    AccFragment acc;
-    LeftFragment left_frag;
-    RightFragment right_frag;
-    left_frag.load_from(lane, fragment_source(lhs_tile, lhs_stride).bounded(valid_rows, short(16)));
-    right_frag.load_from(lane, fragment_source(mxu_rhs_tile_16x32, 32).bounded(short(16), short(32)));
-    fragment_mm(acc, left_frag, right_frag);
-    acc.store(lane, mxu_dst_tile_16x32, 32);
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    for (uint idx = lane; idx < 16 * 16; idx += METAL_SIMD_SIZE) {
-      const uint r = idx / 16;
-      const uint c = idx - r * 16;
-      if (r < uint(valid_rows) && c < uint(valid_cols)) {
-        dst_tile[r * dst_stride + c] = mxu_dst_tile_16x32[r * 32 + c];
-      }
-    }
-  } else {
-    using Ops = SimdgroupFragmentOps;
-    using AccFragment = Fragment<float, 2, 2, Ops>;
-    using LeftFragment = OperandFragment<float, 2, 2, Ops>;
-    using RightFragment = OperandFragment<float, 2, 2, Ops>;
-    AccFragment acc;
-    LeftFragment left_frag;
-    RightFragment right_frag;
-    acc.clear();
-    left_frag.load_from(lane, fragment_source(lhs_tile, lhs_stride).bounded(valid_rows, short(16)));
-    right_frag.load_from(lane, fragment_source(rhs_tile, rhs_stride).bounded(short(16), valid_cols));
-    fragment_mma(acc, left_frag, right_frag);
-    acc.store_safe(lane, dst_tile, dst_stride, short2(valid_cols, valid_rows));
-  }
-}
-
-template <bool USE_MXU>
-METAL_FUNC void invert_tree_gram_diag_neumann_tile(
-    threadgroup float* neumann_power_tile,
-    threadgroup float* inverse_tile,
-    threadgroup float* product_tile,
-    threadgroup float* mxu_scratch,
-    device float* ainv,
-    ulong mat_base,
-    uint tree_size,
-    uint block_start,
-    uint block_size,
-    uint tid
-) {
-  for (uint covered_power = 1; covered_power < block_size - 1; covered_power = covered_power * 2 + 1) {
-    if (tid < METAL_SIMD_SIZE) {
-      // Strict MXU precision is intentional here; relaxed precision fails the
-      // repeated-squaring Ainv accuracy check.
-      tree_gram_neumann_matmul16<USE_MXU, false>(
-          neumann_power_tile,
-          16,
-          neumann_power_tile,
-          16,
-          product_tile,
-          16,
-          mxu_scratch,
-          mxu_scratch + 16 * 32,
-          ushort(tid),
-          short(block_size),
-          short(block_size)
-      );
-    }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    for (uint idx = tid; idx < 16 * 16; idx += TREE_GRAM_MAT_THREADS) {
-      const uint r = idx / 16;
-      const uint c = idx - r * 16;
-      neumann_power_tile[r * 16 + c] = product_tile[r * 16 + c];
-    }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    if (tid < METAL_SIMD_SIZE) {
-      tree_gram_neumann_matmul16<USE_MXU, false>(
-          inverse_tile,
-          16,
-          neumann_power_tile,
-          16,
-          product_tile,
-          16,
-          mxu_scratch,
-          mxu_scratch + 16 * 32,
-          ushort(tid),
-          short(block_size),
-          short(block_size)
-      );
-    }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    for (uint idx = tid; idx < block_size * block_size; idx += TREE_GRAM_MAT_THREADS) {
-      const uint r = idx / block_size;
-      const uint c = idx - r * block_size;
-      const uint i = block_start + r;
-      const uint j = block_start + c;
-      inverse_tile[r * 16 + c] += product_tile[r * 16 + c];
-      ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = inverse_tile[r * 16 + c];
-    }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-  }
-}
+#define TREE_GRAM_THREADS METAL_SIMD_SIZE
 
 template <typename T, bool USE_MXU>
 VARIANTS(T, float, half, bfloat)
@@ -164,26 +32,13 @@ PUBLIC KERNEL(BuildTreeGram)(
     constant const uint& k_heads,
     constant const uint& value_heads,
     constant const uint& head_k_dim,
-    threadgroup float row_prefix_shared[TREE_GRAM_MAX_T],
-    threadgroup float row_beta_shared[TREE_GRAM_MAX_T],
-    threadgroup float col_prefix_shared[TREE_GRAM_COL_TILE],
-    threadgroup uint col_start_shared[TREE_GRAM_COL_TILE],
-    threadgroup uint col_end_shared[TREE_GRAM_COL_TILE],
-    threadgroup float a_tile_shared[TREE_GRAM_ROW_TILE * TREE_GRAM_COL_TILE],
-    threadgroup float neumann_power_shared[16 * 16],
-    threadgroup float neumann_inverse_shared[16 * 16],
-    threadgroup float neumann_product_shared[16 * 16],
-    threadgroup float mxu_neumann_scratch[16 * 32 * 2],
+    threadgroup float diagonal_a[TREE_GRAM_ROW_TILE * TREE_GRAM_ROW_TILE],
     const ThreadContext thread_context,
-    const uint batch_idx GROUPS(batch_size),
-    const uint hv GROUPS(value_heads),
+    const uint batch GROUPS(batch_size),
+    const uint value_head GROUPS(value_heads),
     const uint tile_idx GROUPS(tree_size.div_ceil(TREE_GRAM_ROW_TILE) * tree_size.div_ceil(TREE_GRAM_COL_TILE)),
-    const uint tid THREADS(TREE_GRAM_MAT_THREADS)
+    const uint tid THREADS(TREE_GRAM_THREADS)
 ) {
-  if (tree_size > TREE_GRAM_MAX_T) {
-    return;
-  }
-
   using Ops = metal::conditional_t<USE_MXU, MxuFragmentOps<>, SimdgroupFragmentOps>;
   constexpr ushort ROW_FRAGMENTS = TREE_GRAM_ROW_TILE / Ops::FRAGMENT_ROWS;
   constexpr ushort COL_FRAGMENTS = TREE_GRAM_COL_TILE / Ops::FRAGMENT_COLS;
@@ -192,13 +47,13 @@ PUBLIC KERNEL(BuildTreeGram)(
   using LeftFragment = OperandFragment<InputType, ROW_FRAGMENTS, 1, Ops>;
   using RightFragment = OperandFragment<InputType, 1, COL_FRAGMENTS, Ops, ReadTranspose>;
 
-  const uint groups_per_head = value_heads / k_heads;
-  const uint hk = hv / groups_per_head;
-  const ulong qk_head_base = (((ulong)batch_idx * (ulong)tree_size) * (ulong)k_heads + (ulong)hk) * (ulong)head_k_dim;
+  const uint value_heads_per_key_head = value_heads / k_heads;
+  const uint key_head = value_head / value_heads_per_key_head;
+  const ulong qk_head_base = (((ulong)batch * (ulong)tree_size) * (ulong)k_heads + (ulong)key_head) * (ulong)head_k_dim;
   const uint qk_row_stride = k_heads * head_k_dim;
-  const ulong prefix_base = ((ulong)batch_idx * (ulong)tree_size) * (ulong)value_heads + (ulong)hv;
-  const ulong trie_base = (ulong)batch_idx * (ulong)tree_size;
-  const ulong mat_base = ((ulong)batch_idx * (ulong)value_heads + (ulong)hv) * (ulong)tree_size * (ulong)tree_size;
+  const ulong prefix_base = ((ulong)batch * (ulong)tree_size) * (ulong)value_heads + (ulong)value_head;
+  const ulong trie_base = (ulong)batch * (ulong)tree_size;
+  const ulong mat_base = ((ulong)batch * (ulong)value_heads + (ulong)value_head) * (ulong)tree_size * (ulong)tree_size;
 
   const uint col_tiles = (tree_size + TREE_GRAM_COL_TILE - 1) / TREE_GRAM_COL_TILE;
   const uint row_tile_idx = tile_idx / col_tiles;
@@ -206,25 +61,6 @@ PUBLIC KERNEL(BuildTreeGram)(
   const uint row_base = row_tile_idx * TREE_GRAM_ROW_TILE;
   const uint col_base = col_tile_idx * TREE_GRAM_COL_TILE;
   const ushort lane = thread_context.simd_lane_id;
-
-  for (uint i = tid; i < tree_size; i += TREE_GRAM_MAT_THREADS) {
-    row_prefix_shared[i] = prefix[prefix_base + (ulong)i * (ulong)value_heads];
-    row_beta_shared[i] = beta[prefix_base + (ulong)i * (ulong)value_heads];
-  }
-  if (tid < TREE_GRAM_COL_TILE) {
-    const uint j = col_base + tid;
-    if (j < tree_size) {
-      const TrieNode node = trie[trie_base + (ulong)j];
-      col_prefix_shared[tid] = prefix[prefix_base + (ulong)j * (ulong)value_heads];
-      col_start_shared[tid] = node.trie_start;
-      col_end_shared[tid] = node.trie_end;
-    } else {
-      col_prefix_shared[tid] = 0.0f;
-      col_start_shared[tid] = 1;
-      col_end_shared[tid] = 0;
-    }
-  }
-  threadgroup_barrier(mem_flags::mem_threadgroup);
 
   AccFragment kk_acc;
   AccFragment qk_acc;
@@ -260,20 +96,29 @@ PUBLIC KERNEL(BuildTreeGram)(
     return;
   }
 
+  const bool has_diagonal_block = col_base <= row_base && row_base < col_base + TREE_GRAM_COL_TILE;
+  const uint diagonal_col_offset = has_diagonal_block ? row_base - col_base : 0;
+  const uint diagonal_block_size = min(uint(TREE_GRAM_ROW_TILE), tree_size - row_base);
+
   kk_acc.map_coords(lane, [&](short row, short col, float kk) {
     const uint i = row_base + uint(row);
     const uint j = col_base + uint(col);
     if (i >= tree_size || j >= tree_size) {
       return 0.0f;
     }
-    const bool incl = i >= col_start_shared[col] && i <= col_end_shared[col];
-    const float prefix_i = row_prefix_shared[i];
-    const float prefix_j = col_prefix_shared[col];
-    const float beta_i = row_beta_shared[i];
-    if (!incl || i == j) {
-      return 0.0f;
+    const TrieNode node = trie[trie_base + (ulong)j];
+    const bool incl = i >= node.trie_start && i <= node.trie_end;
+    const float prefix_i = prefix[prefix_base + (ulong)i * (ulong)value_heads];
+    const float prefix_j = prefix[prefix_base + (ulong)j * (ulong)value_heads];
+    const float beta_i = beta[prefix_base + (ulong)i * (ulong)value_heads];
+    const float a = incl && i != j ? beta_i * exp(prefix_i - prefix_j) * kk : 0.0f;
+    if (has_diagonal_block && uint(row) < diagonal_block_size && uint(col) >= diagonal_col_offset) {
+      const uint local_col = uint(col) - diagonal_col_offset;
+      if (local_col < diagonal_block_size) {
+        diagonal_a[uint(row) * TREE_GRAM_ROW_TILE + local_col] = a;
+      }
     }
-    return beta_i * exp(prefix_i - prefix_j) * kk;
+    return a;
   });
 
   qk_acc.map_coords(lane, [&](short row, short col, float qk_dot) {
@@ -282,9 +127,10 @@ PUBLIC KERNEL(BuildTreeGram)(
     if (i >= tree_size || j >= tree_size) {
       return 0.0f;
     }
-    const bool incl = i >= col_start_shared[col] && i <= col_end_shared[col];
-    const float prefix_i = row_prefix_shared[i];
-    const float prefix_j = col_prefix_shared[col];
+    const TrieNode node = trie[trie_base + (ulong)j];
+    const bool incl = i >= node.trie_start && i <= node.trie_end;
+    const float prefix_i = prefix[prefix_base + (ulong)i * (ulong)value_heads];
+    const float prefix_j = prefix[prefix_base + (ulong)j * (ulong)value_heads];
     if (!incl) {
       return 0.0f;
     }
@@ -300,7 +146,6 @@ PUBLIC KERNEL(BuildTreeGram)(
       int(tree_size),
       tile_dims
   );
-  kk_acc.store_safe(lane, a_tile_shared, TREE_GRAM_COL_TILE, tile_dims);
   qk_acc.store_safe(
       lane,
       qkd + mat_base + (ulong)row_base * (ulong)tree_size + (ulong)col_base,
@@ -308,41 +153,42 @@ PUBLIC KERNEL(BuildTreeGram)(
       tile_dims
   );
 
-  for (uint idx = tid; idx < tile_rows * tile_cols; idx += TREE_GRAM_MAT_THREADS) {
+  for (uint idx = tid; idx < tile_rows * tile_cols; idx += TREE_GRAM_THREADS) {
     const uint i = row_base + idx / tile_cols;
     const uint j = col_base + idx % tile_cols;
     ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = i == j ? 1.0f : 0.0f;
   }
-  threadgroup_barrier(mem_flags::mem_threadgroup);
 
-  if (col_base <= row_base && row_base < col_base + TREE_GRAM_COL_TILE) {
-    const uint diag_col = row_base - col_base;
-    const uint block_size = min(uint(16), tree_size - row_base);
-    for (uint idx = tid; idx < 16 * 16; idx += TREE_GRAM_MAT_THREADS) {
-      const uint r = idx / 16;
-      const uint c = idx - r * 16;
-      const uint i = row_base + r;
-      const uint j = row_base + c;
-      const bool in_block = r < block_size && c < block_size;
-      const float neg_a = in_block && c < r ? -a_tile_shared[r * TREE_GRAM_COL_TILE + diag_col + c] : 0.0f;
-      neumann_power_shared[idx] = neg_a;
-      neumann_inverse_shared[idx] = in_block && r == c ? 1.0f : neg_a;
-      if (in_block) {
-        ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = neumann_inverse_shared[idx];
+  // ponytail: only diagonal 16x16 inverse blocks are produced; downstream reads no off-block Ainv.
+  if (has_diagonal_block) {
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    const uint block_size = diagonal_block_size;
+    const uint j = tid;
+    if (j < block_size) {
+      float xcol[16];
+      METAL_PRAGMA_UNROLL
+      for (uint i = 0; i < 16; i++) {
+        if (i >= block_size || i < j) {
+          xcol[i] = 0.0f;
+        } else if (i == j) {
+          xcol[i] = 1.0f;
+        } else {
+          float acc = 0.0f;
+          METAL_PRAGMA_UNROLL
+          for (uint prev_row = 0; prev_row < 16; prev_row++) {
+            if (prev_row < i) {
+              acc += diagonal_a[i * TREE_GRAM_ROW_TILE + prev_row] * xcol[prev_row];
+            }
+          }
+          xcol[i] = -acc;
+        }
+      }
+      METAL_PRAGMA_UNROLL
+      for (uint i = 0; i < 16; i++) {
+        if (i < block_size) {
+          ainv[mat_base + (ulong)(row_base + i) * (ulong)tree_size + (ulong)(row_base + j)] = xcol[i];
+        }
       }
     }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-    invert_tree_gram_diag_neumann_tile<USE_MXU>(
-        neumann_power_shared,
-        neumann_inverse_shared,
-        neumann_product_shared,
-        mxu_neumann_scratch,
-        ainv,
-        mat_base,
-        tree_size,
-        row_base,
-        block_size,
-        tid
-    );
   }
 }

--- a/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/gram.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/gram.metal
@@ -4,6 +4,7 @@
 #include "../generated/trie.h"
 #include "../matmul/common/fragment.h"
 #include "../matmul/common/mxu_fragment_ops.h"
+#include "../matmul/common/simdgroup_fragment_ops.h"
 
 using namespace metal;
 using namespace uzu::matmul;
@@ -14,6 +15,49 @@ using namespace uzu::trie;
 #define TREE_GRAM_COL_TILE 32
 #define TREE_GRAM_SIMDGROUPS 4
 #define TREE_GRAM_THREADS (TREE_GRAM_SIMDGROUPS * METAL_SIMD_SIZE)
+
+METAL_FUNC uint tree_gram_lower_index(uint i, uint j) {
+  return (i * (i + 1)) / 2 + j;
+}
+
+METAL_FUNC void invert_tree_gram_matrix(
+    threadgroup const float* a_shared,
+    threadgroup float* x_shared,
+    device float* ainv,
+    ulong mat_base,
+    uint tree_size,
+    uint tid
+) {
+  for (uint idx = tid; idx < tree_size * tree_size; idx += TREE_GRAM_THREADS) {
+    const uint i = idx / tree_size;
+    const uint j = idx - i * tree_size;
+    ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = i == j ? 1.0f : 0.0f;
+  }
+  for (uint i = tid; i < tree_size; i += TREE_GRAM_THREADS) {
+    x_shared[tree_gram_lower_index(i, i)] = 1.0f;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint d = 1; d < tree_size; ++d) {
+    for (uint j = tid; j + d < tree_size; j += TREE_GRAM_THREADS) {
+      const uint i = j + d;
+      float sum = 0.0f;
+      for (uint m = j; m < i; ++m) {
+        sum += a_shared[i * TREE_GRAM_MAX_T + m] * x_shared[tree_gram_lower_index(m, j)];
+      }
+      x_shared[tree_gram_lower_index(i, j)] = -sum;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  for (uint idx = tid; idx < tree_size * tree_size; idx += TREE_GRAM_THREADS) {
+    const uint i = idx / tree_size;
+    const uint j = idx - i * tree_size;
+    if (j < i) {
+      ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = x_shared[tree_gram_lower_index(i, j)];
+    }
+  }
+}
 
 // K1: tree gram + masked decay + diagonal inverse.
 //
@@ -37,8 +81,9 @@ using namespace uzu::trie;
 //   AINV[i,i] = 1
 //   AINV[i,j] = -sum_{m=j}^{i-1} A[i,m] * AINV[m,j], for j < i
 //   AINV[i,j] = 0, for j > i
-template <typename T>
+template <typename T, bool USE_MXU>
 VARIANTS(T, float, half, bfloat)
+VARIANTS(USE_MXU, false, true)
 PUBLIC KERNEL(BuildTreeGram)(
     const device T* q,
     const device T* k,
@@ -55,6 +100,12 @@ PUBLIC KERNEL(BuildTreeGram)(
     constant const uint& value_heads,
     constant const uint& head_k_dim,
     threadgroup float a_shared[TREE_GRAM_MAX_T * TREE_GRAM_MAX_T],
+    threadgroup float x_shared[(TREE_GRAM_MAX_T * (TREE_GRAM_MAX_T + 1)) / 2],
+    threadgroup float row_prefix_shared[TREE_GRAM_MAX_T],
+    threadgroup float row_beta_shared[TREE_GRAM_MAX_T],
+    threadgroup float col_prefix_shared[TREE_GRAM_COL_TILE],
+    threadgroup uint col_start_shared[TREE_GRAM_COL_TILE],
+    threadgroup uint col_end_shared[TREE_GRAM_COL_TILE],
     const ThreadContext thread_context,
     const uint batch_idx GROUPS(batch_size),
     const uint hv GROUPS(value_heads),
@@ -64,9 +115,13 @@ PUBLIC KERNEL(BuildTreeGram)(
     return;
   }
 
-  using AccFragment = Fragment<float, 1, 2, MxuFragmentOps>;
-  using LeftFragment = OperandFragment<T, 1, 1, MxuFragmentOps>;
-  using RightFragment = OperandFragment<T, 1, 2, MxuFragmentOps, ReadTranspose>;
+  using Ops = metal::conditional_t<USE_MXU, MxuFragmentOps, SimdgroupFragmentOps>;
+  constexpr ushort ROW_FRAGMENTS = TREE_GRAM_ROW_TILE / Ops::FRAGMENT_ROWS;
+  constexpr ushort COL_FRAGMENTS = TREE_GRAM_COL_TILE / Ops::FRAGMENT_COLS;
+  using InputType = metal::conditional_t<USE_MXU, T, float>;
+  using AccFragment = Fragment<float, ROW_FRAGMENTS, COL_FRAGMENTS, Ops>;
+  using LeftFragment = OperandFragment<InputType, ROW_FRAGMENTS, 1, Ops>;
+  using RightFragment = OperandFragment<InputType, 1, COL_FRAGMENTS, Ops, ReadTranspose>;
 
   const uint groups_per_head = value_heads / k_heads;
   const uint hk = hv / groups_per_head;
@@ -80,68 +135,89 @@ PUBLIC KERNEL(BuildTreeGram)(
   const uint row_base = thread_context.simdgroup_index * TREE_GRAM_ROW_TILE;
   const ushort lane = thread_context.simd_lane_id;
 
-  if (row_base < tree_size) {
-    for (uint col_base = 0; col_base < tree_size; col_base += TREE_GRAM_COL_TILE) {
+  for (uint i = tid; i < tree_size; i += TREE_GRAM_THREADS) {
+    row_prefix_shared[i] = prefix[prefix_base + (ulong)i * (ulong)value_heads];
+    row_beta_shared[i] = beta[prefix_base + (ulong)i * (ulong)value_heads];
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint col_base = 0; col_base < tree_size; col_base += TREE_GRAM_COL_TILE) {
+    if (tid < TREE_GRAM_COL_TILE) {
+      const uint j = col_base + tid;
+      if (j < tree_size) {
+        const TrieNode node = trie[trie_base + (ulong)j];
+        col_prefix_shared[tid] = prefix[prefix_base + (ulong)j * (ulong)value_heads];
+        col_start_shared[tid] = node.trie_start;
+        col_end_shared[tid] = node.trie_end;
+      } else {
+        col_prefix_shared[tid] = 0.0f;
+        col_start_shared[tid] = 1;
+        col_end_shared[tid] = 0;
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
     AccFragment kk_acc;
     AccFragment qk_acc;
     kk_acc.clear();
     qk_acc.clear();
 
-    for (uint k_base = 0; k_base < head_k_dim; k_base += MxuFragmentOps::FRAGMENT_ROWS) {
+    for (uint k_base = 0; k_base < head_k_dim; k_base += Ops::FRAGMENT_ROWS) {
       const uint k_rem = head_k_dim - k_base;
-      const ushort valid_k_cols = ushort(min(k_rem, uint(MxuFragmentOps::FRAGMENT_ROWS)));
+      const ushort valid_k_cols = ushort(min(k_rem, uint(Ops::FRAGMENT_ROWS)));
 
-      LeftFragment k_left;
-      LeftFragment q_left;
-      RightFragment k_right;
+      if (row_base < tree_size) {
+        LeftFragment k_left;
+        LeftFragment q_left;
+        RightFragment k_right;
 
-      const device T* k_rows = k + qk_head_base + (ulong)row_base * (ulong)qk_row_stride + (ulong)k_base;
-      const device T* q_rows = q + qk_head_base + (ulong)row_base * (ulong)qk_row_stride + (ulong)k_base;
-      const device T* k_col_ptr = k + qk_head_base + (ulong)col_base * (ulong)qk_row_stride + (ulong)k_base;
+        const short row_limit = short(max(int(0), int(tree_size) - int(row_base)));
+        const short col_limit = short(max(int(0), int(tree_size) - int(col_base)));
 
-      const short row_limit = short(max(int(0), int(tree_size) - int(row_base)));
-      const short col_limit = short(max(int(0), int(tree_size) - int(col_base)));
+        const device T* k_rows = k + qk_head_base + (ulong)row_base * (ulong)qk_row_stride + (ulong)k_base;
+        const device T* q_rows = q + qk_head_base + (ulong)row_base * (ulong)qk_row_stride + (ulong)k_base;
+        const device T* k_col_ptr = k + qk_head_base + (ulong)col_base * (ulong)qk_row_stride + (ulong)k_base;
 
-      k_left.load_from(lane, fragment_source(k_rows, int(qk_row_stride)).bounded(row_limit, short(valid_k_cols)));
-      q_left.load_from(lane, fragment_source(q_rows, int(qk_row_stride)).bounded(row_limit, short(valid_k_cols)));
-      k_right.load_from(lane, fragment_source(k_col_ptr, int(qk_row_stride)).bounded(col_limit, short(valid_k_cols)));
+        k_left.load_from(lane, fragment_source(k_rows, int(qk_row_stride)).bounded(row_limit, short(valid_k_cols)));
+        q_left.load_from(lane, fragment_source(q_rows, int(qk_row_stride)).bounded(row_limit, short(valid_k_cols)));
+        k_right.load_from(lane, fragment_source(k_col_ptr, int(qk_row_stride)).bounded(col_limit, short(valid_k_cols)));
 
-      fragment_mma(kk_acc, k_left, k_right);
-      fragment_mma(qk_acc, q_left, k_right);
+        fragment_mma(kk_acc, k_left, k_right);
+        fragment_mma(qk_acc, q_left, k_right);
+      }
     }
 
-    kk_acc.map_coords(lane, [&](short row, short col, float kk) {
-      const uint i = row_base + uint(row);
-      const uint j = col_base + uint(col);
-      if (i >= tree_size || j >= tree_size) {
-        return 0.0f;
-      }
-      const TrieNode node = trie[trie_base + (ulong)j];
-      const bool incl = i >= node.trie_start && i <= node.trie_end;
-      if (!incl || i == j) {
-        return 0.0f;
-      }
-      const float prefix_i = prefix[prefix_base + (ulong)i * (ulong)value_heads];
-      const float prefix_j = prefix[prefix_base + (ulong)j * (ulong)value_heads];
-      const float beta_i = beta[prefix_base + (ulong)i * (ulong)value_heads];
-      return beta_i * exp(prefix_i - prefix_j) * kk;
-    });
+    if (row_base < tree_size) {
+      kk_acc.map_coords(lane, [&](short row, short col, float kk) {
+        const uint i = row_base + uint(row);
+        const uint j = col_base + uint(col);
+        if (i >= tree_size || j >= tree_size) {
+          return 0.0f;
+        }
+        const bool incl = i >= col_start_shared[col] && i <= col_end_shared[col];
+        const float prefix_i = row_prefix_shared[i];
+        const float prefix_j = col_prefix_shared[col];
+        const float beta_i = row_beta_shared[i];
+        if (!incl || i == j) {
+          return 0.0f;
+        }
+        return beta_i * exp(prefix_i - prefix_j) * kk;
+      });
 
-    qk_acc.map_coords(lane, [&](short row, short col, float qk_dot) {
-      const uint i = row_base + uint(row);
-      const uint j = col_base + uint(col);
-      if (i >= tree_size || j >= tree_size) {
-        return 0.0f;
-      }
-      const TrieNode node = trie[trie_base + (ulong)j];
-      const bool incl = i >= node.trie_start && i <= node.trie_end;
-      if (!incl) {
-        return 0.0f;
-      }
-      const float prefix_i = prefix[prefix_base + (ulong)i * (ulong)value_heads];
-      const float prefix_j = prefix[prefix_base + (ulong)j * (ulong)value_heads];
-      return scale * exp(prefix_i - prefix_j) * qk_dot;
-    });
+      qk_acc.map_coords(lane, [&](short row, short col, float qk_dot) {
+        const uint i = row_base + uint(row);
+        const uint j = col_base + uint(col);
+        if (i >= tree_size || j >= tree_size) {
+          return 0.0f;
+        }
+        const bool incl = i >= col_start_shared[col] && i <= col_end_shared[col];
+        const float prefix_i = row_prefix_shared[i];
+        const float prefix_j = col_prefix_shared[col];
+        if (!incl) {
+          return 0.0f;
+        }
+        return scale * exp(prefix_i - prefix_j) * qk_dot;
+      });
 
       const short2 tile_dims = short2(
           short(min(uint(TREE_GRAM_COL_TILE), tree_size - col_base)),
@@ -166,24 +242,9 @@ PUBLIC KERNEL(BuildTreeGram)(
           tile_dims
       );
     }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
   }
 
   threadgroup_barrier(mem_flags::mem_threadgroup);
-
-  if (tid == 0) {
-    for (uint i = 0; i < tree_size; ++i) {
-      for (uint j = 0; j < tree_size; ++j) {
-        ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = i == j ? 1.0f : 0.0f;
-      }
-    }
-    for (uint i = 0; i < tree_size; ++i) {
-      for (uint j = 0; j < i; ++j) {
-        float sum = 0.0f;
-        for (uint m = j; m < i; ++m) {
-          sum += a_shared[i * TREE_GRAM_MAX_T + m] * ainv[mat_base + (ulong)m * (ulong)tree_size + (ulong)j];
-        }
-        ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = -sum;
-      }
-    }
-  }
+  invert_tree_gram_matrix(a_shared, x_shared, ainv, mat_base, tree_size, tid);
 }

--- a/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/gram.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/gram.metal
@@ -13,74 +13,14 @@ using namespace uzu::trie;
 #define TREE_GRAM_MAX_T 64
 #define TREE_GRAM_ROW_TILE 16
 #define TREE_GRAM_COL_TILE 32
-#define TREE_GRAM_SIMDGROUPS 4
-#define TREE_GRAM_THREADS (TREE_GRAM_SIMDGROUPS * METAL_SIMD_SIZE)
+#define TREE_GRAM_MAT_THREADS METAL_SIMD_SIZE
+#define TREE_GRAM_AINV_THREADS 64
+#define TREE_GRAM_FUSED_SIMDGROUPS 4
+#define TREE_GRAM_FUSED_THREADS (TREE_GRAM_FUSED_SIMDGROUPS * METAL_SIMD_SIZE)
+#define TREE_GRAM_LOWER_SIZE (TREE_GRAM_MAX_T * (TREE_GRAM_MAX_T + 1) / 2)
 
-METAL_FUNC uint tree_gram_lower_index(uint i, uint j) {
-  return (i * (i + 1)) / 2 + j;
-}
-
-METAL_FUNC void invert_tree_gram_matrix(
-    threadgroup const float* a_shared,
-    threadgroup float* x_shared,
-    device float* ainv,
-    ulong mat_base,
-    uint tree_size,
-    uint tid
-) {
-  for (uint idx = tid; idx < tree_size * tree_size; idx += TREE_GRAM_THREADS) {
-    const uint i = idx / tree_size;
-    const uint j = idx - i * tree_size;
-    ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = i == j ? 1.0f : 0.0f;
-  }
-  for (uint i = tid; i < tree_size; i += TREE_GRAM_THREADS) {
-    x_shared[tree_gram_lower_index(i, i)] = 1.0f;
-  }
-  threadgroup_barrier(mem_flags::mem_threadgroup);
-
-  for (uint d = 1; d < tree_size; ++d) {
-    for (uint j = tid; j + d < tree_size; j += TREE_GRAM_THREADS) {
-      const uint i = j + d;
-      float sum = 0.0f;
-      for (uint m = j; m < i; ++m) {
-        sum += a_shared[i * TREE_GRAM_MAX_T + m] * x_shared[tree_gram_lower_index(m, j)];
-      }
-      x_shared[tree_gram_lower_index(i, j)] = -sum;
-    }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-  }
-
-  for (uint idx = tid; idx < tree_size * tree_size; idx += TREE_GRAM_THREADS) {
-    const uint i = idx / tree_size;
-    const uint j = idx - i * tree_size;
-    if (j < i) {
-      ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = x_shared[tree_gram_lower_index(i, j)];
-    }
-  }
-}
-
-// K1: tree gram + masked decay + diagonal inverse.
-//
-// Inputs:
-//   q, k   : [B, T, Hg, K]     value head hv maps to key head hk = hv / (HV / Hg)
-//   trie   : [B, T]            Euler intervals for ancestor tests
-//   prefix : [B, T, HV] float  G = path cumsum of log-decay from K0
-//   beta   : [B, T, HV] float  sigmoid gate from K0
-//
-// Let M[i,j] = trie[j].trie_start <= i <= trie[j].trie_end.
-// Let D[i,j,hv] = exp(prefix[i,hv] - prefix[j,hv]).
-// Let KK[i,j,hv] = dot(k[i,hk], k[j,hk]).
-// Let QK[i,j,hv] = scale * dot(q[i,hk], k[j,hk]).
-//
-// Outputs:
-//   A[i,j,hv]   = (i != j && M[i,j]) ? beta[i,hv] * D[i,j,hv] * KK[i,j,hv] : 0
-//   QKD[i,j,hv] = M[i,j] ? D[i,j,hv] * QK[i,j,hv] : 0
-//   AINV[hv]    = (I + A[hv])^-1
-//
-// Since A is strictly lower triangular:
-//   AINV[i,i] = 1
-//   AINV[i,j] = -sum_{m=j}^{i-1} A[i,m] * AINV[m,j], for j < i
-//   AINV[i,j] = 0, for j > i
+// The Rust BuildTreeGramMetalKernel wrapper dispatches BuildTreeGramMat then BuildTreeGramAinv.
+// This public entry keeps the CPU/Metal DSL kernel lists aligned.
 template <typename T, bool USE_MXU>
 VARIANTS(T, float, half, bfloat)
 VARIANTS(USE_MXU, false, true)
@@ -99,8 +39,101 @@ PUBLIC KERNEL(BuildTreeGram)(
     constant const uint& k_heads,
     constant const uint& value_heads,
     constant const uint& head_k_dim,
-    threadgroup float a_shared[TREE_GRAM_MAX_T * TREE_GRAM_MAX_T],
-    threadgroup float x_shared[(TREE_GRAM_MAX_T * (TREE_GRAM_MAX_T + 1)) / 2],
+    const uint tid THREADS(1)
+) {}
+
+template <bool USE_MASK>
+METAL_FUNC void invert_tree_gram_matrix(
+    threadgroup const float* a_shared,
+    threadgroup float* x_shared,
+    threadgroup ulong* row_mask_shared,
+    const device TrieNode* trie,
+    device float* ainv,
+    ulong mat_base,
+    ulong trie_base,
+    uint tree_size,
+    uint tid
+) {
+  for (uint idx = tid; idx < tree_size * tree_size; idx += TREE_GRAM_FUSED_THREADS) {
+    const uint i = idx / tree_size;
+    const uint j = idx - i * tree_size;
+    ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = i == j ? 1.0f : 0.0f;
+  }
+  for (uint i = tid; i < tree_size; i += TREE_GRAM_FUSED_THREADS) {
+    x_shared[(i * (i + 1)) / 2 + i] = 1.0f;
+  }
+  if constexpr (USE_MASK) {
+    for (uint i = tid; i < tree_size; i += TREE_GRAM_FUSED_THREADS) {
+      ulong mask = 0;
+      for (uint j = 0; j < tree_size; ++j) {
+        const TrieNode node = trie[trie_base + (ulong)j];
+        if (i != j && i >= node.trie_start && i <= node.trie_end) {
+          mask |= ulong(1) << j;
+        }
+      }
+      row_mask_shared[i] = mask;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  constexpr uint GROUP_WIDTH = 8;
+  constexpr uint GROUPS = TREE_GRAM_FUSED_THREADS / GROUP_WIDTH;
+  const uint group_id = tid / GROUP_WIDTH;
+  const uint group_lane = tid & (GROUP_WIDTH - 1);
+  for (uint i = 1; i < tree_size; ++i) {
+    const uint row_lower_base = (i * (i + 1)) / 2;
+    const ulong row_mask = USE_MASK ? row_mask_shared[i] : ~ulong(0);
+    for (uint j = group_id; j < i; j += GROUPS) {
+      if (((row_mask >> j) & 1) != 0) {
+        float sum = 0.0f;
+        for (uint m = j + group_lane; m < i; m += GROUP_WIDTH) {
+          if (((row_mask >> m) & 1) != 0) {
+            sum += a_shared[i * TREE_GRAM_MAX_T + m] * x_shared[(m * (m + 1)) / 2 + j];
+          }
+        }
+        sum += simd_shuffle_xor(sum, 1);
+        sum += simd_shuffle_xor(sum, 2);
+        sum += simd_shuffle_xor(sum, 4);
+        if (group_lane == 0) {
+          const float v = -sum;
+          x_shared[row_lower_base + j] = v;
+          ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = v;
+        }
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+}
+
+// K1: tree gram + masked decay.
+//
+// Inputs:
+//   q, k   : [B, T, Hg, K]     value head hv maps to key head hk = hv / (HV / Hg)
+//   trie   : [B, T]            Euler intervals for ancestor tests
+//   prefix : [B, T, HV] float  G = path cumsum of log-decay from K0
+//   beta   : [B, T, HV] float  sigmoid gate from K0
+//
+// Outputs:
+//   A[i,j,hv]   = (i != j && trie[j] contains i) ? beta[i,hv] * exp(prefix[i,hv] - prefix[j,hv]) * dot(k[i,hk],
+//   k[j,hk]) : 0 QKD[i,j,hv] = trie[j] contains i ? exp(prefix[i,hv] - prefix[j,hv]) * scale * dot(q[i,hk], k[j,hk]) :
+//   0
+template <typename T, bool USE_MXU>
+VARIANTS(T, float, half, bfloat)
+VARIANTS(USE_MXU, false, true)
+PUBLIC KERNEL(BuildTreeGramMat)(
+    const device T* q,
+    const device T* k,
+    const device TrieNode* trie,
+    const device float* prefix,
+    const device float* beta,
+    device float* a_mat,
+    device float* qkd,
+    constant const float& scale,
+    constant const uint& batch_size,
+    constant const uint& tree_size,
+    constant const uint& k_heads,
+    constant const uint& value_heads,
+    constant const uint& head_k_dim,
     threadgroup float row_prefix_shared[TREE_GRAM_MAX_T],
     threadgroup float row_beta_shared[TREE_GRAM_MAX_T],
     threadgroup float col_prefix_shared[TREE_GRAM_COL_TILE],
@@ -109,7 +142,8 @@ PUBLIC KERNEL(BuildTreeGram)(
     const ThreadContext thread_context,
     const uint batch_idx GROUPS(batch_size),
     const uint hv GROUPS(value_heads),
-    const uint tid THREADS(TREE_GRAM_THREADS)
+    const uint tile_idx GROUPS(tree_size.div_ceil(TREE_GRAM_ROW_TILE) * tree_size.div_ceil(TREE_GRAM_COL_TILE)),
+    const uint tid THREADS(TREE_GRAM_MAT_THREADS)
 ) {
   if (tree_size > TREE_GRAM_MAX_T) {
     return;
@@ -125,8 +159,168 @@ PUBLIC KERNEL(BuildTreeGram)(
 
   const uint groups_per_head = value_heads / k_heads;
   const uint hk = hv / groups_per_head;
-  const ulong qk_head_base =
-      (((ulong)batch_idx * (ulong)tree_size) * (ulong)k_heads + (ulong)hk) * (ulong)head_k_dim;
+  const ulong qk_head_base = (((ulong)batch_idx * (ulong)tree_size) * (ulong)k_heads + (ulong)hk) * (ulong)head_k_dim;
+  const uint qk_row_stride = k_heads * head_k_dim;
+  const ulong prefix_base = ((ulong)batch_idx * (ulong)tree_size) * (ulong)value_heads + (ulong)hv;
+  const ulong trie_base = (ulong)batch_idx * (ulong)tree_size;
+  const ulong mat_base = ((ulong)batch_idx * (ulong)value_heads + (ulong)hv) * (ulong)tree_size * (ulong)tree_size;
+
+  const uint col_tiles = (tree_size + TREE_GRAM_COL_TILE - 1) / TREE_GRAM_COL_TILE;
+  const uint row_tile_idx = tile_idx / col_tiles;
+  const uint col_tile_idx = tile_idx - row_tile_idx * col_tiles;
+  const uint row_base = row_tile_idx * TREE_GRAM_ROW_TILE;
+  const uint col_base = col_tile_idx * TREE_GRAM_COL_TILE;
+  const ushort lane = thread_context.simd_lane_id;
+
+  for (uint i = tid; i < tree_size; i += TREE_GRAM_MAT_THREADS) {
+    row_prefix_shared[i] = prefix[prefix_base + (ulong)i * (ulong)value_heads];
+    row_beta_shared[i] = beta[prefix_base + (ulong)i * (ulong)value_heads];
+  }
+  if (tid < TREE_GRAM_COL_TILE) {
+    const uint j = col_base + tid;
+    if (j < tree_size) {
+      const TrieNode node = trie[trie_base + (ulong)j];
+      col_prefix_shared[tid] = prefix[prefix_base + (ulong)j * (ulong)value_heads];
+      col_start_shared[tid] = node.trie_start;
+      col_end_shared[tid] = node.trie_end;
+    } else {
+      col_prefix_shared[tid] = 0.0f;
+      col_start_shared[tid] = 1;
+      col_end_shared[tid] = 0;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  AccFragment kk_acc;
+  AccFragment qk_acc;
+  kk_acc.clear();
+  qk_acc.clear();
+
+  for (uint k_base = 0; k_base < head_k_dim; k_base += Ops::FRAGMENT_ROWS) {
+    const uint k_rem = head_k_dim - k_base;
+    const ushort valid_k_cols = ushort(min(k_rem, uint(Ops::FRAGMENT_ROWS)));
+
+    if (row_base < tree_size) {
+      LeftFragment k_left;
+      LeftFragment q_left;
+      RightFragment k_right;
+
+      const short row_limit = short(max(int(0), int(tree_size) - int(row_base)));
+      const short col_limit = short(max(int(0), int(tree_size) - int(col_base)));
+
+      const device T* k_rows = k + qk_head_base + (ulong)row_base * (ulong)qk_row_stride + (ulong)k_base;
+      const device T* q_rows = q + qk_head_base + (ulong)row_base * (ulong)qk_row_stride + (ulong)k_base;
+      const device T* k_col_ptr = k + qk_head_base + (ulong)col_base * (ulong)qk_row_stride + (ulong)k_base;
+
+      k_left.load_from(lane, fragment_source(k_rows, int(qk_row_stride)).bounded(row_limit, short(valid_k_cols)));
+      q_left.load_from(lane, fragment_source(q_rows, int(qk_row_stride)).bounded(row_limit, short(valid_k_cols)));
+      k_right.load_from(lane, fragment_source(k_col_ptr, int(qk_row_stride)).bounded(col_limit, short(valid_k_cols)));
+
+      fragment_mma(kk_acc, k_left, k_right);
+      fragment_mma(qk_acc, q_left, k_right);
+    }
+  }
+
+  if (row_base >= tree_size) {
+    return;
+  }
+
+  kk_acc.map_coords(lane, [&](short row, short col, float kk) {
+    const uint i = row_base + uint(row);
+    const uint j = col_base + uint(col);
+    if (i >= tree_size || j >= tree_size) {
+      return 0.0f;
+    }
+    const bool incl = i >= col_start_shared[col] && i <= col_end_shared[col];
+    const float prefix_i = row_prefix_shared[i];
+    const float prefix_j = col_prefix_shared[col];
+    const float beta_i = row_beta_shared[i];
+    if (!incl || i == j) {
+      return 0.0f;
+    }
+    return beta_i * exp(prefix_i - prefix_j) * kk;
+  });
+
+  qk_acc.map_coords(lane, [&](short row, short col, float qk_dot) {
+    const uint i = row_base + uint(row);
+    const uint j = col_base + uint(col);
+    if (i >= tree_size || j >= tree_size) {
+      return 0.0f;
+    }
+    const bool incl = i >= col_start_shared[col] && i <= col_end_shared[col];
+    const float prefix_i = row_prefix_shared[i];
+    const float prefix_j = col_prefix_shared[col];
+    if (!incl) {
+      return 0.0f;
+    }
+    return scale * exp(prefix_i - prefix_j) * qk_dot;
+  });
+
+  const short2 tile_dims = short2(
+      short(min(uint(TREE_GRAM_COL_TILE), tree_size - col_base)),
+      short(min(uint(TREE_GRAM_ROW_TILE), tree_size - row_base))
+  );
+  kk_acc.store_safe(
+      lane,
+      a_mat + mat_base + (ulong)row_base * (ulong)tree_size + (ulong)col_base,
+      int(tree_size),
+      tile_dims
+  );
+  qk_acc.store_safe(
+      lane,
+      qkd + mat_base + (ulong)row_base * (ulong)tree_size + (ulong)col_base,
+      int(tree_size),
+      tile_dims
+  );
+}
+
+template <typename T, bool USE_MXU, bool USE_MASK>
+VARIANTS(T, float, half, bfloat)
+VARIANTS(USE_MXU, false, true)
+VARIANTS(USE_MASK, false, true)
+PUBLIC KERNEL(BuildTreeGramFused)(
+    const device T* q,
+    const device T* k,
+    const device TrieNode* trie,
+    const device float* prefix,
+    const device float* beta,
+    device float* a_mat,
+    device float* qkd,
+    device float* ainv,
+    constant const float& scale,
+    constant const uint& batch_size,
+    constant const uint& tree_size,
+    constant const uint& k_heads,
+    constant const uint& value_heads,
+    constant const uint& head_k_dim,
+    threadgroup float a_shared[TREE_GRAM_MAX_T * TREE_GRAM_MAX_T],
+    threadgroup float x_shared[TREE_GRAM_LOWER_SIZE],
+    threadgroup ulong row_mask_shared[TREE_GRAM_MAX_T],
+    threadgroup float row_prefix_shared[TREE_GRAM_MAX_T],
+    threadgroup float row_beta_shared[TREE_GRAM_MAX_T],
+    threadgroup float col_prefix_shared[TREE_GRAM_COL_TILE],
+    threadgroup uint col_start_shared[TREE_GRAM_COL_TILE],
+    threadgroup uint col_end_shared[TREE_GRAM_COL_TILE],
+    const ThreadContext thread_context,
+    const uint batch_idx GROUPS(batch_size),
+    const uint hv GROUPS(value_heads),
+    const uint tid THREADS(TREE_GRAM_FUSED_THREADS)
+) {
+  if (tree_size > TREE_GRAM_MAX_T) {
+    return;
+  }
+
+  using Ops = metal::conditional_t<USE_MXU, MxuFragmentOps, SimdgroupFragmentOps>;
+  constexpr ushort ROW_FRAGMENTS = TREE_GRAM_ROW_TILE / Ops::FRAGMENT_ROWS;
+  constexpr ushort COL_FRAGMENTS = TREE_GRAM_COL_TILE / Ops::FRAGMENT_COLS;
+  using InputType = metal::conditional_t<USE_MXU, T, float>;
+  using AccFragment = Fragment<float, ROW_FRAGMENTS, COL_FRAGMENTS, Ops>;
+  using LeftFragment = OperandFragment<InputType, ROW_FRAGMENTS, 1, Ops>;
+  using RightFragment = OperandFragment<InputType, 1, COL_FRAGMENTS, Ops, ReadTranspose>;
+
+  const uint groups_per_head = value_heads / k_heads;
+  const uint hk = hv / groups_per_head;
+  const ulong qk_head_base = (((ulong)batch_idx * (ulong)tree_size) * (ulong)k_heads + (ulong)hk) * (ulong)head_k_dim;
   const uint qk_row_stride = k_heads * head_k_dim;
   const ulong prefix_base = ((ulong)batch_idx * (ulong)tree_size) * (ulong)value_heads + (ulong)hv;
   const ulong trie_base = (ulong)batch_idx * (ulong)tree_size;
@@ -135,7 +329,7 @@ PUBLIC KERNEL(BuildTreeGram)(
   const uint row_base = thread_context.simdgroup_index * TREE_GRAM_ROW_TILE;
   const ushort lane = thread_context.simd_lane_id;
 
-  for (uint i = tid; i < tree_size; i += TREE_GRAM_THREADS) {
+  for (uint i = tid; i < tree_size; i += TREE_GRAM_FUSED_THREADS) {
     row_prefix_shared[i] = prefix[prefix_base + (ulong)i * (ulong)value_heads];
     row_beta_shared[i] = beta[prefix_base + (ulong)i * (ulong)value_heads];
   }
@@ -229,12 +423,7 @@ PUBLIC KERNEL(BuildTreeGram)(
           int(tree_size),
           tile_dims
       );
-      kk_acc.store_safe(
-          lane,
-          a_shared + row_base * TREE_GRAM_MAX_T + col_base,
-          TREE_GRAM_MAX_T,
-          tile_dims
-      );
+      kk_acc.store_safe(lane, a_shared + row_base * TREE_GRAM_MAX_T + col_base, TREE_GRAM_MAX_T, tile_dims);
       qk_acc.store_safe(
           lane,
           qkd + mat_base + (ulong)row_base * (ulong)tree_size + (ulong)col_base,
@@ -246,5 +435,82 @@ PUBLIC KERNEL(BuildTreeGram)(
   }
 
   threadgroup_barrier(mem_flags::mem_threadgroup);
-  invert_tree_gram_matrix(a_shared, x_shared, ainv, mat_base, tree_size, tid);
+  invert_tree_gram_matrix<
+      USE_MASK>(a_shared, x_shared, row_mask_shared, trie, ainv, mat_base, trie_base, tree_size, tid);
+}
+
+// K2: inverse columns of (I + A), split by column block.
+template <uint COL_BLOCK, bool USE_MASK>
+VARIANTS(COL_BLOCK, 4, 8, 16, 32)
+VARIANTS(USE_MASK, false, true)
+PUBLIC KERNEL(BuildTreeGramAinv)(
+    const device float* a_mat,
+    const device TrieNode* trie,
+    device float* ainv,
+    constant const uint& batch_size,
+    constant const uint& tree_size,
+    constant const uint& value_heads,
+    threadgroup float a_shared[TREE_GRAM_MAX_T * TREE_GRAM_MAX_T],
+    threadgroup float x_shared[TREE_GRAM_MAX_T * COL_BLOCK],
+    threadgroup ulong row_mask_shared[TREE_GRAM_MAX_T],
+    const uint batch_idx GROUPS(batch_size),
+    const uint hv GROUPS(value_heads),
+    const uint col_block_idx GROUPS(tree_size.div_ceil(COL_BLOCK)),
+    const uint tid THREADS(TREE_GRAM_AINV_THREADS)
+) {
+  if (tree_size > TREE_GRAM_MAX_T) {
+    return;
+  }
+
+  const ulong mat_base = ((ulong)batch_idx * (ulong)value_heads + (ulong)hv) * (ulong)tree_size * (ulong)tree_size;
+  const ulong trie_base = (ulong)batch_idx * (ulong)tree_size;
+  const uint col_base = col_block_idx * COL_BLOCK;
+
+  for (uint idx = tid; idx < tree_size * tree_size; idx += TREE_GRAM_AINV_THREADS) {
+    const uint i = idx / tree_size;
+    const uint j = idx - i * tree_size;
+    a_shared[i * TREE_GRAM_MAX_T + j] = a_mat[mat_base + (ulong)i * (ulong)tree_size + (ulong)j];
+  }
+  for (uint idx = tid; idx < tree_size * COL_BLOCK; idx += TREE_GRAM_AINV_THREADS) {
+    const uint i = idx / COL_BLOCK;
+    const uint local_j = idx - i * COL_BLOCK;
+    const uint j = col_base + local_j;
+    const float v = j < tree_size && i == j ? 1.0f : 0.0f;
+    x_shared[idx] = v;
+    if (j < tree_size) {
+      ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = v;
+    }
+  }
+  if constexpr (USE_MASK) {
+    for (uint i = tid; i < tree_size; i += TREE_GRAM_AINV_THREADS) {
+      ulong mask = 0;
+      for (uint j = 0; j < tree_size; ++j) {
+        const TrieNode node = trie[trie_base + (ulong)j];
+        if (i != j && i >= node.trie_start && i <= node.trie_end) {
+          mask |= ulong(1) << j;
+        }
+      }
+      row_mask_shared[i] = mask;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint i = 1; i < tree_size; ++i) {
+    const ulong row_mask = USE_MASK ? row_mask_shared[i] : ~ulong(0);
+    for (uint local_j = tid; local_j < COL_BLOCK; local_j += TREE_GRAM_AINV_THREADS) {
+      const uint j = col_base + local_j;
+      if (j < i && j < tree_size && ((row_mask >> j) & 1) != 0) {
+        float sum = 0.0f;
+        for (uint m = j; m < i; ++m) {
+          if (((row_mask >> m) & 1) != 0) {
+            sum += a_shared[i * TREE_GRAM_MAX_T + m] * x_shared[m * COL_BLOCK + local_j];
+          }
+        }
+        const float v = -sum;
+        x_shared[i * COL_BLOCK + local_j] = v;
+        ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = v;
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
 }

--- a/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/gram.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/gram.metal
@@ -32,11 +32,17 @@ PUBLIC KERNEL(BuildTreeGram)(
     constant const uint& k_heads,
     constant const uint& value_heads,
     constant const uint& head_k_dim,
-    threadgroup float diagonal_a[TREE_GRAM_ROW_TILE * TREE_GRAM_ROW_TILE],
+    threadgroup float diagonal_a_tile[TREE_GRAM_ROW_TILE * TREE_GRAM_ROW_TILE],
+    threadgroup float row_prefix_tile[TREE_GRAM_ROW_TILE],
+    threadgroup float row_beta_tile[TREE_GRAM_ROW_TILE],
+    threadgroup uint row_token_tile[TREE_GRAM_ROW_TILE],
+    threadgroup float col_prefix_tile[TREE_GRAM_COL_TILE],
+    threadgroup uint col_subtree_start[TREE_GRAM_COL_TILE],
+    threadgroup uint col_subtree_end[TREE_GRAM_COL_TILE],
     const ThreadContext thread_context,
     const uint batch GROUPS(batch_size),
     const uint value_head GROUPS(value_heads),
-    const uint tile_idx GROUPS(tree_size.div_ceil(TREE_GRAM_ROW_TILE) * tree_size.div_ceil(TREE_GRAM_COL_TILE)),
+    const uint tile_index GROUPS(tree_size.div_ceil(TREE_GRAM_ROW_TILE) * tree_size.div_ceil(TREE_GRAM_COL_TILE)),
     const uint tid THREADS(TREE_GRAM_THREADS)
 ) {
   using Ops = metal::conditional_t<USE_MXU, MxuFragmentOps<>, SimdgroupFragmentOps>;
@@ -48,18 +54,18 @@ PUBLIC KERNEL(BuildTreeGram)(
   using RightFragment = OperandFragment<InputType, 1, COL_FRAGMENTS, Ops, ReadTranspose>;
 
   const uint value_heads_per_key_head = value_heads / k_heads;
-  const uint key_head = value_head / value_heads_per_key_head;
-  const ulong qk_head_base = (((ulong)batch * (ulong)tree_size) * (ulong)k_heads + (ulong)key_head) * (ulong)head_k_dim;
-  const uint qk_row_stride = k_heads * head_k_dim;
-  const ulong prefix_base = ((ulong)batch * (ulong)tree_size) * (ulong)value_heads + (ulong)value_head;
-  const ulong trie_base = (ulong)batch * (ulong)tree_size;
-  const ulong mat_base = ((ulong)batch * (ulong)value_heads + (ulong)value_head) * (ulong)tree_size * (ulong)tree_size;
+  const uint key_head_index = value_head / value_heads_per_key_head;
+  const uint qk_token_stride = k_heads * head_k_dim;
+  const uint qk_key_head_offset = (batch * tree_size * k_heads + key_head_index) * head_k_dim;
+  const uint prefix_value_head_offset = batch * tree_size * value_heads + value_head;
+  const uint trie_batch_offset = batch * tree_size;
+  const uint matrix_head_offset = (batch * value_heads + value_head) * tree_size * tree_size;
 
   const uint col_tiles = (tree_size + TREE_GRAM_COL_TILE - 1) / TREE_GRAM_COL_TILE;
-  const uint row_tile_idx = tile_idx / col_tiles;
-  const uint col_tile_idx = tile_idx - row_tile_idx * col_tiles;
-  const uint row_base = row_tile_idx * TREE_GRAM_ROW_TILE;
-  const uint col_base = col_tile_idx * TREE_GRAM_COL_TILE;
+  const uint row_tile_index = tile_index / col_tiles;
+  const uint col_tile_index = tile_index - row_tile_index * col_tiles;
+  const uint tile_row_start = row_tile_index * TREE_GRAM_ROW_TILE;
+  const uint tile_col_start = col_tile_index * TREE_GRAM_COL_TILE;
   const ushort lane = thread_context.simd_lane_id;
 
   AccFragment kk_acc;
@@ -67,117 +73,127 @@ PUBLIC KERNEL(BuildTreeGram)(
   kk_acc.clear();
   qk_acc.clear();
 
-  for (uint k_base = 0; k_base < head_k_dim; k_base += Ops::FRAGMENT_ROWS) {
-    const uint k_rem = head_k_dim - k_base;
-    const ushort valid_k_cols = ushort(min(k_rem, uint(Ops::FRAGMENT_ROWS)));
+  for (uint k_block_start = 0; k_block_start < head_k_dim; k_block_start += Ops::FRAGMENT_ROWS) {
+    const uint k_remaining = head_k_dim - k_block_start;
+    const ushort valid_k_cols = ushort(min(k_remaining, uint(Ops::FRAGMENT_ROWS)));
 
-    if (row_base < tree_size) {
+    if (tile_row_start < tree_size) {
       LeftFragment k_left;
       LeftFragment q_left;
       RightFragment k_right;
 
-      const short row_limit = short(max(int(0), int(tree_size) - int(row_base)));
-      const short col_limit = short(max(int(0), int(tree_size) - int(col_base)));
+      const short row_limit = short(max(int(0), int(tree_size) - int(tile_row_start)));
+      const short col_limit = short(max(int(0), int(tree_size) - int(tile_col_start)));
 
-      const device T* k_rows = k + qk_head_base + (ulong)row_base * (ulong)qk_row_stride + (ulong)k_base;
-      const device T* q_rows = q + qk_head_base + (ulong)row_base * (ulong)qk_row_stride + (ulong)k_base;
-      const device T* k_col_ptr = k + qk_head_base + (ulong)col_base * (ulong)qk_row_stride + (ulong)k_base;
+      const uint qk_row_tile_offset = qk_key_head_offset + tile_row_start * qk_token_stride + k_block_start;
+      const uint qk_col_tile_offset = qk_key_head_offset + tile_col_start * qk_token_stride + k_block_start;
+      const device T* k_rows = k + qk_row_tile_offset;
+      const device T* q_rows = q + qk_row_tile_offset;
+      const device T* k_cols = k + qk_col_tile_offset;
 
-      k_left.load_from(lane, fragment_source(k_rows, int(qk_row_stride)).bounded(row_limit, short(valid_k_cols)));
-      q_left.load_from(lane, fragment_source(q_rows, int(qk_row_stride)).bounded(row_limit, short(valid_k_cols)));
-      k_right.load_from(lane, fragment_source(k_col_ptr, int(qk_row_stride)).bounded(col_limit, short(valid_k_cols)));
+      const bool full_k_tile = valid_k_cols == Ops::FRAGMENT_ROWS;
+      if (full_k_tile && tile_row_start + TREE_GRAM_ROW_TILE <= tree_size) {
+        k_left.load_from(lane, fragment_source(k_rows, int(qk_token_stride)));
+        q_left.load_from(lane, fragment_source(q_rows, int(qk_token_stride)));
+      } else {
+        k_left.load_from(lane, fragment_source(k_rows, int(qk_token_stride)).bounded(row_limit, short(valid_k_cols)));
+        q_left.load_from(lane, fragment_source(q_rows, int(qk_token_stride)).bounded(row_limit, short(valid_k_cols)));
+      }
+      if (full_k_tile && tile_col_start + TREE_GRAM_COL_TILE <= tree_size) {
+        k_right.load_from(lane, fragment_source(k_cols, int(qk_token_stride)));
+      } else {
+        k_right.load_from(lane, fragment_source(k_cols, int(qk_token_stride)).bounded(col_limit, short(valid_k_cols)));
+      }
 
       fragment_mma(kk_acc, k_left, k_right);
       fragment_mma(qk_acc, q_left, k_right);
     }
   }
 
-  if (row_base >= tree_size) {
+  if (tile_row_start >= tree_size) {
     return;
   }
 
-  const bool has_diagonal_block = col_base <= row_base && row_base < col_base + TREE_GRAM_COL_TILE;
-  const uint diagonal_col_offset = has_diagonal_block ? row_base - col_base : 0;
-  const uint diagonal_block_size = min(uint(TREE_GRAM_ROW_TILE), tree_size - row_base);
+  const bool has_diagonal_block =
+      tile_col_start <= tile_row_start && tile_row_start < tile_col_start + TREE_GRAM_COL_TILE;
+  const uint diagonal_col_offset = has_diagonal_block ? tile_row_start - tile_col_start : 0;
+  const uint diagonal_block_size = min(uint(TREE_GRAM_ROW_TILE), tree_size - tile_row_start);
 
-  kk_acc.map_coords(lane, [&](short row, short col, float kk) {
-    const uint i = row_base + uint(row);
-    const uint j = col_base + uint(col);
-    if (i >= tree_size || j >= tree_size) {
-      return 0.0f;
+  if (tid < TREE_GRAM_COL_TILE) {
+    const uint col_token = tile_col_start + tid;
+    if (col_token < tree_size) {
+      const TrieNode node = trie[trie_batch_offset + col_token];
+      col_subtree_start[tid] = node.trie_start;
+      col_subtree_end[tid] = node.trie_end;
+      col_prefix_tile[tid] = prefix[prefix_value_head_offset + col_token * value_heads];
+    } else {
+      col_subtree_start[tid] = 1;
+      col_subtree_end[tid] = 0;
+      col_prefix_tile[tid] = 0.0f;
     }
-    const TrieNode node = trie[trie_base + (ulong)j];
-    const bool incl = i >= node.trie_start && i <= node.trie_end;
-    const float prefix_i = prefix[prefix_base + (ulong)i * (ulong)value_heads];
-    const float prefix_j = prefix[prefix_base + (ulong)j * (ulong)value_heads];
-    const float beta_i = beta[prefix_base + (ulong)i * (ulong)value_heads];
-    const float a = incl && i != j ? beta_i * exp(prefix_i - prefix_j) * kk : 0.0f;
-    if (has_diagonal_block && uint(row) < diagonal_block_size && uint(col) >= diagonal_col_offset) {
-      const uint local_col = uint(col) - diagonal_col_offset;
-      if (local_col < diagonal_block_size) {
-        diagonal_a[uint(row) * TREE_GRAM_ROW_TILE + local_col] = a;
+  }
+  if (tid < TREE_GRAM_ROW_TILE) {
+    const uint row_token = tile_row_start + tid;
+    if (row_token < tree_size) {
+      row_token_tile[tid] = row_token;
+      row_prefix_tile[tid] = prefix[prefix_value_head_offset + row_token * value_heads];
+      row_beta_tile[tid] = beta[prefix_value_head_offset + row_token * value_heads];
+    } else {
+      row_token_tile[tid] = 0xffffffff;
+      row_prefix_tile[tid] = 0.0f;
+      row_beta_tile[tid] = 0.0f;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  kk_acc.zip_map_coords(lane, qk_acc, [&](short row, short col, float kk, float qk_dot) {
+    const uint local_row = uint(row);
+    const uint local_col = uint(col);
+    const uint row_token = row_token_tile[local_row];
+    const uint col_token = tile_col_start + local_col;
+    const bool col_contains_row = row_token >= col_subtree_start[local_col] && row_token <= col_subtree_end[local_col];
+    const float decay = exp(row_prefix_tile[local_row] - col_prefix_tile[local_col]);
+    const float a_value = col_contains_row && row_token != col_token ? row_beta_tile[local_row] * decay * kk : 0.0f;
+    const float qkd_value = col_contains_row ? scale * decay * qk_dot : 0.0f;
+    if (has_diagonal_block && local_row < diagonal_block_size && local_col >= diagonal_col_offset) {
+      const uint local_diag_col = local_col - diagonal_col_offset;
+      if (local_diag_col < diagonal_block_size) {
+        diagonal_a_tile[local_row * TREE_GRAM_ROW_TILE + local_diag_col] = a_value;
       }
     }
-    return a;
+    return float2(a_value, qkd_value);
   });
 
-  qk_acc.map_coords(lane, [&](short row, short col, float qk_dot) {
-    const uint i = row_base + uint(row);
-    const uint j = col_base + uint(col);
-    if (i >= tree_size || j >= tree_size) {
-      return 0.0f;
-    }
-    const TrieNode node = trie[trie_base + (ulong)j];
-    const bool incl = i >= node.trie_start && i <= node.trie_end;
-    const float prefix_i = prefix[prefix_base + (ulong)i * (ulong)value_heads];
-    const float prefix_j = prefix[prefix_base + (ulong)j * (ulong)value_heads];
-    if (!incl) {
-      return 0.0f;
-    }
-    return scale * exp(prefix_i - prefix_j) * qk_dot;
-  });
-
-  const uint tile_rows = min(uint(TREE_GRAM_ROW_TILE), tree_size - row_base);
-  const uint tile_cols = min(uint(TREE_GRAM_COL_TILE), tree_size - col_base);
+  const uint tile_rows = min(uint(TREE_GRAM_ROW_TILE), tree_size - tile_row_start);
+  const uint tile_cols = min(uint(TREE_GRAM_COL_TILE), tree_size - tile_col_start);
   const short2 tile_dims = short2(short(tile_cols), short(tile_rows));
-  kk_acc.store_safe(
-      lane,
-      a_mat + mat_base + (ulong)row_base * (ulong)tree_size + (ulong)col_base,
-      int(tree_size),
-      tile_dims
-  );
-  qk_acc.store_safe(
-      lane,
-      qkd + mat_base + (ulong)row_base * (ulong)tree_size + (ulong)col_base,
-      int(tree_size),
-      tile_dims
-  );
-
-  for (uint idx = tid; idx < tile_rows * tile_cols; idx += TREE_GRAM_THREADS) {
-    const uint i = row_base + idx / tile_cols;
-    const uint j = col_base + idx % tile_cols;
-    ainv[mat_base + (ulong)i * (ulong)tree_size + (ulong)j] = i == j ? 1.0f : 0.0f;
+  const uint matrix_tile_offset = matrix_head_offset + tile_row_start * tree_size + tile_col_start;
+  device float* a_tile = a_mat + matrix_tile_offset;
+  device float* qkd_tile = qkd + matrix_tile_offset;
+  if (tile_row_start + TREE_GRAM_ROW_TILE <= tree_size && tile_col_start + TREE_GRAM_COL_TILE <= tree_size) {
+    kk_acc.store(lane, a_tile, int(tree_size));
+    qk_acc.store(lane, qkd_tile, int(tree_size));
+  } else {
+    kk_acc.store_safe(lane, a_tile, int(tree_size), tile_dims);
+    qk_acc.store_safe(lane, qkd_tile, int(tree_size), tile_dims);
   }
 
-  // ponytail: only diagonal 16x16 inverse blocks are produced; downstream reads no off-block Ainv.
+  // Invert each diagonal block by column-wise forward substitution on I + A.
   if (has_diagonal_block) {
     threadgroup_barrier(mem_flags::mem_threadgroup);
     const uint block_size = diagonal_block_size;
     const uint j = tid;
     if (j < block_size) {
-      float xcol[16];
+      float xcol[16] = {};
+      xcol[j] = 1.0f;
       METAL_PRAGMA_UNROLL
       for (uint i = 0; i < 16; i++) {
-        if (i >= block_size || i < j) {
-          xcol[i] = 0.0f;
-        } else if (i == j) {
-          xcol[i] = 1.0f;
-        } else {
+        if (i > j && i < block_size) {
           float acc = 0.0f;
           METAL_PRAGMA_UNROLL
           for (uint prev_row = 0; prev_row < 16; prev_row++) {
             if (prev_row < i) {
-              acc += diagonal_a[i * TREE_GRAM_ROW_TILE + prev_row] * xcol[prev_row];
+              acc += diagonal_a_tile[i * TREE_GRAM_ROW_TILE + prev_row] * xcol[prev_row];
             }
           }
           xcol[i] = -acc;
@@ -186,7 +202,8 @@ PUBLIC KERNEL(BuildTreeGram)(
       METAL_PRAGMA_UNROLL
       for (uint i = 0; i < 16; i++) {
         if (i < block_size) {
-          ainv[mat_base + (ulong)(row_base + i) * (ulong)tree_size + (ulong)(row_base + j)] = xcol[i];
+          const uint ainv_offset = matrix_head_offset + (tile_row_start + i) * tree_size + tile_row_start + j;
+          ainv[ainv_offset] = xcol[i];
         }
       }
     }

--- a/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/gram.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/gram.metal
@@ -14,6 +14,7 @@ using namespace uzu::trie;
 #define TREE_GRAM_ROW_TILE 16u
 #define TREE_GRAM_COL_TILE 32u
 #define TREE_GRAM_THREADS METAL_SIMD_SIZE
+#define TREE_GRAM_INVALID_ROW 0xffffffffu
 
 METAL_FUNC void invert_tree_gram_diagonal_block(
     device float* ainv,
@@ -172,7 +173,7 @@ PUBLIC KERNEL(BuildTreeGram)(
       row_prefix[thread_idx] = prefix[prefix_base + token * value_heads];
       row_beta[thread_idx] = beta[prefix_base + token * value_heads];
     } else {
-      row_token[thread_idx] = 0xffffffff;
+      row_token[thread_idx] = TREE_GRAM_INVALID_ROW;
       row_prefix[thread_idx] = 0.0f;
       row_beta[thread_idx] = 0.0f;
     }

--- a/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/gram.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/gdn_tree_verify/gram.metal
@@ -14,8 +14,18 @@ using namespace uzu::trie;
 #define TREE_GRAM_COL_TILE 32
 #define TREE_GRAM_THREADS METAL_SIMD_SIZE
 
+METAL_FUNC void invert_tree_gram_diagonal_block(
+    device float* ainv,
+    threadgroup const float* diag_a_tile,
+    const uint mat_base,
+    const uint row_base,
+    const uint tree_size,
+    const uint block_size,
+    const uint thread_idx
+);
+
 template <typename T, bool USE_MXU>
-VARIANTS(T, float, half, bfloat)
+VARIANTS(T, float, bfloat)
 VARIANTS(USE_MXU, false, true)
 PUBLIC KERNEL(BuildTreeGram)(
     const device T* q,
@@ -32,18 +42,18 @@ PUBLIC KERNEL(BuildTreeGram)(
     constant const uint& k_heads,
     constant const uint& value_heads,
     constant const uint& head_k_dim,
-    threadgroup float diagonal_a_tile[TREE_GRAM_ROW_TILE * TREE_GRAM_ROW_TILE],
-    threadgroup float row_prefix_tile[TREE_GRAM_ROW_TILE],
-    threadgroup float row_beta_tile[TREE_GRAM_ROW_TILE],
-    threadgroup uint row_token_tile[TREE_GRAM_ROW_TILE],
-    threadgroup float col_prefix_tile[TREE_GRAM_COL_TILE],
-    threadgroup uint col_subtree_start[TREE_GRAM_COL_TILE],
-    threadgroup uint col_subtree_end[TREE_GRAM_COL_TILE],
+    threadgroup float diag_a_tile[TREE_GRAM_ROW_TILE * TREE_GRAM_ROW_TILE],
+    threadgroup float row_prefix[TREE_GRAM_ROW_TILE],
+    threadgroup float row_beta[TREE_GRAM_ROW_TILE],
+    threadgroup uint row_token[TREE_GRAM_ROW_TILE],
+    threadgroup float col_prefix[TREE_GRAM_COL_TILE],
+    threadgroup uint col_trie_start[TREE_GRAM_COL_TILE],
+    threadgroup uint col_trie_end[TREE_GRAM_COL_TILE],
     const ThreadContext thread_context,
-    const uint batch GROUPS(batch_size),
-    const uint value_head GROUPS(value_heads),
-    const uint tile_index GROUPS(tree_size.div_ceil(TREE_GRAM_ROW_TILE) * tree_size.div_ceil(TREE_GRAM_COL_TILE)),
-    const uint tid THREADS(TREE_GRAM_THREADS)
+    const uint batch_idx GROUPS(batch_size),
+    const uint value_head_idx GROUPS(value_heads),
+    const uint tile_idx GROUPS(tree_size.div_ceil(TREE_GRAM_ROW_TILE) * tree_size.div_ceil(TREE_GRAM_COL_TILE)),
+    const uint thread_idx THREADS(TREE_GRAM_THREADS)
 ) {
   using Ops = metal::conditional_t<USE_MXU, MxuFragmentOps<>, SimdgroupFragmentOps>;
   constexpr ushort ROW_FRAGMENTS = TREE_GRAM_ROW_TILE / Ops::FRAGMENT_ROWS;
@@ -54,19 +64,40 @@ PUBLIC KERNEL(BuildTreeGram)(
   using RightFragment = OperandFragment<InputType, 1, COL_FRAGMENTS, Ops, ReadTranspose>;
 
   const uint value_heads_per_key_head = value_heads / k_heads;
-  const uint key_head_index = value_head / value_heads_per_key_head;
-  const uint qk_token_stride = k_heads * head_k_dim;
-  const uint qk_key_head_offset = (batch * tree_size * k_heads + key_head_index) * head_k_dim;
-  const uint prefix_value_head_offset = batch * tree_size * value_heads + value_head;
-  const uint trie_batch_offset = batch * tree_size;
-  const uint matrix_head_offset = (batch * value_heads + value_head) * tree_size * tree_size;
+  const uint key_head_idx = value_head_idx / value_heads_per_key_head;
+  const uint qk_stride = k_heads * head_k_dim;
+  const uint qk_base = (batch_idx * tree_size * k_heads + key_head_idx) * head_k_dim;
+  const uint prefix_base = batch_idx * tree_size * value_heads + value_head_idx;
+  const uint trie_base = batch_idx * tree_size;
+  const uint mat_base = (batch_idx * value_heads + value_head_idx) * tree_size * tree_size;
 
   const uint col_tiles = (tree_size + TREE_GRAM_COL_TILE - 1) / TREE_GRAM_COL_TILE;
-  const uint row_tile_index = tile_index / col_tiles;
-  const uint col_tile_index = tile_index - row_tile_index * col_tiles;
-  const uint tile_row_start = row_tile_index * TREE_GRAM_ROW_TILE;
-  const uint tile_col_start = col_tile_index * TREE_GRAM_COL_TILE;
+  const uint row_tile_idx = tile_idx / col_tiles;
+  const uint col_tile_idx = tile_idx - row_tile_idx * col_tiles;
+  const uint row_base = row_tile_idx * TREE_GRAM_ROW_TILE;
+  const uint col_base = col_tile_idx * TREE_GRAM_COL_TILE;
+  const uint row_tile_size = TREE_GRAM_ROW_TILE;
+  const uint col_tile_size = TREE_GRAM_COL_TILE;
   const ushort lane = thread_context.simd_lane_id;
+
+  if (row_base >= tree_size) {
+    return;
+  }
+
+  const uint tile_rows = min(row_tile_size, tree_size - row_base);
+  const uint tile_cols = min(col_tile_size, tree_size - col_base);
+  const uint tile_base = mat_base + row_base * tree_size + col_base;
+
+  if (col_base >= row_base + TREE_GRAM_ROW_TILE) {
+    for (uint idx = thread_idx; idx < tile_rows * tile_cols; idx += TREE_GRAM_THREADS) {
+      const uint local_row = idx / tile_cols;
+      const uint local_col = idx - local_row * tile_cols;
+      const uint offset = tile_base + local_row * tree_size + local_col;
+      a_mat[offset] = 0.0f;
+      qkd[offset] = 0.0f;
+    }
+    return;
+  }
 
   AccFragment kk_acc;
   AccFragment qk_acc;
@@ -75,137 +106,137 @@ PUBLIC KERNEL(BuildTreeGram)(
 
   for (uint k_block_start = 0; k_block_start < head_k_dim; k_block_start += Ops::FRAGMENT_ROWS) {
     const uint k_remaining = head_k_dim - k_block_start;
-    const ushort valid_k_cols = ushort(min(k_remaining, uint(Ops::FRAGMENT_ROWS)));
+    const uint k_tile_size = Ops::FRAGMENT_ROWS;
+    const uint valid_k_cols = min(k_remaining, k_tile_size);
 
-    if (tile_row_start < tree_size) {
-      LeftFragment k_left;
-      LeftFragment q_left;
-      RightFragment k_right;
+    LeftFragment k_left;
+    LeftFragment q_left;
+    RightFragment k_right;
 
-      const short row_limit = short(max(int(0), int(tree_size) - int(tile_row_start)));
-      const short col_limit = short(max(int(0), int(tree_size) - int(tile_col_start)));
+    const uint qk_row_base = qk_base + row_base * qk_stride + k_block_start;
+    const uint qk_col_base = qk_base + col_base * qk_stride + k_block_start;
+    const device T* k_rows = k + qk_row_base;
+    const device T* q_rows = q + qk_row_base;
+    const device T* k_cols = k + qk_col_base;
 
-      const uint qk_row_tile_offset = qk_key_head_offset + tile_row_start * qk_token_stride + k_block_start;
-      const uint qk_col_tile_offset = qk_key_head_offset + tile_col_start * qk_token_stride + k_block_start;
-      const device T* k_rows = k + qk_row_tile_offset;
-      const device T* q_rows = q + qk_row_tile_offset;
-      const device T* k_cols = k + qk_col_tile_offset;
-
-      const bool full_k_tile = valid_k_cols == Ops::FRAGMENT_ROWS;
-      if (full_k_tile && tile_row_start + TREE_GRAM_ROW_TILE <= tree_size) {
-        k_left.load_from(lane, fragment_source(k_rows, int(qk_token_stride)));
-        q_left.load_from(lane, fragment_source(q_rows, int(qk_token_stride)));
-      } else {
-        k_left.load_from(lane, fragment_source(k_rows, int(qk_token_stride)).bounded(row_limit, short(valid_k_cols)));
-        q_left.load_from(lane, fragment_source(q_rows, int(qk_token_stride)).bounded(row_limit, short(valid_k_cols)));
-      }
-      if (full_k_tile && tile_col_start + TREE_GRAM_COL_TILE <= tree_size) {
-        k_right.load_from(lane, fragment_source(k_cols, int(qk_token_stride)));
-      } else {
-        k_right.load_from(lane, fragment_source(k_cols, int(qk_token_stride)).bounded(col_limit, short(valid_k_cols)));
-      }
-
-      fragment_mma(kk_acc, k_left, k_right);
-      fragment_mma(qk_acc, q_left, k_right);
+    const bool full_k_tile = valid_k_cols == k_tile_size;
+    if (full_k_tile && row_base + TREE_GRAM_ROW_TILE <= tree_size) {
+      k_left.load_from(lane, fragment_source(k_rows, qk_stride));
+      q_left.load_from(lane, fragment_source(q_rows, qk_stride));
+    } else {
+      k_left.load_from(lane, fragment_source(k_rows, qk_stride).bounded(tile_rows, valid_k_cols));
+      q_left.load_from(lane, fragment_source(q_rows, qk_stride).bounded(tile_rows, valid_k_cols));
     }
+    if (full_k_tile && col_base + TREE_GRAM_COL_TILE <= tree_size) {
+      k_right.load_from(lane, fragment_source(k_cols, qk_stride));
+    } else {
+      k_right.load_from(lane, fragment_source(k_cols, qk_stride).bounded(tile_cols, valid_k_cols));
+    }
+
+    fragment_mma(kk_acc, k_left, k_right);
+    fragment_mma(qk_acc, q_left, k_right);
   }
 
-  if (tile_row_start >= tree_size) {
-    return;
-  }
+  const bool has_diag = col_base <= row_base && row_base < col_base + TREE_GRAM_COL_TILE;
+  const uint diag_col_offset = has_diag ? row_base - col_base : 0;
+  const uint diag_size = min(row_tile_size, tree_size - row_base);
 
-  const bool has_diagonal_block =
-      tile_col_start <= tile_row_start && tile_row_start < tile_col_start + TREE_GRAM_COL_TILE;
-  const uint diagonal_col_offset = has_diagonal_block ? tile_row_start - tile_col_start : 0;
-  const uint diagonal_block_size = min(uint(TREE_GRAM_ROW_TILE), tree_size - tile_row_start);
-
-  if (tid < TREE_GRAM_COL_TILE) {
-    const uint col_token = tile_col_start + tid;
+  if (thread_idx < TREE_GRAM_COL_TILE) {
+    const uint col_token = col_base + thread_idx;
     if (col_token < tree_size) {
-      const TrieNode node = trie[trie_batch_offset + col_token];
-      col_subtree_start[tid] = node.trie_start;
-      col_subtree_end[tid] = node.trie_end;
-      col_prefix_tile[tid] = prefix[prefix_value_head_offset + col_token * value_heads];
+      const TrieNode node = trie[trie_base + col_token];
+      col_trie_start[thread_idx] = node.trie_start;
+      col_trie_end[thread_idx] = node.trie_end;
+      col_prefix[thread_idx] = prefix[prefix_base + col_token * value_heads];
     } else {
-      col_subtree_start[tid] = 1;
-      col_subtree_end[tid] = 0;
-      col_prefix_tile[tid] = 0.0f;
+      col_trie_start[thread_idx] = 1;
+      col_trie_end[thread_idx] = 0;
+      col_prefix[thread_idx] = 0.0f;
     }
   }
-  if (tid < TREE_GRAM_ROW_TILE) {
-    const uint row_token = tile_row_start + tid;
-    if (row_token < tree_size) {
-      row_token_tile[tid] = row_token;
-      row_prefix_tile[tid] = prefix[prefix_value_head_offset + row_token * value_heads];
-      row_beta_tile[tid] = beta[prefix_value_head_offset + row_token * value_heads];
+  if (thread_idx < TREE_GRAM_ROW_TILE) {
+    const uint token = row_base + thread_idx;
+    if (token < tree_size) {
+      row_token[thread_idx] = token;
+      row_prefix[thread_idx] = prefix[prefix_base + token * value_heads];
+      row_beta[thread_idx] = beta[prefix_base + token * value_heads];
     } else {
-      row_token_tile[tid] = 0xffffffff;
-      row_prefix_tile[tid] = 0.0f;
-      row_beta_tile[tid] = 0.0f;
+      row_token[thread_idx] = 0xffffffff;
+      row_prefix[thread_idx] = 0.0f;
+      row_beta[thread_idx] = 0.0f;
     }
   }
   threadgroup_barrier(mem_flags::mem_threadgroup);
 
-  kk_acc.zip_map_coords(lane, qk_acc, [&](short row, short col, float kk, float qk_dot) {
-    const uint local_row = uint(row);
-    const uint local_col = uint(col);
-    const uint row_token = row_token_tile[local_row];
-    const uint col_token = tile_col_start + local_col;
-    const bool col_contains_row = row_token >= col_subtree_start[local_col] && row_token <= col_subtree_end[local_col];
-    const float decay = exp(row_prefix_tile[local_row] - col_prefix_tile[local_col]);
-    const float a_value = col_contains_row && row_token != col_token ? row_beta_tile[local_row] * decay * kk : 0.0f;
-    const float qkd_value = col_contains_row ? scale * decay * qk_dot : 0.0f;
-    if (has_diagonal_block && local_row < diagonal_block_size && local_col >= diagonal_col_offset) {
-      const uint local_diag_col = local_col - diagonal_col_offset;
-      if (local_diag_col < diagonal_block_size) {
-        diagonal_a_tile[local_row * TREE_GRAM_ROW_TILE + local_diag_col] = a_value;
+  kk_acc.zip_map_coords(lane, qk_acc, [&](ushort local_row, ushort local_col, float kk, float qk_dot) {
+    const uint row_idx = row_token[local_row];
+    const uint col_idx = col_base + local_col;
+    const bool in_subtree = row_idx >= col_trie_start[local_col] && row_idx <= col_trie_end[local_col];
+    const float decay = exp(row_prefix[local_row] - col_prefix[local_col]);
+    const float a_value = in_subtree && row_idx != col_idx ? row_beta[local_row] * decay * kk : 0.0f;
+    const float qkd_value = in_subtree ? scale * decay * qk_dot : 0.0f;
+    if (has_diag && local_row < diag_size && local_col >= diag_col_offset) {
+      const uint diag_col = local_col - diag_col_offset;
+      if (diag_col < diag_size) {
+        diag_a_tile[local_row * TREE_GRAM_ROW_TILE + diag_col] = a_value;
       }
     }
     return float2(a_value, qkd_value);
   });
 
-  const uint tile_rows = min(uint(TREE_GRAM_ROW_TILE), tree_size - tile_row_start);
-  const uint tile_cols = min(uint(TREE_GRAM_COL_TILE), tree_size - tile_col_start);
-  const short2 tile_dims = short2(short(tile_cols), short(tile_rows));
-  const uint matrix_tile_offset = matrix_head_offset + tile_row_start * tree_size + tile_col_start;
-  device float* a_tile = a_mat + matrix_tile_offset;
-  device float* qkd_tile = qkd + matrix_tile_offset;
-  if (tile_row_start + TREE_GRAM_ROW_TILE <= tree_size && tile_col_start + TREE_GRAM_COL_TILE <= tree_size) {
-    kk_acc.store(lane, a_tile, int(tree_size));
-    qk_acc.store(lane, qkd_tile, int(tree_size));
+  const short2 tile_dims = short2(tile_cols, tile_rows);
+  device float* a_tile = a_mat + tile_base;
+  device float* qkd_tile = qkd + tile_base;
+  if (row_base + TREE_GRAM_ROW_TILE <= tree_size && col_base + TREE_GRAM_COL_TILE <= tree_size) {
+    kk_acc.store(lane, a_tile, tree_size);
+    qk_acc.store(lane, qkd_tile, tree_size);
   } else {
-    kk_acc.store_safe(lane, a_tile, int(tree_size), tile_dims);
-    qk_acc.store_safe(lane, qkd_tile, int(tree_size), tile_dims);
+    kk_acc.store_safe(lane, a_tile, tree_size, tile_dims);
+    qk_acc.store_safe(lane, qkd_tile, tree_size, tile_dims);
   }
 
-  // Invert each diagonal block by column-wise forward substitution on I + A.
-  if (has_diagonal_block) {
+  if (has_diag) {
     threadgroup_barrier(mem_flags::mem_threadgroup);
-    const uint block_size = diagonal_block_size;
-    const uint j = tid;
-    if (j < block_size) {
-      float xcol[16] = {};
-      xcol[j] = 1.0f;
+    invert_tree_gram_diagonal_block(ainv, diag_a_tile, mat_base, row_base, tree_size, diag_size, thread_idx);
+  }
+}
+
+METAL_FUNC void invert_tree_gram_diagonal_block(
+    device float* ainv,
+    threadgroup const float* diag_a_tile,
+    const uint mat_base,
+    const uint row_base,
+    const uint tree_size,
+    const uint block_size,
+    const uint thread_idx
+) {
+  if (thread_idx >= block_size) {
+    return;
+  }
+
+  const uint col = thread_idx;
+  float inverse_col[TREE_GRAM_ROW_TILE] = {};
+  inverse_col[col] = 1.0f;
+
+  METAL_PRAGMA_UNROLL
+  for (uint row = 0; row < TREE_GRAM_ROW_TILE; row++) {
+    if (row > col && row < block_size) {
+      float acc = 0.0f;
       METAL_PRAGMA_UNROLL
-      for (uint i = 0; i < 16; i++) {
-        if (i > j && i < block_size) {
-          float acc = 0.0f;
-          METAL_PRAGMA_UNROLL
-          for (uint prev_row = 0; prev_row < 16; prev_row++) {
-            if (prev_row < i) {
-              acc += diagonal_a_tile[i * TREE_GRAM_ROW_TILE + prev_row] * xcol[prev_row];
-            }
-          }
-          xcol[i] = -acc;
+      for (uint prev_row = 0; prev_row < TREE_GRAM_ROW_TILE; prev_row++) {
+        if (prev_row < row) {
+          acc += diag_a_tile[row * TREE_GRAM_ROW_TILE + prev_row] * inverse_col[prev_row];
         }
       }
-      METAL_PRAGMA_UNROLL
-      for (uint i = 0; i < 16; i++) {
-        if (i < block_size) {
-          const uint ainv_offset = matrix_head_offset + (tile_row_start + i) * tree_size + tile_row_start + j;
-          ainv[ainv_offset] = xcol[i];
-        }
-      }
+      inverse_col[row] = -acc;
+    }
+  }
+
+  METAL_PRAGMA_UNROLL
+  for (uint row = 0; row < TREE_GRAM_ROW_TILE; row++) {
+    if (row < block_size) {
+      const uint ainv_offset = mat_base + (row_base + row) * tree_size + row_base + col;
+      ainv[ainv_offset] = inverse_col[row];
     }
   }
 }

--- a/crates/backend-uzu/src/backends/metal/kernel/matmul/common/fragment.h
+++ b/crates/backend-uzu/src/backends/metal/kernel/matmul/common/fragment.h
@@ -140,15 +140,11 @@ struct Fragment {
     });
   }
 
-  template <class Other, class Fn>
-  METAL_FUNC void zip_map_coords(const ushort simd_lane_id, thread Other& other, Fn fn) thread {
-    static_assert(metal::is_same_v<FragmentOpsType, typename Other::FragmentOpsType>, "fragment ops must match");
-    static_assert(metal::is_same_v<ElementType, typename Other::ElementType>, "fragment element types must match");
-    static_assert(ROW_FRAGMENTS == Other::ROW_FRAGMENTS, "fragment row counts must match");
-    static_assert(COL_FRAGMENTS == Other::COL_FRAGMENTS, "fragment column counts must match");
+  template <class Fn, class... Fragments>
+  METAL_FUNC static void zip_for_each_coord(const ushort simd_lane_id, Fn fn, thread Fragments&... fragments) {
+    static_assert(sizeof...(Fragments) > 0, "zip_for_each_coord needs at least one fragment");
+    static_assert((metal::is_same_v<Fragment, Fragments> && ...), "zipped fragments must have the same type");
 
-    thread ElementType* data = elements();
-    thread ElementType* other_data = other.elements();
     const short2 position = get_position(simd_lane_id);
     for_each_fragment([&](auto fragment_row, auto fragment_col) {
       const ushort frag_base = (fragment_row.value * COL_FRAGMENTS + fragment_col.value) * Ops::ELEMENTS_PER_THREAD;
@@ -160,9 +156,7 @@ struct Fragment {
         const short row = row_base + element_offset.y;
         const short col = col_base + element_offset.x;
         const ushort index = frag_base + element_index;
-        const auto mapped = fn(row, col, data[index], other_data[index]);
-        data[index] = ElementType(mapped.x);
-        other_data[index] = ElementType(mapped.y);
+        fn(row, col, fragments.elements()[index]...);
       }
     });
   }
@@ -302,7 +296,7 @@ private:
   METAL_CONST bool UNSAFE = false;
 
   template <class Fn>
-  METAL_FUNC void for_each_fragment(Fn fn) thread {
+  METAL_FUNC static void for_each_fragment(Fn fn) {
     const_for_loop<0, ROW_FRAGMENTS, 1>([&](auto row_index) {
       const_for_loop<0, COL_FRAGMENTS, 1>([&](auto col_index) { fn(row_index, col_index); });
     });

--- a/crates/backend-uzu/src/backends/metal/kernel/matmul/common/fragment.h
+++ b/crates/backend-uzu/src/backends/metal/kernel/matmul/common/fragment.h
@@ -140,6 +140,33 @@ struct Fragment {
     });
   }
 
+  template <class Other, class Fn>
+  METAL_FUNC void zip_map_coords(const ushort simd_lane_id, thread Other& other, Fn fn) thread {
+    static_assert(metal::is_same_v<FragmentOpsType, typename Other::FragmentOpsType>, "fragment ops must match");
+    static_assert(metal::is_same_v<ElementType, typename Other::ElementType>, "fragment element types must match");
+    static_assert(ROW_FRAGMENTS == Other::ROW_FRAGMENTS, "fragment row counts must match");
+    static_assert(COL_FRAGMENTS == Other::COL_FRAGMENTS, "fragment column counts must match");
+
+    thread ElementType* data = elements();
+    thread ElementType* other_data = other.elements();
+    const short2 position = get_position(simd_lane_id);
+    for_each_fragment([&](auto fragment_row, auto fragment_col) {
+      const ushort frag_base = (fragment_row.value * COL_FRAGMENTS + fragment_col.value) * Ops::ELEMENTS_PER_THREAD;
+      const short row_base = position.y + short(fragment_row.value) * FRAGMENT_ROWS;
+      const short col_base = position.x + short(fragment_col.value) * FRAGMENT_COLS;
+      METAL_PRAGMA_UNROLL
+      for (ushort element_index = 0; element_index < Ops::ELEMENTS_PER_THREAD; ++element_index) {
+        const short2 element_offset = Ops::get_element_offset(element_index);
+        const short row = row_base + element_offset.y;
+        const short col = col_base + element_offset.x;
+        const ushort index = frag_base + element_index;
+        const auto mapped = fn(row, col, data[index], other_data[index]);
+        data[index] = ElementType(mapped.x);
+        other_data[index] = ElementType(mapped.y);
+      }
+    });
+  }
+
   // Row lanes differ in bits {0,3} for both simdgroup and MXU layouts.
   template <typename Acc, class Fn>
   METAL_FUNC void row_reduce(thread Acc* out, const Acc identity, Fn op) thread {

--- a/crates/backend-uzu/src/backends/metal/kernel/matmul/common/fragment.h
+++ b/crates/backend-uzu/src/backends/metal/kernel/matmul/common/fragment.h
@@ -73,8 +73,8 @@ struct Fragment {
   METAL_CONST ushort ROW_FRAGMENTS = ROW_FRAGMENTS_;
   METAL_CONST ushort COL_FRAGMENTS = COL_FRAGMENTS_;
 
-  METAL_CONST ushort FRAGMENT_ROWS = ushort(Ops::FRAGMENT_ROWS);
-  METAL_CONST ushort FRAGMENT_COLS = ushort(Ops::FRAGMENT_COLS);
+  METAL_CONST ushort FRAGMENT_ROWS = Ops::FRAGMENT_ROWS;
+  METAL_CONST ushort FRAGMENT_COLS = Ops::FRAGMENT_COLS;
 
   METAL_CONST ushort NUM_FRAGS = ROW_FRAGMENTS * COL_FRAGMENTS;
   METAL_CONST ushort ELEMENTS_PER_FRAGMENT = NUM_FRAGS * Ops::ELEMENTS_PER_THREAD;
@@ -127,8 +127,8 @@ struct Fragment {
     const short2 position = get_position(simd_lane_id);
     for_each_fragment([&](auto fragment_row, auto fragment_col) {
       const ushort frag_base = (fragment_row.value * COL_FRAGMENTS + fragment_col.value) * Ops::ELEMENTS_PER_THREAD;
-      const short row_base = position.y + short(fragment_row.value) * FRAGMENT_ROWS;
-      const short col_base = position.x + short(fragment_col.value) * FRAGMENT_COLS;
+      const short row_base = position.y + fragment_row.value * FRAGMENT_ROWS;
+      const short col_base = position.x + fragment_col.value * FRAGMENT_COLS;
       METAL_PRAGMA_UNROLL
       for (ushort element_index = 0; element_index < Ops::ELEMENTS_PER_THREAD; ++element_index) {
         const short2 element_offset = Ops::get_element_offset(element_index);
@@ -152,8 +152,8 @@ struct Fragment {
     const short2 position = get_position(simd_lane_id);
     for_each_fragment([&](auto fragment_row, auto fragment_col) {
       const ushort frag_base = (fragment_row.value * COL_FRAGMENTS + fragment_col.value) * Ops::ELEMENTS_PER_THREAD;
-      const short row_base = position.y + short(fragment_row.value) * FRAGMENT_ROWS;
-      const short col_base = position.x + short(fragment_col.value) * FRAGMENT_COLS;
+      const short row_base = position.y + fragment_row.value * FRAGMENT_ROWS;
+      const short col_base = position.x + fragment_col.value * FRAGMENT_COLS;
       METAL_PRAGMA_UNROLL
       for (ushort element_index = 0; element_index < Ops::ELEMENTS_PER_THREAD; ++element_index) {
         const short2 element_offset = Ops::get_element_offset(element_index);

--- a/crates/backend-uzu/unit/backends/common/kernel/gram_bench.rs
+++ b/crates/backend-uzu/unit/backends/common/kernel/gram_bench.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{env, mem::size_of, time::Duration};
 
 use criterion::{BenchmarkId, Criterion};
 use half::bf16;
@@ -11,7 +11,7 @@ use crate::{
         metal::Metal,
     },
     data_type::DataType,
-    tests::matmul::iter_encode_loop_named,
+    tests::{cold_pool::ColdPool, matmul::iter_encode_loop_named},
 };
 
 const K_HEADS: usize = 16;
@@ -109,6 +109,7 @@ fn make_buffers(
 #[uzu_bench]
 fn bench_build_tree_gram(c: &mut Criterion) {
     let context = <Metal as Backend>::Context::new().expect("metal context");
+    let cold_buffers = env::var("UZU_GRAM_COLD_BUFFERS").is_ok();
     let kernel_paths = if context.supports_mxu() {
         &[("Simdgroup", false), ("MXU", true)][..]
     } else {
@@ -116,22 +117,58 @@ fn bench_build_tree_gram(c: &mut Criterion) {
     };
 
     for &(kernel_path, use_mxu) in kernel_paths {
-        let kernel =
-            <<Metal as Backend>::Kernels as Kernels>::BuildTreeGramKernel::new(&context, DataType::BF16, use_mxu)
-                .expect("BuildTreeGramKernel");
         let mut group = c.benchmark_group(format!("Metal/Kernel/GDNTreeVerify/BuildTreeGram/{kernel_path}"));
         group.sample_size(10).warm_up_time(Duration::from_millis(100)).measurement_time(Duration::from_millis(500));
 
         for &batch_size in BATCH_SIZES {
             for &tree_size in TREE_SIZES {
-                let (mut buffers, scale) = make_buffers(&context, batch_size, tree_size);
+                let kernel = <<Metal as Backend>::Kernels as Kernels>::BuildTreeGramKernel::new(
+                    &context,
+                    DataType::BF16,
+                    use_mxu,
+                )
+                .expect("BuildTreeGramKernel");
+                let scale = (HEAD_K_DIM as f32).sqrt().recip();
+                let qk_len = batch_size * tree_size * K_HEADS * HEAD_K_DIM;
+                let head_len = batch_size * tree_size * VALUE_HEADS;
+                let out_len = batch_size * VALUE_HEADS * tree_size * tree_size;
+                let bytes_per_copy = qk_len * size_of::<bf16>() * 2
+                    + batch_size * tree_size * 3 * size_of::<u32>()
+                    + head_len * size_of::<f32>() * 2
+                    + out_len * size_of::<f32>() * 3;
                 let benchmark_path =
                     format!("Metal/Kernel/GDNTreeVerify/BuildTreeGram/{kernel_path}/B{batch_size}_T{tree_size}");
-                group.bench_function(
-                    BenchmarkId::from_parameter(format!(
-                        "B{batch_size}_T{tree_size}_Hg{K_HEADS}_HV{VALUE_HEADS}_K{HEAD_K_DIM}"
-                    )),
-                    |bencher| {
+                let benchmark_id = BenchmarkId::from_parameter(format!(
+                    "B{batch_size}_T{tree_size}_Hg{K_HEADS}_HV{VALUE_HEADS}_K{HEAD_K_DIM}"
+                ));
+
+                if cold_buffers {
+                    let mut buffers = ColdPool::new(bytes_per_copy, || make_buffers(&context, batch_size, tree_size).0);
+                    group.bench_function(benchmark_id, |bencher| {
+                        iter_encode_loop_named::<Metal, _>(context.as_ref(), bencher, &benchmark_path, |encoder| {
+                            let buffers = buffers.next_mut();
+                            kernel.encode(
+                                &buffers.q,
+                                &buffers.k,
+                                &buffers.trie,
+                                &buffers.prefix,
+                                &buffers.beta,
+                                &mut buffers.a_mat,
+                                &mut buffers.qkd,
+                                &mut buffers.ainv,
+                                scale,
+                                batch_size as u32,
+                                tree_size as u32,
+                                K_HEADS as u32,
+                                VALUE_HEADS as u32,
+                                HEAD_K_DIM as u32,
+                                encoder,
+                            );
+                        });
+                    });
+                } else {
+                    let (mut buffers, _) = make_buffers(&context, batch_size, tree_size);
+                    group.bench_function(benchmark_id, |bencher| {
                         iter_encode_loop_named::<Metal, _>(context.as_ref(), bencher, &benchmark_path, |encoder| {
                             kernel.encode(
                                 &buffers.q,
@@ -151,8 +188,8 @@ fn bench_build_tree_gram(c: &mut Criterion) {
                                 encoder,
                             );
                         });
-                    },
-                );
+                    });
+                }
             }
         }
         group.finish();

--- a/crates/backend-uzu/unit/backends/common/kernel/gram_bench.rs
+++ b/crates/backend-uzu/unit/backends/common/kernel/gram_bench.rs
@@ -1,3 +1,5 @@
+#![cfg(metal_backend)]
+
 use std::{env, mem::size_of, time::Duration};
 
 use criterion::{BenchmarkId, Criterion};

--- a/crates/backend-uzu/unit/backends/common/kernel/gram_bench.rs
+++ b/crates/backend-uzu/unit/backends/common/kernel/gram_bench.rs
@@ -108,6 +108,19 @@ fn make_buffers(
     )
 }
 
+fn buffers_bytes(
+    batch_size: usize,
+    tree_size: usize,
+) -> usize {
+    let qk_len = batch_size * tree_size * K_HEADS * HEAD_K_DIM;
+    let head_len = batch_size * tree_size * VALUE_HEADS;
+    let out_len = batch_size * VALUE_HEADS * tree_size * tree_size;
+    qk_len * size_of::<bf16>() * 2
+        + batch_size * tree_size * 3 * size_of::<u32>()
+        + head_len * size_of::<f32>() * 2
+        + out_len * size_of::<f32>() * 3
+}
+
 #[uzu_bench]
 fn bench_build_tree_gram(c: &mut Criterion) {
     let context = <Metal as Backend>::Context::new().expect("metal context");
@@ -131,64 +144,47 @@ fn bench_build_tree_gram(c: &mut Criterion) {
                 )
                 .expect("BuildTreeGramKernel");
                 let scale = (HEAD_K_DIM as f32).sqrt().recip();
-                let qk_len = batch_size * tree_size * K_HEADS * HEAD_K_DIM;
-                let head_len = batch_size * tree_size * VALUE_HEADS;
-                let out_len = batch_size * VALUE_HEADS * tree_size * tree_size;
-                let bytes_per_copy = qk_len * size_of::<bf16>() * 2
-                    + batch_size * tree_size * 3 * size_of::<u32>()
-                    + head_len * size_of::<f32>() * 2
-                    + out_len * size_of::<f32>() * 3;
                 let benchmark_path =
                     format!("Metal/Kernel/GDNTreeVerify/BuildTreeGram/{kernel_path}/B{batch_size}_T{tree_size}");
                 let benchmark_id = BenchmarkId::from_parameter(format!(
                     "B{batch_size}_T{tree_size}_Hg{K_HEADS}_HV{VALUE_HEADS}_K{HEAD_K_DIM}"
                 ));
 
+                let encode = |buffers: &mut TreeGramBuffers, encoder| {
+                    kernel.encode(
+                        &buffers.q,
+                        &buffers.k,
+                        &buffers.trie,
+                        &buffers.prefix,
+                        &buffers.beta,
+                        &mut buffers.a_mat,
+                        &mut buffers.qkd,
+                        &mut buffers.ainv,
+                        scale,
+                        batch_size as u32,
+                        tree_size as u32,
+                        K_HEADS as u32,
+                        VALUE_HEADS as u32,
+                        HEAD_K_DIM as u32,
+                        encoder,
+                    );
+                };
+
                 if cold_buffers {
-                    let mut buffers = ColdPool::new(bytes_per_copy, || make_buffers(&context, batch_size, tree_size).0);
+                    let mut buffers = ColdPool::new(buffers_bytes(batch_size, tree_size), || {
+                        make_buffers(&context, batch_size, tree_size).0
+                    });
                     group.bench_function(benchmark_id, |bencher| {
                         iter_encode_loop_named::<Metal, _>(context.as_ref(), bencher, &benchmark_path, |encoder| {
                             let buffers = buffers.next_mut();
-                            kernel.encode(
-                                &buffers.q,
-                                &buffers.k,
-                                &buffers.trie,
-                                &buffers.prefix,
-                                &buffers.beta,
-                                &mut buffers.a_mat,
-                                &mut buffers.qkd,
-                                &mut buffers.ainv,
-                                scale,
-                                batch_size as u32,
-                                tree_size as u32,
-                                K_HEADS as u32,
-                                VALUE_HEADS as u32,
-                                HEAD_K_DIM as u32,
-                                encoder,
-                            );
+                            encode(buffers, encoder);
                         });
                     });
                 } else {
                     let (mut buffers, _) = make_buffers(&context, batch_size, tree_size);
                     group.bench_function(benchmark_id, |bencher| {
                         iter_encode_loop_named::<Metal, _>(context.as_ref(), bencher, &benchmark_path, |encoder| {
-                            kernel.encode(
-                                &buffers.q,
-                                &buffers.k,
-                                &buffers.trie,
-                                &buffers.prefix,
-                                &buffers.beta,
-                                &mut buffers.a_mat,
-                                &mut buffers.qkd,
-                                &mut buffers.ainv,
-                                scale,
-                                batch_size as u32,
-                                tree_size as u32,
-                                K_HEADS as u32,
-                                VALUE_HEADS as u32,
-                                HEAD_K_DIM as u32,
-                                encoder,
-                            );
+                            encode(&mut buffers, encoder);
                         });
                     });
                 }

--- a/crates/backend-uzu/unit/backends/common/kernel/gram_bench.rs
+++ b/crates/backend-uzu/unit/backends/common/kernel/gram_bench.rs
@@ -1,20 +1,23 @@
 use std::time::Duration;
 
-use backend_uzu::{
+use criterion::{BenchmarkId, Criterion};
+use half::bf16;
+use proc_macros::uzu_bench;
+
+use crate::{
     array::ArrayContextExt,
     backends::{
-        common::{Allocation, Backend, Context, Encoder, Kernels, kernel::BuildTreeGramKernel},
+        common::{Allocation, Backend, Context, Kernels, kernel::BuildTreeGramKernel},
         metal::Metal,
     },
     data_type::DataType,
+    tests::matmul::iter_encode_loop_named,
 };
-use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use half::bf16;
 
 const K_HEADS: usize = 16;
 const VALUE_HEADS: usize = 48;
 const HEAD_K_DIM: usize = 128;
-const TREE_SIZES: &[usize] = &[33, 49, 64];
+const TREE_SIZES: &[usize] = &[33, 49, 64, 128, 256, 512];
 const BATCH_SIZES: &[usize] = &[1, 2, 4, 8];
 
 struct TreeGramBuffers {
@@ -103,6 +106,7 @@ fn make_buffers(
     )
 }
 
+#[uzu_bench]
 fn bench_build_tree_gram(c: &mut Criterion) {
     let context = <Metal as Backend>::Context::new().expect("metal context");
     let kernel_paths = if context.supports_mxu() {
@@ -121,16 +125,14 @@ fn bench_build_tree_gram(c: &mut Criterion) {
         for &batch_size in BATCH_SIZES {
             for &tree_size in TREE_SIZES {
                 let (mut buffers, scale) = make_buffers(&context, batch_size, tree_size);
-                let gram_flops = 4 * batch_size * VALUE_HEADS * tree_size * tree_size * HEAD_K_DIM;
-                let inverse_flops = batch_size * VALUE_HEADS * (tree_size * tree_size * tree_size - tree_size) / 3;
-                group.throughput(Throughput::Elements((gram_flops + inverse_flops) as u64));
+                let benchmark_path =
+                    format!("Metal/Kernel/GDNTreeVerify/BuildTreeGram/{kernel_path}/B{batch_size}_T{tree_size}");
                 group.bench_function(
                     BenchmarkId::from_parameter(format!(
                         "B{batch_size}_T{tree_size}_Hg{K_HEADS}_HV{VALUE_HEADS}_K{HEAD_K_DIM}"
                     )),
                     |bencher| {
-                        bencher.iter(|| {
-                            let mut encoder = Encoder::new(context.as_ref()).expect("encoder");
+                        iter_encode_loop_named::<Metal, _>(context.as_ref(), bencher, &benchmark_path, |encoder| {
                             kernel.encode(
                                 &buffers.q,
                                 &buffers.k,
@@ -146,9 +148,8 @@ fn bench_build_tree_gram(c: &mut Criterion) {
                                 K_HEADS as u32,
                                 VALUE_HEADS as u32,
                                 HEAD_K_DIM as u32,
-                                &mut encoder,
+                                encoder,
                             );
-                            encoder.end_encoding().submit().wait_until_completed().unwrap();
                         });
                     },
                 );
@@ -157,6 +158,3 @@ fn bench_build_tree_gram(c: &mut Criterion) {
         group.finish();
     }
 }
-
-criterion_group!(benches, bench_build_tree_gram);
-criterion_main!(benches);

--- a/crates/backend-uzu/unit/backends/common/kernel/gram_bench.rs
+++ b/crates/backend-uzu/unit/backends/common/kernel/gram_bench.rs
@@ -9,7 +9,7 @@ use proc_macros::uzu_bench;
 use crate::{
     array::ArrayContextExt,
     backends::{
-        common::{Allocation, Backend, Context, Kernels, kernel::BuildTreeGramKernel},
+        common::{Allocation, Backend, Context, Encoder, Kernels, kernel::BuildTreeGramKernel},
         metal::Metal,
     },
     data_type::DataType,
@@ -150,7 +150,7 @@ fn bench_build_tree_gram(c: &mut Criterion) {
                     "B{batch_size}_T{tree_size}_Hg{K_HEADS}_HV{VALUE_HEADS}_K{HEAD_K_DIM}"
                 ));
 
-                let encode = |buffers: &mut TreeGramBuffers, encoder| {
+                let encode = |buffers: &mut TreeGramBuffers, encoder: &mut Encoder<Metal>| {
                     kernel.encode(
                         &buffers.q,
                         &buffers.k,

--- a/crates/backend-uzu/unit/backends/common/kernel/gram_test.rs
+++ b/crates/backend-uzu/unit/backends/common/kernel/gram_test.rs
@@ -11,25 +11,26 @@ use crate::{
     tests::{assert::assert_eq_float, helpers::allocation_to_vec},
 };
 
+const BATCH_SIZE: usize = 2;
+const K_HEADS: usize = 2;
+const VALUE_HEADS: usize = 6;
+const HEAD_K_DIM: usize = 128;
+
 fn get_output<B: Backend>(
     q: &[f32],
     k: &[f32],
     trie: &[u32],
     prefix: &[f32],
     beta: &[f32],
+    tree_size: usize,
     scale: f32,
-    batch_size: u32,
-    tree_size: u32,
-    k_heads: u32,
-    value_heads: u32,
-    head_k_dim: u32,
     use_mxu: bool,
 ) -> (Vec<f32>, Vec<f32>, Vec<f32>) {
     let context = B::Context::new().expect("Failed to create Context");
     let kernel = <<B as Backend>::Kernels as Kernels>::BuildTreeGramKernel::new(&context, DataType::F32, use_mxu)
         .expect("Failed to create BuildTreeGramKernel");
 
-    let output_len = batch_size as usize * value_heads as usize * tree_size as usize * tree_size as usize;
+    let output_len = BATCH_SIZE * VALUE_HEADS * tree_size * tree_size;
     let q = context.create_array_from(&[q.len()], q);
     let k = context.create_array_from(&[k.len()], k);
     let trie = context.create_array_from(&[trie.len()], trie);
@@ -50,11 +51,11 @@ fn get_output<B: Backend>(
         &mut qkd,
         &mut ainv,
         scale,
-        batch_size,
-        tree_size,
-        k_heads,
-        value_heads,
-        head_k_dim,
+        BATCH_SIZE as u32,
+        tree_size as u32,
+        K_HEADS as u32,
+        VALUE_HEADS as u32,
+        HEAD_K_DIM as u32,
         &mut encoder,
     );
     encoder.end_encoding().submit().wait_until_completed().unwrap();
@@ -64,7 +65,7 @@ fn get_output<B: Backend>(
 
 fn build_trie(tree_size: usize) -> Vec<u32> {
     let last = tree_size as u32 - 1;
-    let mut trie = Vec::with_capacity(2 * tree_size * 3);
+    let mut trie = Vec::with_capacity(BATCH_SIZE * tree_size * 3);
     for i in 0..tree_size as u32 {
         trie.extend_from_slice(&[i, last, i]);
     }
@@ -77,54 +78,24 @@ fn build_trie(tree_size: usize) -> Vec<u32> {
 
 #[uzu_test]
 fn test_build_tree_gram_matches_cpu() {
-    let batch_size = 2;
-    let k_heads = 2;
-    let value_heads = 6;
-    let head_k_dim = 128;
-    let scale = (head_k_dim as f32).sqrt().recip();
+    let scale = (HEAD_K_DIM as f32).sqrt().recip();
 
-    for tree_size in [17, 64] {
-        let q_len = batch_size * tree_size * k_heads * head_k_dim;
-        let kv_len = batch_size * tree_size * value_heads;
+    for tree_size in [17, 64, 128] {
+        let q_len = BATCH_SIZE * tree_size * K_HEADS * HEAD_K_DIM;
+        let kv_len = BATCH_SIZE * tree_size * VALUE_HEADS;
         let trie = build_trie(tree_size);
         let q = (0..q_len).map(|i| ((i as f32 * 0.017).sin() * 0.2) + 0.01).collect::<Vec<_>>();
         let k = (0..q_len).map(|i| ((i as f32 * 0.019).cos() * 0.18) - 0.02).collect::<Vec<_>>();
         let prefix = (0..kv_len)
-            .map(|i| -((i % tree_size) as f32) * 0.01 - ((i % value_heads) as f32) * 0.003)
+            .map(|i| -((i % tree_size) as f32) * 0.01 - ((i % VALUE_HEADS) as f32) * 0.003)
             .collect::<Vec<_>>();
         let beta = (0..kv_len).map(|i| 0.25 + ((i as f32 * 0.013).sin() + 1.0) * 0.2).collect::<Vec<_>>();
 
-        let expected = get_output::<Cpu>(
-            &q,
-            &k,
-            &trie,
-            &prefix,
-            &beta,
-            scale,
-            batch_size as u32,
-            tree_size as u32,
-            k_heads as u32,
-            value_heads as u32,
-            head_k_dim as u32,
-            false,
-        );
+        let expected = get_output::<Cpu>(&q, &k, &trie, &prefix, &beta, tree_size, scale, false);
 
         for_each_non_cpu_backend!(|B| {
             for use_mxu in [false, true] {
-                let actual = get_output::<B>(
-                    &q,
-                    &k,
-                    &trie,
-                    &prefix,
-                    &beta,
-                    scale,
-                    batch_size as u32,
-                    tree_size as u32,
-                    k_heads as u32,
-                    value_heads as u32,
-                    head_k_dim as u32,
-                    use_mxu,
-                );
+                let actual = get_output::<B>(&q, &k, &trie, &prefix, &beta, tree_size, scale, use_mxu);
                 let path = if use_mxu {
                     "mxu"
                 } else {
@@ -133,7 +104,25 @@ fn test_build_tree_gram_matches_cpu() {
                 let msg = format!("backend {} {path} tree_size {tree_size}", std::any::type_name::<B>());
                 assert_eq_float::<f32>(&expected.0, &actual.0, 5e-3, &format!("a_mat {msg}"));
                 assert_eq_float::<f32>(&expected.1, &actual.1, 5e-3, &format!("qkd {msg}"));
-                assert_eq_float::<f32>(&expected.2, &actual.2, 1e-2, &format!("ainv {msg}"));
+
+                for (expected_matrix, actual_matrix) in
+                    expected.2.chunks(tree_size * tree_size).zip(actual.2.chunks(tree_size * tree_size))
+                {
+                    for block_start in (0..tree_size).step_by(16) {
+                        let block_end = (block_start + 16).min(tree_size);
+                        for i in block_start..block_end {
+                            for j in block_start..block_end {
+                                let idx = i * tree_size + j;
+                                let expected = expected_matrix[idx];
+                                let actual = actual_matrix[idx];
+                                assert!(
+                                    (expected - actual).abs() < 1e-2,
+                                    "ainv {msg}. Mismatch at matrix index {idx}: expected {expected}, got {actual}"
+                                );
+                            }
+                        }
+                    }
+                }
             }
         });
     }

--- a/crates/backend-uzu/unit/backends/common/kernel/gram_test.rs
+++ b/crates/backend-uzu/unit/backends/common/kernel/gram_test.rs
@@ -94,7 +94,14 @@ fn test_build_tree_gram_matches_cpu() {
         let expected = get_output::<Cpu>(&q, &k, &trie, &prefix, &beta, tree_size, scale, false);
 
         for_each_non_cpu_backend!(|B| {
-            for use_mxu in [false, true] {
+            let context = <<B as Backend>::Context as Context>::new().expect("Failed to create Context");
+            let paths: &[bool] = if context.supports_mxu() {
+                &[false, true]
+            } else {
+                &[false]
+            };
+
+            for &use_mxu in paths {
                 let actual = get_output::<B>(&q, &k, &trie, &prefix, &beta, tree_size, scale, use_mxu);
                 let path = if use_mxu {
                     "mxu"

--- a/crates/backend-uzu/unit/backends/common/kernel/gram_test.rs
+++ b/crates/backend-uzu/unit/backends/common/kernel/gram_test.rs
@@ -1,0 +1,130 @@
+use proc_macros::uzu_test;
+use test_runner::for_each_non_cpu_backend;
+
+use crate::{
+    array::ArrayContextExt,
+    backends::{
+        common::{Backend, Context, Encoder, Kernels, kernel::BuildTreeGramKernel},
+        cpu::Cpu,
+    },
+    data_type::DataType,
+    tests::{assert::assert_eq_float, helpers::allocation_to_vec},
+};
+
+fn get_output<B: Backend>(
+    q: &[f32],
+    k: &[f32],
+    trie: &[u32],
+    prefix: &[f32],
+    beta: &[f32],
+    scale: f32,
+    batch_size: u32,
+    tree_size: u32,
+    k_heads: u32,
+    value_heads: u32,
+    head_k_dim: u32,
+) -> (Vec<f32>, Vec<f32>, Vec<f32>) {
+    let context = B::Context::new().expect("Failed to create Context");
+    let kernel = <<B as Backend>::Kernels as Kernels>::BuildTreeGramKernel::new(&context, DataType::F32)
+        .expect("Failed to create BuildTreeGramKernel");
+
+    let output_len = batch_size as usize * value_heads as usize * tree_size as usize * tree_size as usize;
+    let q = context.create_array_from(&[q.len()], q);
+    let k = context.create_array_from(&[k.len()], k);
+    let trie = context.create_array_from(&[trie.len()], trie);
+    let prefix = context.create_array_from(&[prefix.len()], prefix);
+    let beta = context.create_array_from(&[beta.len()], beta);
+    let mut a_mat = context.create_array_uninitialized(&[output_len], DataType::F32).into_allocation();
+    let mut qkd = context.create_array_uninitialized(&[output_len], DataType::F32).into_allocation();
+    let mut ainv = context.create_array_uninitialized(&[output_len], DataType::F32).into_allocation();
+
+    let mut encoder = Encoder::new(context.as_ref()).expect("Failed to create encoder");
+    kernel.encode(
+        q.allocation(),
+        k.allocation(),
+        trie.allocation(),
+        prefix.allocation(),
+        beta.allocation(),
+        &mut a_mat,
+        &mut qkd,
+        &mut ainv,
+        scale,
+        batch_size,
+        tree_size,
+        k_heads,
+        value_heads,
+        head_k_dim,
+        &mut encoder,
+    );
+    encoder.end_encoding().submit().wait_until_completed().unwrap();
+
+    (allocation_to_vec(&a_mat), allocation_to_vec(&qkd), allocation_to_vec(&ainv))
+}
+
+fn build_trie(tree_size: usize) -> Vec<u32> {
+    let last = tree_size as u32 - 1;
+    let mut trie = Vec::with_capacity(2 * tree_size * 3);
+    for i in 0..tree_size as u32 {
+        trie.extend_from_slice(&[i, last, i]);
+    }
+    trie.extend_from_slice(&[0, last, 0]);
+    for i in 1..tree_size as u32 {
+        trie.extend_from_slice(&[i, i, 1]);
+    }
+    trie
+}
+
+#[uzu_test]
+fn test_build_tree_gram_matches_cpu() {
+    let batch_size = 2;
+    let k_heads = 2;
+    let value_heads = 6;
+    let head_k_dim = 128;
+    let scale = (head_k_dim as f32).sqrt().recip();
+
+    for tree_size in [17, 64] {
+        let q_len = batch_size * tree_size * k_heads * head_k_dim;
+        let kv_len = batch_size * tree_size * value_heads;
+        let trie = build_trie(tree_size);
+        let q = (0..q_len).map(|i| ((i as f32 * 0.017).sin() * 0.2) + 0.01).collect::<Vec<_>>();
+        let k = (0..q_len).map(|i| ((i as f32 * 0.019).cos() * 0.18) - 0.02).collect::<Vec<_>>();
+        let prefix = (0..kv_len)
+            .map(|i| -((i % tree_size) as f32) * 0.01 - ((i % value_heads) as f32) * 0.003)
+            .collect::<Vec<_>>();
+        let beta = (0..kv_len).map(|i| 0.25 + ((i as f32 * 0.013).sin() + 1.0) * 0.2).collect::<Vec<_>>();
+
+        let expected = get_output::<Cpu>(
+            &q,
+            &k,
+            &trie,
+            &prefix,
+            &beta,
+            scale,
+            batch_size as u32,
+            tree_size as u32,
+            k_heads as u32,
+            value_heads as u32,
+            head_k_dim as u32,
+        );
+
+        for_each_non_cpu_backend!(|B| {
+            let actual = get_output::<B>(
+                &q,
+                &k,
+                &trie,
+                &prefix,
+                &beta,
+                scale,
+                batch_size as u32,
+                tree_size as u32,
+                k_heads as u32,
+                value_heads as u32,
+                head_k_dim as u32,
+            );
+            let msg = format!("backend {} tree_size {tree_size}", std::any::type_name::<B>());
+            assert_eq_float::<f32>(&expected.0, &actual.0, 5e-3, &format!("a_mat {msg}"));
+            assert_eq_float::<f32>(&expected.1, &actual.1, 5e-3, &format!("qkd {msg}"));
+            assert_eq_float::<f32>(&expected.2, &actual.2, 1e-2, &format!("ainv {msg}"));
+        });
+    }
+}

--- a/crates/backend-uzu/unit/backends/common/kernel/gram_test.rs
+++ b/crates/backend-uzu/unit/backends/common/kernel/gram_test.rs
@@ -23,9 +23,10 @@ fn get_output<B: Backend>(
     k_heads: u32,
     value_heads: u32,
     head_k_dim: u32,
+    use_mxu: bool,
 ) -> (Vec<f32>, Vec<f32>, Vec<f32>) {
     let context = B::Context::new().expect("Failed to create Context");
-    let kernel = <<B as Backend>::Kernels as Kernels>::BuildTreeGramKernel::new(&context, DataType::F32)
+    let kernel = <<B as Backend>::Kernels as Kernels>::BuildTreeGramKernel::new(&context, DataType::F32, use_mxu)
         .expect("Failed to create BuildTreeGramKernel");
 
     let output_len = batch_size as usize * value_heads as usize * tree_size as usize * tree_size as usize;
@@ -105,26 +106,35 @@ fn test_build_tree_gram_matches_cpu() {
             k_heads as u32,
             value_heads as u32,
             head_k_dim as u32,
+            false,
         );
 
         for_each_non_cpu_backend!(|B| {
-            let actual = get_output::<B>(
-                &q,
-                &k,
-                &trie,
-                &prefix,
-                &beta,
-                scale,
-                batch_size as u32,
-                tree_size as u32,
-                k_heads as u32,
-                value_heads as u32,
-                head_k_dim as u32,
-            );
-            let msg = format!("backend {} tree_size {tree_size}", std::any::type_name::<B>());
-            assert_eq_float::<f32>(&expected.0, &actual.0, 5e-3, &format!("a_mat {msg}"));
-            assert_eq_float::<f32>(&expected.1, &actual.1, 5e-3, &format!("qkd {msg}"));
-            assert_eq_float::<f32>(&expected.2, &actual.2, 1e-2, &format!("ainv {msg}"));
+            for use_mxu in [false, true] {
+                let actual = get_output::<B>(
+                    &q,
+                    &k,
+                    &trie,
+                    &prefix,
+                    &beta,
+                    scale,
+                    batch_size as u32,
+                    tree_size as u32,
+                    k_heads as u32,
+                    value_heads as u32,
+                    head_k_dim as u32,
+                    use_mxu,
+                );
+                let path = if use_mxu {
+                    "mxu"
+                } else {
+                    "simdgroup"
+                };
+                let msg = format!("backend {} {path} tree_size {tree_size}", std::any::type_name::<B>());
+                assert_eq_float::<f32>(&expected.0, &actual.0, 5e-3, &format!("a_mat {msg}"));
+                assert_eq_float::<f32>(&expected.1, &actual.1, 5e-3, &format!("qkd {msg}"));
+                assert_eq_float::<f32>(&expected.2, &actual.2, 1e-2, &format!("ainv {msg}"));
+            }
         });
     }
 }

--- a/crates/backend-uzu/unit/backends/common/kernel/mod.rs
+++ b/crates/backend-uzu/unit/backends/common/kernel/mod.rs
@@ -4,6 +4,7 @@ mod audio;
 mod delta_net_test;
 mod embedding;
 mod gated_act_mul_test;
+mod gram_test;
 mod hadamard_transform_test;
 mod kv_cache_update_test;
 mod layer_norm_test;

--- a/crates/backend-uzu/unit/backends/common/kernel/mod.rs
+++ b/crates/backend-uzu/unit/backends/common/kernel/mod.rs
@@ -4,6 +4,7 @@ mod audio;
 mod delta_net_test;
 mod embedding;
 mod gated_act_mul_test;
+mod gram_bench;
 mod gram_test;
 mod hadamard_transform_test;
 mod kv_cache_update_test;


### PR DESCRIPTION
 ## Current MXU Speedup vs Simdgroup

| B | T33 | T49 | T64 | T128 | T256 | T512 |
|---|------|------|------|------|------|------|
| 1 | 1.01x | 1.03x | 1.00x | 1.10x | 1.17x | 1.52x |
| 2 | 1.04x | 1.06x | 1.03x | 1.23x | 1.46x | 1.50x |
| 4 | 1.12x | 1.20x | 1.15x | 1.16x | 1.51x | 1.50x |
| 8 | 1.20x | 1.19x | 1.17x | 1.34x | 1.37x | 1.40x |

## Simple Forward Substitution vs Old Diagonal Neumann

Old Neumann only supported up to T64.

| B | MXU T33 | MXU T64 | Simdgroup T33 | Simdgroup T64 |
|---|---------|---------|---------------|---------------|
| 1 | 1.04x | 1.06x | 1.01x | 1.01x |
| 2 | 1.04x | 1.23x | 1.03x | 1.17x |
| 4 | 1.17x | 1.20x | 1.10x | 1.05x |
| 8 | 1.21x | 1.25x | 1.02x | 1.12x |

**Takeaway:** MXU only clearly pulls away at larger T/B; for B1 T33–T64, it is basically tied. This is because the MXU tile setup is too much work to pay off at small T/B — the setup overhead dominates, so MXU stays slow until T/B grow large enough to amortize it. Forward substitution beat the old Neumann setup modestly at B1, more at larger batch.