### PR TITLE
Low batch suffix len tuning for dflash

### DIFF
--- a/crates/backend-uzu/src/backends/metal/kernel/matmul/gemm/kernel.rs
+++ b/crates/backend-uzu/src/backends/metal/kernel/matmul/gemm/kernel.rs
@@ -697,7 +697,7 @@ pub(crate) fn select_mxu_tiling(
                 GemmTiling::Tile32x64x256_Simdgroups2x2
             };
         }
-        return if m < 16 {
+        return if m <= 16 {
             select_small_m_mxu_tiling(n, k)
         } else {
             select_base_mxu_tiling(m, n)


### PR DESCRIPTION
4-7% faster gate/up/down.
no speedup on e2e dflash+weaver though