### PR TITLE
Metal: Add dynamic caching capability check

### DIFF
--- a/crates/backend-uzu/src/backends/metal/context.rs
+++ b/crates/backend-uzu/src/backends/metal/context.rs
@@ -52,6 +52,12 @@ impl MetalContext {
         self.device.supports_mxu()
     }
 
+    // TODO: remove allow once a dynamic-caching dispatcher uses this probe.
+    #[allow(dead_code)]
+    pub fn supports_dynamic_caching(&self) -> bool {
+        self.device.supports_family(metal::MTLGPUFamily::Apple9)
+    }
+
     pub(crate) fn device_tier(&self) -> DeviceTier {
         self.device_tier
     }

--- a/crates/backend-uzu/unit/backends/common/kernel/matmul/dispatch_paths_test.rs
+++ b/crates/backend-uzu/unit/backends/common/kernel/matmul/dispatch_paths_test.rs
@@ -179,12 +179,9 @@ fn gemv_fp_output_transforms_bf16() {
 }
 
 #[uzu_test]
-fn small_m_mxu_tiles_parity() {
+fn small_m_tiles_parity() {
     use crate::tests::matmul::Shape;
     let context = MetalContext::new().expect("Metal context");
-    if !context.supports_mxu() {
-        return;
-    }
     let mut bf16_kernel = <<Metal as Backend>::Kernels as Kernels>::MatmulKernel::new(
         &context,
         bf16::data_type(),
@@ -200,8 +197,10 @@ fn small_m_mxu_tiles_parity() {
     )
     .expect("MatmulKernel");
 
-    for shape in [Shape::new(8, 256, 256), Shape::new(8, 512, 256)] {
-        check_case::<bf16>(&context, &mut bf16_kernel, Some(GemmDispatchPath::Mxu), Case::new(shape), 1.0);
-        check_case::<f32>(&context, &mut f32_kernel, Some(GemmDispatchPath::Mxu), Case::new(shape), 0.01);
+    for path in gemm_paths_for_hw(&context) {
+        for shape in [Shape::new(8, 256, 256), Shape::new(8, 512, 256)] {
+            check_case::<bf16>(&context, &mut bf16_kernel, Some(path), Case::new(shape), 1.0);
+            check_case::<f32>(&context, &mut f32_kernel, Some(path), Case::new(shape), 0.01);
+        }
     }
 }

--- a/crates/backend-uzu/unit/backends/common/kernel/out_test.rs
+++ b/crates/backend-uzu/unit/backends/common/kernel/out_test.rs
@@ -1,13 +1,13 @@
 use half::bf16;
 use num_traits::Float;
 use proc_macros::uzu_test;
-use test_runner::for_each_non_cpu_backend;
 
 use crate::{
     array::ArrayElement,
     backends::{
         common::{Backend, Context, Encoder, Kernels, kernel::BuildTreeOutKernel},
         cpu::Cpu,
+        metal::{Metal, MetalContext},
     },
     tests::{
         assert::assert_eq_float,
@@ -39,6 +39,10 @@ const BUILD_TREE_OUT_PATHS: &[(&str, bool, bool)] = &[
     ("Simdgroup/H0Transposed/Rows8_VCols32_SG4", false, true),
     ("MXU/H0Direct/Rows16_VCols32_SG4", true, false),
 ];
+
+fn build_tree_out_paths(context: &MetalContext) -> impl Iterator<Item = (&'static str, bool, bool)> + '_ {
+    BUILD_TREE_OUT_PATHS.iter().copied().filter(|&(_, use_mxu, _)| !use_mxu || context.supports_mxu())
+}
 
 fn make_inputs<T: ArrayElement + Float>(shape: Shape) -> Inputs<T> {
     let q_len = shape.batch_size * shape.tree_size * shape.qk_heads * shape.head_k_dim;
@@ -123,29 +127,24 @@ fn check_shape<T: ArrayElement + Float + std::fmt::Display>(
 
     for use_h0 in [false, true] {
         let expected = run_build_tree_out::<Cpu, T>(shape, &inputs, use_h0, false, false);
-        for_each_non_cpu_backend!(|B| {
-            let context = <B as Backend>::Context::new().expect("Failed to create Context");
-            for &(path, use_mxu, transposed_h0) in BUILD_TREE_OUT_PATHS {
-                if use_mxu && !context.supports_mxu() {
-                    continue;
-                }
-                if transposed_h0 && !use_h0 {
-                    continue;
-                }
-                let actual = run_build_tree_out::<B, T>(shape, &inputs, use_h0, use_mxu, transposed_h0);
-                let msg = format!(
-                    "backend {} path {path} use_h0 {use_h0} B{}_T{}_QK{}_HV{}_K{}_V{}",
-                    std::any::type_name::<B>(),
-                    shape.batch_size,
-                    shape.tree_size,
-                    shape.qk_heads,
-                    shape.value_heads,
-                    shape.head_k_dim,
-                    shape.head_v_dim
-                );
-                assert_eq_float::<T>(&expected, &actual, eps, &msg);
+        let context = MetalContext::new().expect("Failed to create Context");
+        for (path, use_mxu, transposed_h0) in build_tree_out_paths(&context) {
+            if transposed_h0 && !use_h0 {
+                continue;
             }
-        });
+            let actual = run_build_tree_out::<Metal, T>(shape, &inputs, use_h0, use_mxu, transposed_h0);
+            let msg = format!(
+                "backend {} path {path} use_h0 {use_h0} B{}_T{}_QK{}_HV{}_K{}_V{}",
+                std::any::type_name::<Metal>(),
+                shape.batch_size,
+                shape.tree_size,
+                shape.qk_heads,
+                shape.value_heads,
+                shape.head_k_dim,
+                shape.head_v_dim
+            );
+            assert_eq_float::<T>(&expected, &actual, eps, &msg);
+        }
     }
 }
 

--- a/crates/backend-uzu/unit/backends/common/kernel/tree_gram_test.rs
+++ b/crates/backend-uzu/unit/backends/common/kernel/tree_gram_test.rs
@@ -1,10 +1,10 @@
 use proc_macros::uzu_test;
-use test_runner::for_each_non_cpu_backend;
 
 use crate::{
     backends::{
         common::{Backend, Context, Encoder, Kernels, kernel::BuildTreeGramKernel},
         cpu::Cpu,
+        metal::{Metal, MetalContext},
     },
     data_type::DataType,
     tests::{
@@ -19,6 +19,14 @@ const VALUE_HEADS: usize = 6;
 const HEAD_K_DIM: usize = 128;
 // 80 = two full 32-wide kh0 dv chunks plus a ragged 16-wide one.
 const HEAD_V_DIM: usize = 80;
+
+fn build_tree_gram_paths(context: &MetalContext) -> Vec<(&'static str, bool)> {
+    let mut paths = vec![("Simdgroup", false)];
+    if context.supports_mxu() {
+        paths.push(("MXU", true));
+    }
+    paths
+}
 
 fn get_output<B: Backend>(
     q: &[f32],
@@ -118,30 +126,14 @@ fn test_build_tree_gram_matches_cpu() {
 
         let expected = get_output::<Cpu>(&q, &k, &trie, &prefix, &beta, &h0, &h0_idx, tree_size, scale, false);
 
-        for_each_non_cpu_backend!(|B| {
-            let context = <<B as Backend>::Context as Context>::new().expect("Failed to create Context");
-            let paths: &[bool] = if context.supports_mxu() {
-                &[false, true]
-            } else {
-                &[false]
-            };
-
-            for &use_mxu in paths {
-                let actual = get_output::<B>(&q, &k, &trie, &prefix, &beta, &h0, &h0_idx, tree_size, scale, use_mxu);
-                let path = if use_mxu {
-                    "mxu"
-                } else {
-                    "simdgroup"
-                };
-                let msg = format!("backend {} {path} tree_size {tree_size}", std::any::type_name::<B>());
-                assert_eq_float::<f32>(&expected.0, &actual.0, 5e-3, &format!("a_packed {msg}"));
-                assert_eq_float::<f32>(&expected.1, &actual.1, 5e-3, &format!("qkd {msg}"));
-
-                // Ainv is compact [B * HV, ceil(T/16), 16, 16]; both CPU and GPU
-                // pad ragged blocks with identity, so compare the whole buffer.
-                assert_eq_float::<f32>(&expected.2, &actual.2, 1e-2, &format!("a_inv {msg}"));
-                assert_eq_float::<f32>(&expected.3, &actual.3, 5e-3, &format!("kh0 {msg}"));
-            }
-        });
+        let context = MetalContext::new().expect("Failed to create Context");
+        for (path, use_mxu) in build_tree_gram_paths(&context) {
+            let actual = get_output::<Metal>(&q, &k, &trie, &prefix, &beta, &h0, &h0_idx, tree_size, scale, use_mxu);
+            let msg = format!("backend {} path {path} tree_size {tree_size}", std::any::type_name::<Metal>());
+            assert_eq_float::<f32>(&expected.0, &actual.0, 5e-3, &format!("a_packed {msg}"));
+            assert_eq_float::<f32>(&expected.1, &actual.1, 5e-3, &format!("qkd {msg}"));
+            assert_eq_float::<f32>(&expected.2, &actual.2, 1e-2, &format!("a_inv {msg}"));
+            assert_eq_float::<f32>(&expected.3, &actual.3, 5e-3, &format!("kh0 {msg}"));
+        }
     }
 }

--- a/crates/backend-uzu/unit/backends/common/kernel/tree_update_solve_test.rs
+++ b/crates/backend-uzu/unit/backends/common/kernel/tree_update_solve_test.rs
@@ -7,6 +7,7 @@ use crate::{
     backends::{
         common::{Backend, Context, Encoder, Kernels, kernel::TreeUpdateSolveKernel},
         cpu::Cpu,
+        metal::Metal,
     },
     data_type::DataType,
     tests::{
@@ -20,6 +21,26 @@ const BVS: &[u32] = &[16, 32];
 // MXU needs an even number of column fragments or MPP row pairing; BV16 (a single
 // 16x16 fragment) is not supported.
 const MXU_BVS: &[u32] = &[32];
+
+#[derive(Clone, Copy)]
+struct KernelPath {
+    name: &'static str,
+    use_mxu: bool,
+}
+
+fn bf16_kernel_paths(context: &<Metal as Backend>::Context) -> Vec<KernelPath> {
+    let mut paths = vec![KernelPath {
+        name: "Simdgroup",
+        use_mxu: false,
+    }];
+    if context.supports_mxu() {
+        paths.push(KernelPath {
+            name: "MXU",
+            use_mxu: true,
+        });
+    }
+    paths
+}
 
 #[derive(Clone, Copy)]
 struct SolveCase {
@@ -202,17 +223,23 @@ fn test_tree_update_solve_cases() {
 }
 
 #[uzu_test]
-fn test_tree_update_solve_mxu_cases() {
+fn test_tree_update_solve_bf16_paths() {
+    let context = <Metal as Backend>::Context::new().expect("context");
+    let paths = bf16_kernel_paths(&context);
     for &bv in MXU_BVS {
         for &use_h0 in &[true, false] {
             for &case in CASES {
                 let expected = run_case::<Cpu, bf16>(case, bv, false, use_h0, DataType::BF16, bf16::from_f32);
-                for_each_non_cpu_backend!(|B| {
-                    if <B as Backend>::Context::new().expect("context").supports_mxu() {
-                        let output = run_case::<B, bf16>(case, bv, true, use_h0, DataType::BF16, bf16::from_f32);
-                        assert_eq_float(&expected, &output, 1e-2, &format!("{} MXU BV{bv} h0={use_h0}", case.name));
-                    }
-                });
+                for path in &paths {
+                    let output =
+                        run_case::<Metal, bf16>(case, bv, path.use_mxu, use_h0, DataType::BF16, bf16::from_f32);
+                    assert_eq_float(
+                        &expected,
+                        &output,
+                        1e-2,
+                        &format!("{} {} BV{bv} h0={use_h0}", case.name, path.name),
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
- Since M3 chips, metal supports dynamic SM memory between register/threadgroup/buffer etc.
- Some cleanups

resource:
https://www.digitaltrends.com/computing/apple-dynamic-caching-explained/
https://developer.apple.com/videos/play/tech-talks/111375/?utm_source=chatgpt.com