### PR TITLE
GPT-OSS MXFP4 MoE

### DIFF
--- a/crates/backend-uzu/src/backends/cpu/kernel/moe/counts_offsets_fused.rs
+++ b/crates/backend-uzu/src/backends/cpu/kernel/moe/counts_offsets_fused.rs
@@ -22,24 +22,37 @@ pub fn moe_counts_offsets_fused(
         return;
     }
 
-    // Phase 1: Count tokens per expert (histogram)
+    const SCATTER_BLOCK_SIZE: usize = 256;
+    const TILE_E: usize = 512;
+    let num_blocks = t.div_ceil(SCATTER_BLOCK_SIZE);
+    let num_tiles = e.div_ceil(TILE_E);
+
+    // Phase 1: Count tokens per expert and per scatter block.
     let mut counts = vec![0u32; e];
-    for ti in 0..t {
-        let base = ti * k;
-        for kk in 0..k {
-            let eid = unsafe { *topk_ids.add(base + kk) };
-            if eid >= 0 {
-                let ue = eid as usize;
-                if ue < e {
-                    counts[ue] += 1;
+    for block_id in 0..num_blocks {
+        let mut block_counts = vec![0u32; e];
+        let t_start = block_id * SCATTER_BLOCK_SIZE;
+        let t_end = (t_start + SCATTER_BLOCK_SIZE).min(t);
+        for ti in t_start..t_end {
+            let base = ti * k;
+            for kk in 0..k {
+                let eid = unsafe { *topk_ids.add(base + kk) };
+                if eid >= 0 {
+                    let ue = eid as usize;
+                    if ue < e {
+                        counts[ue] += 1;
+                        block_counts[ue] += 1;
+                    }
                 }
             }
         }
-    }
 
-    // Write partials (same as counts for single-threadgroup case)
-    for i in 0..e {
-        unsafe { *partials.add(i) = counts[i] };
+        for (expert_id, count) in block_counts.into_iter().enumerate() {
+            let tile_id = expert_id / TILE_E;
+            let tile_expert_id = expert_id % TILE_E;
+            let partial_idx = (block_id * num_tiles + tile_id) * TILE_E + tile_expert_id;
+            unsafe { *partials.add(partial_idx) = count };
+        }
     }
 
     // Phase 2: Exclusive prefix scan to produce offsets

--- a/crates/backend-uzu/src/backends/cpu/kernel/moe/experts_mxfp4_decode.rs
+++ b/crates/backend-uzu/src/backends/cpu/kernel/moe/experts_mxfp4_decode.rs
@@ -1,0 +1,54 @@
+use half::{bf16, f16};
+use num_traits::Float;
+use proc_macros::kernel;
+
+use crate::array::ArrayElement;
+
+#[kernel(MoeExpertsMxfp4DecodePassA)]
+#[variants(T, f32, f16, bf16)]
+pub fn moe_experts_mxfp4_decode_pass_a<T: ArrayElement + Float>(
+    #[allow(unused)] x_perm: *const T,
+    #[allow(unused)] expert_offsets: *const u32,
+    #[allow(unused)] w13_blocks: *const u8,
+    #[allow(unused)] w13_scales: *const u8,
+    #[allow(unused)] w13_global_scale: *const T,
+    #[allow(unused)] hidden_out: *mut f32,
+    #[allow(unused)] up_biases: *const T,
+    #[allow(unused)] d_model: u32,
+    #[allow(unused)] d_ff: u32,
+    #[allow(unused)] e: u32,
+    #[allow(unused)] gate_clip_min: f32,
+    #[allow(unused)] gate_clip_max: f32,
+    #[allow(unused)] up_clip_min: f32,
+    #[allow(unused)] up_clip_max: f32,
+    #[allow(unused)] silu_alpha: f32,
+    #[allow(unused)] tile_map: *const u32,
+    #[allow(unused)]
+    #[specialize]
+    gating_sel: u32,
+    #[allow(unused)] __dsl_indirect_dispatch_buffer: *const u32,
+) {
+    // CPU indirect MoE dispatch is not implemented for either dense or packed experts.
+    todo!()
+}
+
+#[kernel(MoeExpertsMxfp4DecodeDownFused2D)]
+#[variants(T, f32, f16, bf16)]
+#[variants(AccumT, f32)]
+#[allow(clippy::extra_unused_type_parameters)]
+pub fn moe_experts_mxfp4_decode_down_fused2_d<T: ArrayElement + Float, AccumT: ArrayElement + Float>(
+    #[allow(unused)] hidden: *const f32,
+    #[allow(unused)] row_expert_map: *const u32,
+    #[allow(unused)] w2_blocks: *const u8,
+    #[allow(unused)] w2_scales: *const u8,
+    #[allow(unused)] w2_global_scale: *const T,
+    #[allow(unused)] down_biases: *const T,
+    #[allow(unused)] y_out: *mut T,
+    #[allow(unused)] total_rows: u32,
+    #[allow(unused)] d_model: u32,
+    #[allow(unused)] d_ff: u32,
+    #[allow(unused)] e: u32,
+) {
+    // Kept aligned with the existing dense decode path until CPU indirect dispatch exists.
+    todo!()
+}

--- a/crates/backend-uzu/src/backends/cpu/kernel/moe/experts_mxfp4_prefill.rs
+++ b/crates/backend-uzu/src/backends/cpu/kernel/moe/experts_mxfp4_prefill.rs
@@ -1,0 +1,53 @@
+use half::{bf16, f16};
+use num_traits::Float;
+use proc_macros::kernel;
+
+use crate::array::ArrayElement;
+
+#[kernel(MoeExpertsMxfp4PrefillPassA)]
+#[variants(T, f32, f16, bf16)]
+pub fn moe_experts_mxfp4_prefill_pass_a<T: ArrayElement + Float>(
+    #[allow(unused)] x_perm: *const T,
+    #[allow(unused)] expert_offsets: *const u32,
+    #[allow(unused)] w13_blocks: *const u8,
+    #[allow(unused)] w13_scales: *const u8,
+    #[allow(unused)] w13_global_scale: *const T,
+    #[allow(unused)] up_biases: *const T,
+    #[allow(unused)] hidden_out: *mut f32,
+    #[allow(unused)] d_model: u32,
+    #[allow(unused)] d_ff: u32,
+    #[allow(unused)] e: u32,
+    #[allow(unused)] gate_clip_min: f32,
+    #[allow(unused)] gate_clip_max: f32,
+    #[allow(unused)] up_clip_min: f32,
+    #[allow(unused)] up_clip_max: f32,
+    #[allow(unused)] silu_alpha: f32,
+    #[allow(unused)] tile_map: *const u32,
+    #[allow(unused)]
+    #[specialize]
+    gating_sel: u32,
+    #[allow(unused)] __dsl_indirect_dispatch_buffer: *const u32,
+) {
+    // CPU indirect MoE dispatch is not implemented for either dense or packed experts.
+    todo!()
+}
+
+#[kernel(MoeExpertsMxfp4PrefillPassB)]
+#[variants(T, f32, f16, bf16)]
+pub fn moe_experts_mxfp4_prefill_pass_b<T: ArrayElement + Float>(
+    #[allow(unused)] hidden: *const f32,
+    #[allow(unused)] expert_offsets: *const u32,
+    #[allow(unused)] w2_blocks: *const u8,
+    #[allow(unused)] w2_scales: *const u8,
+    #[allow(unused)] w2_global_scale: *const T,
+    #[allow(unused)] down_biases: *const T,
+    #[allow(unused)] output: *mut T,
+    #[allow(unused)] d_model: u32,
+    #[allow(unused)] d_ff: u32,
+    #[allow(unused)] e: u32,
+    #[allow(unused)] tile_map: *const u32,
+    #[allow(unused)] __dsl_indirect_dispatch_buffer: *const u32,
+) {
+    // CPU indirect MoE dispatch is not implemented for either dense or packed experts.
+    todo!()
+}

--- a/crates/backend-uzu/src/backends/cpu/kernel/moe/mod.rs
+++ b/crates/backend-uzu/src/backends/cpu/kernel/moe/mod.rs
@@ -1,4 +1,6 @@
 pub mod counts_offsets_fused;
+pub mod experts_mxfp4_decode;
+pub mod experts_mxfp4_prefill;
 pub mod experts_two_pass_decode;
 pub mod experts_two_pass_prefill;
 pub mod finalize;

--- a/crates/backend-uzu/src/backends/cpu/kernel/moe/tiles_map.rs
+++ b/crates/backend-uzu/src/backends/cpu/kernel/moe/tiles_map.rs
@@ -5,6 +5,7 @@ pub fn moe_tile_counts(
     #[allow(unused)] offsets: *const u32,
     #[allow(unused)] tile_counts: *mut u32,
     #[allow(unused)] e: u32,
+    #[allow(unused)] row_tile_size: u32,
 ) {
     todo!()
 }
@@ -26,6 +27,7 @@ pub fn moe_build_tile_map(
     #[allow(unused)] tile_counts: *const u32,
     #[allow(unused)] tile_map: *mut u32,
     #[allow(unused)] e: u32,
+    #[allow(unused)] row_tile_size: u32,
 ) {
     todo!()
 }

--- a/crates/backend-uzu/src/backends/metal/kernel/moe/counts_offsets_fused.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/moe/counts_offsets_fused.metal
@@ -36,6 +36,7 @@ static T threadgroup_raking_prefix_exclusive_sum(T value, threadgroup T* shared,
 }
 
 #define BLOCK_SIZE 128
+#define SCATTER_BLOCK_SIZE 256
 #define TILE_E 512
 
 // Single-kernel fused: count all experts + scan to offsets
@@ -44,14 +45,14 @@ PUBLIC KERNEL(MoeCountsOffsetsFused)(
     device const int* topk_ids,
     device uint* offsets,   // output: exclusive scan [E+1]
     device uint* sum_k_out, // output: total count [1]
-    device uint* partials,  // output: partials [num_tiles * TILE_E] (for block_bases)
+    device uint* partials,  // output: partials [num_blocks * num_tiles * TILE_E] (for block_bases)
     constant uint& t_input,
     constant uint& e_input,
     constant uint& k_input,
     threadgroup _atomic<uint> tg_hist[TILE_E],
     threadgroup uint scan_shared[BLOCK_SIZE],
     threadgroup uint reduce_shared[BLOCK_SIZE],
-    threadgroup uint counts_shared[BLOCK_SIZE], // Cache counts in threadgroup memory
+    threadgroup uint counts_shared[TILE_E], // Cache global counts in threadgroup memory
     threadgroup uint& carry,
     const ThreadContext thread_context,
     const uint lid THREADS(128)
@@ -67,40 +68,51 @@ PUBLIC KERNEL(MoeCountsOffsetsFused)(
   // ═══════════════════════════════════════════════════════════
   // PHASE 1: Count tokens per expert using tiled histogram
   // ═══════════════════════════════════════════════════════════
-  // Tile over E dimension
+  const uint num_blocks = (t_input + SCATTER_BLOCK_SIZE - 1) / SCATTER_BLOCK_SIZE;
+  const uint num_tiles = (e_input + TILE_E - 1) / TILE_E;
+
+  // Tile over E dimension.
   for (uint e0 = 0; e0 < e_input; e0 += TILE_E) {
     const uint tile_e = (e0 + TILE_E <= e_input) ? TILE_E : (e_input - e0);
+    const uint tile_id = e0 / TILE_E;
 
-    // Zero threadgroup histogram
     for (uint e = lid; e < tile_e; e += BLOCK_SIZE) {
-      atomic_store_explicit(&tg_hist[e], 0u, memory_order_relaxed);
+      counts_shared[e0 + e] = 0u;
     }
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    // Process all tokens in strided fashion
-    // Since we have only 1 threadgroup, we need to cover all T tokens
-    for (uint t = lid; t < t_input; t += BLOCK_SIZE) {
-      const uint base = t * k_input;
-      for (uint k = 0; k < k_input; ++k) {
-        int eid = topk_ids[base + k];
-        if (eid >= 0) {
-          uint ue = uint(eid);
-          if (ue >= e0 && ue < e0 + tile_e) {
-            uint te = ue - e0;
-            atomic_fetch_add_explicit(&tg_hist[te], 1u, memory_order_relaxed);
+    // Scatter consumes one partial histogram per 256-token block.
+    for (uint block_id = 0; block_id < num_blocks; ++block_id) {
+      for (uint e = lid; e < tile_e; e += BLOCK_SIZE) {
+        atomic_store_explicit(&tg_hist[e], 0u, memory_order_relaxed);
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+
+      const uint t_start = block_id * SCATTER_BLOCK_SIZE;
+      const uint t_end = min(t_start + SCATTER_BLOCK_SIZE, t_input);
+      for (uint t = t_start + lid; t < t_end; t += BLOCK_SIZE) {
+        const uint base = t * k_input;
+        for (uint k = 0; k < k_input; ++k) {
+          int eid = topk_ids[base + k];
+          if (eid >= 0) {
+            uint ue = uint(eid);
+            if (ue >= e0 && ue < e0 + tile_e) {
+              uint te = ue - e0;
+              atomic_fetch_add_explicit(&tg_hist[te], 1u, memory_order_relaxed);
+            }
           }
         }
       }
-    }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
+      threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    // Write final counts and partials for this tile
-    for (uint e = lid; e < tile_e; e += BLOCK_SIZE) {
-      const uint count_val = atomic_load_explicit(&tg_hist[e], memory_order_relaxed);
-      counts_shared[e0 + e] = count_val;
-      partials[e0 + e] = count_val;
+      for (uint e = lid; e < tile_e; e += BLOCK_SIZE) {
+        const uint count_val = atomic_load_explicit(&tg_hist[e], memory_order_relaxed);
+        counts_shared[e0 + e] += count_val;
+        const uint partial_idx = (block_id * num_tiles + tile_id) * TILE_E + e;
+        partials[partial_idx] = count_val;
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
     }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
   }
 
   // ═══════════════════════════════════════════════════════════
@@ -115,7 +127,7 @@ PUBLIC KERNEL(MoeCountsOffsetsFused)(
     uint remaining = e_input - base;
     uint chunk_n = remaining < BLOCK_SIZE ? remaining : BLOCK_SIZE;
 
-    uint v = (lid < chunk_n) ? counts_shared[lid] : 0u;
+    uint v = (lid < chunk_n) ? counts_shared[base + lid] : 0u;
 
     uint prefix_local = threadgroup_raking_prefix_exclusive_sum<BLOCK_SIZE>(v, scan_shared, (ushort)lid);
     uint prefix_global = prefix_local + carry;

--- a/crates/backend-uzu/src/backends/metal/kernel/moe/experts_mxfp4_decode.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/moe/experts_mxfp4_decode.metal
@@ -1,0 +1,411 @@
+#include <metal_stdlib>
+#include <metal_simdgroup>
+#include "../activation/activations.h"
+#include "../common/dsl.h"
+#include "../common/thread_context.h"
+using namespace metal;
+
+constant float MXFP4_VALUES[16] = {
+    0.0f,
+    0.5f,
+    1.0f,
+    1.5f,
+    2.0f,
+    3.0f,
+    4.0f,
+    6.0f,
+    -0.0f,
+    -0.5f,
+    -1.0f,
+    -1.5f,
+    -2.0f,
+    -3.0f,
+    -4.0f,
+    -6.0f,
+};
+
+/// E8M0 is an IEEE-754 exponent byte with an implicit unit mantissa.
+inline float e8m0_scale(const uchar exponent) {
+  const uint bits = exponent == 0 ? 0x00400000u : uint(exponent) << 23;
+  return as_type<float>(bits);
+}
+
+/// Tail-only scalar access for fixture dimensions smaller than one MXFP4 group.
+inline float mxfp4_value(
+    device const uchar* blocks,
+    device const uchar* scales,
+    const ulong row,
+    const uint groups_per_row,
+    const uint group,
+    const uint element_in_group
+) {
+  const ulong group_offset = row * (ulong)groups_per_row + group;
+  const uchar packed = blocks[group_offset * 16 + element_in_group / 2];
+  const uchar code = element_in_group % 2 == 0 ? packed & 0x0f : packed >> 4;
+  return e8m0_scale(scales[group_offset]) * MXFP4_VALUES[code];
+}
+
+/// Two lanes consume one 32-value group without redundantly loading its scale 16 times.
+inline float dot_mxfp4_16(
+    device const uchar* blocks,
+    device const uchar* scales,
+    threadgroup const float* values,
+    const ulong row,
+    const uint groups_per_row,
+    const uint group,
+    const uint half_group,
+    const float4 x0,
+    const float4 x1,
+    const float4 x2,
+    const float4 x3
+) {
+  const ulong block_offset = (row * (ulong)groups_per_row + group) * 16;
+  device const uchar* packed = blocks + block_offset + half_group * 8;
+  const float scale = e8m0_scale(scales[row * (ulong)groups_per_row + group]);
+
+  const float4 even0 = float4(x0.x, x0.z, x1.x, x1.z);
+  const float4 odd0 = float4(x0.y, x0.w, x1.y, x1.w);
+  const float4 even1 = float4(x2.x, x2.z, x3.x, x3.z);
+  const float4 odd1 = float4(x2.y, x2.w, x3.y, x3.w);
+  const float4 weights_even0 = float4(
+      values[packed[0] & 0x0f],
+      values[packed[1] & 0x0f],
+      values[packed[2] & 0x0f],
+      values[packed[3] & 0x0f]
+  );
+  const float4 weights_odd0 = float4(
+      values[packed[0] >> 4],
+      values[packed[1] >> 4],
+      values[packed[2] >> 4],
+      values[packed[3] >> 4]
+  );
+  const float4 weights_even1 = float4(
+      values[packed[4] & 0x0f],
+      values[packed[5] & 0x0f],
+      values[packed[6] & 0x0f],
+      values[packed[7] & 0x0f]
+  );
+  const float4 weights_odd1 = float4(
+      values[packed[4] >> 4],
+      values[packed[5] >> 4],
+      values[packed[6] >> 4],
+      values[packed[7] >> 4]
+  );
+  return scale *
+         (dot(even0, weights_even0) + dot(odd0, weights_odd0) + dot(even1, weights_even1) + dot(odd1, weights_odd1));
+}
+
+/// One lane consumes one complete 16-value group.
+inline float dot_mxfp4_group16(
+    device const uchar* blocks,
+    device const uchar* scales,
+    threadgroup const float* values,
+    const ulong row,
+    const uint groups_per_row,
+    const uint group,
+    const float4 x0,
+    const float4 x1,
+    const float4 x2,
+    const float4 x3
+) {
+  const ulong group_offset = row * (ulong)groups_per_row + group;
+  device const uchar* packed = blocks + group_offset * 8;
+  const float scale = e8m0_scale(scales[group_offset]);
+
+  const float4 even0 = float4(x0.x, x0.z, x1.x, x1.z);
+  const float4 odd0 = float4(x0.y, x0.w, x1.y, x1.w);
+  const float4 even1 = float4(x2.x, x2.z, x3.x, x3.z);
+  const float4 odd1 = float4(x2.y, x2.w, x3.y, x3.w);
+  const float4 weights_even0 = float4(
+      values[packed[0] & 0x0f],
+      values[packed[1] & 0x0f],
+      values[packed[2] & 0x0f],
+      values[packed[3] & 0x0f]
+  );
+  const float4 weights_odd0 = float4(
+      values[packed[0] >> 4],
+      values[packed[1] >> 4],
+      values[packed[2] >> 4],
+      values[packed[3] >> 4]
+  );
+  const float4 weights_even1 = float4(
+      values[packed[4] & 0x0f],
+      values[packed[5] & 0x0f],
+      values[packed[6] & 0x0f],
+      values[packed[7] & 0x0f]
+  );
+  const float4 weights_odd1 = float4(
+      values[packed[4] >> 4],
+      values[packed[5] >> 4],
+      values[packed[6] >> 4],
+      values[packed[7] >> 4]
+  );
+  return scale *
+         (dot(even0, weights_even0) + dot(odd0, weights_odd0) + dot(even1, weights_even1) + dot(odd1, weights_odd1));
+}
+
+/// GPT-OSS clips each projection before applying its selected gated activation.
+inline float activate_expert_value(
+    const float acc_up,
+    const float acc_gate,
+    const float up_bias,
+    const float gate_bias,
+    const float gate_clip_min,
+    const float gate_clip_max,
+    const float up_clip_min,
+    const float up_clip_max,
+    const float silu_alpha,
+    const uint gating_sel
+) {
+  const float up = clamp(acc_up + up_bias, up_clip_min, up_clip_max);
+  if (gating_sel <= 1)
+    return gating_sel == 0 ? activate_gelu(up) : activate_silu_alpha(up, silu_alpha);
+
+  const float gate = clamp(acc_gate + gate_bias, gate_clip_min, gate_clip_max);
+  const float gate_activated = gating_sel == 2 ? activate_silu_alpha(gate, silu_alpha) : activate_gelu(gate);
+  return gate_activated * up;
+}
+
+// Adjacent output rows share each activation load while retaining independent reductions.
+template <typename T>
+VARIANTS(T, float, half, bfloat)
+PUBLIC KERNEL(MoeExpertsMxfp4DecodePassA)(
+    device const T* x_perm,
+    device const uint* expert_offsets,
+    device const uchar* w13_blocks,
+    device const uchar* w13_scales,
+    device const T* w13_global_scale,
+    device float* hidden_out,
+    device const T* up_biases,
+    constant uint& d_model,
+    constant uint& d_ff,
+    constant uint& e,
+    constant float& gate_clip_min,
+    constant float& gate_clip_max,
+    constant float& up_clip_min,
+    constant float& up_clip_max,
+    constant float& silu_alpha,
+    device const uint* tile_map,
+    threadgroup float mxfp4_values[16],
+    const uint gating_sel SPECIALIZE,
+    const ThreadContext thread_context,
+    const uint tile_idx GROUPS(INDIRECT),
+    const uint tid THREADS(128)
+) {
+  if (tid < 16)
+    mxfp4_values[tid] = MXFP4_VALUES[tid];
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  const uint h_block_idx = tile_map[tile_idx * 3 + 0];
+  const uint expert_idx = tile_map[tile_idx * 3 + 1];
+  const uint row_in_expert = tile_map[tile_idx * 3 + 2];
+
+  const uint segment_start = expert_offsets[expert_idx];
+  const uint segment_end = expert_offsets[expert_idx + 1];
+  const uint global_row = segment_start + row_in_expert;
+  if (global_row >= segment_end)
+    return;
+
+  const uint h_idx0 = h_block_idx * 8 + thread_context.simdgroup_index * 2;
+  if (h_idx0 >= d_ff)
+    return;
+  const uint h_idx1 = h_idx0 + 1;
+  const bool has_second_output = h_idx1 < d_ff;
+
+  const uint groups_per_row = (d_model + 15) / 16;
+  const ulong rows_per_expert = (ulong)(2 * d_ff);
+  const ulong expert_row_base = (ulong)expert_idx * rows_per_expert;
+  const ulong up_row0 = expert_row_base + h_idx0;
+  const ulong gate_row0 = expert_row_base + d_ff + h_idx0;
+  const ulong up_row1 = expert_row_base + h_idx1;
+  const ulong gate_row1 = expert_row_base + d_ff + h_idx1;
+  const ulong x_row_base = (ulong)global_row * d_model;
+
+  float acc_up0 = 0.0f;
+  float acc_gate0 = 0.0f;
+  float acc_up1 = 0.0f;
+  float acc_gate1 = 0.0f;
+  const uint group_lane = thread_context.simd_lane_id;
+  using Vec4 = typename metal::vec<T, 4>;
+  for (uint group_base = 0; group_base < groups_per_row; group_base += 32) {
+    const uint group = group_base + group_lane;
+    if (group >= groups_per_row)
+      continue;
+
+    const uint element = group * 16;
+    if (element + 15 >= d_model)
+      continue;
+
+    device const Vec4* x = reinterpret_cast<device const Vec4*>(x_perm + x_row_base + element);
+    const float4 x0 = float4(x[0]);
+    const float4 x1 = float4(x[1]);
+    const float4 x2 = float4(x[2]);
+    const float4 x3 = float4(x[3]);
+    acc_up0 +=
+        dot_mxfp4_group16(w13_blocks, w13_scales, mxfp4_values, up_row0, groups_per_row, group, x0, x1, x2, x3);
+    if (gating_sel > 1) {
+      acc_gate0 +=
+          dot_mxfp4_group16(w13_blocks, w13_scales, mxfp4_values, gate_row0, groups_per_row, group, x0, x1, x2, x3);
+    }
+    if (has_second_output) {
+      acc_up1 +=
+          dot_mxfp4_group16(w13_blocks, w13_scales, mxfp4_values, up_row1, groups_per_row, group, x0, x1, x2, x3);
+      if (gating_sel > 1) {
+        acc_gate1 +=
+            dot_mxfp4_group16(w13_blocks, w13_scales, mxfp4_values, gate_row1, groups_per_row, group, x0, x1, x2, x3);
+      }
+    }
+  }
+
+  acc_up0 = simd_sum(acc_up0);
+  acc_up1 = simd_sum(acc_up1);
+  if (gating_sel > 1) {
+    acc_gate0 = simd_sum(acc_gate0);
+    acc_gate1 = simd_sum(acc_gate1);
+  }
+  const float global_scale = float(w13_global_scale[expert_idx]);
+  acc_up0 *= global_scale;
+  acc_gate0 *= global_scale;
+  acc_up1 *= global_scale;
+  acc_gate1 *= global_scale;
+
+  if (thread_context.simd_lane_id != 0)
+    return;
+
+  const float activated0 = activate_expert_value(
+      acc_up0,
+      acc_gate0,
+      float(up_biases[up_row0]),
+      float(up_biases[gate_row0]),
+      gate_clip_min,
+      gate_clip_max,
+      up_clip_min,
+      up_clip_max,
+      silu_alpha,
+      gating_sel
+  );
+  hidden_out[(ulong)global_row * d_ff + h_idx0] = activated0;
+  if (!has_second_output)
+    return;
+
+  const float activated1 = activate_expert_value(
+      acc_up1,
+      acc_gate1,
+      float(up_biases[up_row1]),
+      float(up_biases[gate_row1]),
+      gate_clip_min,
+      gate_clip_max,
+      up_clip_min,
+      up_clip_max,
+      silu_alpha,
+      gating_sel
+  );
+  hidden_out[(ulong)global_row * d_ff + h_idx1] = activated1;
+}
+
+#define THREADS_PER_SIMD 32
+#define SIMDGROUPS_PER_TG 4
+#define OUTPUTS_PER_SIMDGROUP 2
+#define OUTPUTS_PER_TG 8
+
+// The down projection decodes only the values consumed by the dot product;
+// no dense expert weight buffer is allocated on either side of this kernel.
+template <typename T, typename AccumT>
+VARIANTS(T, float, half, bfloat)
+VARIANTS(AccumT, float)
+PUBLIC KERNEL(MoeExpertsMxfp4DecodeDownFused2D)(
+    device const float* hidden,
+    device const uint* row_expert_map,
+    device const uchar* w2_blocks,
+    device const uchar* w2_scales,
+    device const T* w2_global_scale,
+    device const T* down_biases,
+    device T* y_out,
+    constant uint& total_rows,
+    constant uint& d_model,
+    constant uint& d_ff,
+    constant uint& e,
+    threadgroup float mxfp4_values[16],
+    const ThreadContext thread_context,
+    const uint tgpig_x GROUPS(d_model.div_ceil(OUTPUTS_PER_TG)),
+    const uint tgpig_y GROUPS(total_rows),
+    const uint tid THREADS(128)
+) {
+  if (tid < 16)
+    mxfp4_values[tid] = MXFP4_VALUES[tid];
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  const uint row_idx = tgpig_y;
+  const uint output_idx0 = tgpig_x * OUTPUTS_PER_TG + thread_context.simdgroup_index * OUTPUTS_PER_SIMDGROUP;
+  if (output_idx0 >= d_model)
+    return;
+  const uint output_idx1 = output_idx0 + 1;
+  const bool has_second_output = output_idx1 < d_model;
+
+  const uint expert_idx = row_expert_map[row_idx];
+  const uint groups_per_row = (d_ff + 31) / 32;
+  const ulong weight_row0 = (ulong)expert_idx * d_model + output_idx0;
+  const ulong weight_row1 = (ulong)expert_idx * d_model + output_idx1;
+  const ulong hidden_base = (ulong)row_idx * d_ff;
+
+  AccumT acc0 = AccumT(0.0);
+  AccumT acc1 = AccumT(0.0);
+  const uint group_lane = thread_context.simd_lane_id / 2;
+  const uint half_group = thread_context.simd_lane_id % 2;
+  for (uint group_base = 0; group_base < groups_per_row; group_base += 16) {
+    const uint group = group_base + group_lane;
+    if (group >= groups_per_row)
+      continue;
+
+    const uint element = group * 32 + half_group * 16;
+    if (element >= d_ff)
+      continue;
+
+    if (element + 15 >= d_ff) {
+      for (uint offset = 0; offset < 16 && element + offset < d_ff; ++offset) {
+        const float value = hidden[hidden_base + element + offset];
+        acc0 += AccumT(value * mxfp4_value(
+                                  w2_blocks, w2_scales, weight_row0, groups_per_row, group, half_group * 16 + offset
+                              ));
+        if (has_second_output) {
+          acc1 += AccumT(value * mxfp4_value(
+                                    w2_blocks, w2_scales, weight_row1, groups_per_row, group, half_group * 16 + offset
+                                ));
+        }
+      }
+      continue;
+    }
+
+    device const float4* values = reinterpret_cast<device const float4*>(hidden + hidden_base + element);
+    const float4 x0 = values[0];
+    const float4 x1 = values[1];
+    const float4 x2 = values[2];
+    const float4 x3 = values[3];
+    acc0 += AccumT(
+        dot_mxfp4_16(
+            w2_blocks, w2_scales, mxfp4_values, weight_row0, groups_per_row, group, half_group, x0, x1, x2, x3
+        )
+    );
+    if (has_second_output) {
+      acc1 += AccumT(
+          dot_mxfp4_16(
+              w2_blocks, w2_scales, mxfp4_values, weight_row1, groups_per_row, group, half_group, x0, x1, x2, x3
+          )
+      );
+    }
+  }
+
+  const AccumT global_scale = AccumT(w2_global_scale[expert_idx]);
+  AccumT result0 = simd_sum(acc0) * global_scale;
+  AccumT result1 = simd_sum(acc1) * global_scale;
+  if (thread_context.simd_lane_id != 0)
+    return;
+
+  result0 += AccumT(down_biases[(ulong)expert_idx * d_model + output_idx0]);
+  y_out[(ulong)row_idx * d_model + output_idx0] = T(result0);
+  if (!has_second_output)
+    return;
+
+  result1 += AccumT(down_biases[(ulong)expert_idx * d_model + output_idx1]);
+  y_out[(ulong)row_idx * d_model + output_idx1] = T(result1);
+}

--- a/crates/backend-uzu/src/backends/metal/kernel/moe/experts_mxfp4_prefill.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/moe/experts_mxfp4_prefill.metal
@@ -1,0 +1,436 @@
+#include <metal_stdlib>
+#include <metal_simdgroup>
+#include "../activation/activations.h"
+#include "../common/defines.h"
+#include "../common/dsl.h"
+#include "../common/thread_context.h"
+using namespace metal;
+
+constant float MXFP4_PREFILL_VALUES[16] = {
+    0.0f,
+    0.5f,
+    1.0f,
+    1.5f,
+    2.0f,
+    3.0f,
+    4.0f,
+    6.0f,
+    -0.0f,
+    -0.5f,
+    -1.0f,
+    -1.5f,
+    -2.0f,
+    -3.0f,
+    -4.0f,
+    -6.0f,
+};
+
+/// E8M0 is an IEEE-754 exponent byte with an implicit unit mantissa.
+inline float mxfp4_prefill_e8m0_scale(const uchar exponent) {
+  const uint bits = exponent == 0 ? 0x00400000u : uint(exponent) << 23;
+  return as_type<float>(bits);
+}
+
+/// One cooperative load expands eight packed values into an MMA-ready tile.
+template <typename T>
+inline void stage_mxfp4_eight(
+    device const uchar* blocks,
+    device const uchar* scales,
+    threadgroup const float* values,
+    threadgroup T* destination,
+    const ulong weight_row,
+    const uint groups_per_row,
+    const uint group_size,
+    const uint element,
+    const uint dimension,
+    const float global_scale
+) {
+  if (element >= dimension) {
+    METAL_PRAGMA_UNROLL
+    for (uint index = 0; index < 8; ++index)
+      destination[index] = T(0.0f);
+    return;
+  }
+
+  const uint group = element / group_size;
+  const uint pair = (element % group_size) / 2;
+  const ulong group_offset = weight_row * (ulong)groups_per_row + group;
+  const ulong block_offset = group_offset * (group_size / 2) + pair;
+  const float scale = global_scale * mxfp4_prefill_e8m0_scale(scales[group_offset]);
+  const uchar4 packed_values = *reinterpret_cast<device const uchar4*>(blocks + block_offset);
+  METAL_PRAGMA_UNROLL
+  for (uint pair_index = 0; pair_index < 4; ++pair_index) {
+    const uchar packed = packed_values[pair_index];
+    const uint output = pair_index * 2;
+    destination[output] = T(scale * values[packed & 0x0f]);
+    destination[output + 1] = element + output + 1 < dimension ? T(scale * values[packed >> 4]) : T(0.0f);
+  }
+}
+
+/// GPT-OSS clips each projection before applying its selected gated activation.
+inline float activate_mxfp4_prefill_value(
+    const float acc_up,
+    const float acc_gate,
+    const float up_bias,
+    const float gate_bias,
+    const float gate_clip_min,
+    const float gate_clip_max,
+    const float up_clip_min,
+    const float up_clip_max,
+    const float silu_alpha,
+    const uint gating_sel
+) {
+  const float up = clamp(acc_up + up_bias, up_clip_min, up_clip_max);
+  if (gating_sel <= 1)
+    return gating_sel == 0 ? activate_gelu(up) : activate_silu_alpha(up, silu_alpha);
+
+  const float gate = clamp(acc_gate + gate_bias, gate_clip_min, gate_clip_max);
+  const float gate_activated = gating_sel == 2 ? activate_silu_alpha(gate, silu_alpha) : activate_gelu(gate);
+  return gate_activated * up;
+}
+
+constant uint MXFP4_PASSA_BM = 16;
+constant uint MXFP4_PASSA_BN = 32;
+constant uint MXFP4_PASSA_BK = 32;
+constant uint MXFP4_PASSA_LD = 36;
+constant uint MXFP4_PASSA_ROW_FRAGMENTS = 2;
+
+// Each packed weight tile is expanded once and reused by up to 16 routed rows.
+template <typename T>
+VARIANTS(T, float, half, bfloat)
+PUBLIC KERNEL(MoeExpertsMxfp4PrefillPassA)(
+    device const T* x_perm,
+    device const uint* expert_offsets,
+    device const uchar* w13_blocks,
+    device const uchar* w13_scales,
+    device const T* w13_global_scale,
+    device const T* up_biases,
+    device float* hidden_out,
+    constant uint& d_model,
+    constant uint& d_ff,
+    constant uint& e,
+    constant float& gate_clip_min,
+    constant float& gate_clip_max,
+    constant float& up_clip_min,
+    constant float& up_clip_max,
+    constant float& silu_alpha,
+    device const uint* tile_map,
+    threadgroup float mxfp4_values[16],
+    threadgroup T Xs[MXFP4_PASSA_BM * MXFP4_PASSA_LD],
+    threadgroup T Wk_up[MXFP4_PASSA_BN * MXFP4_PASSA_LD],
+    threadgroup T Wk_gate[MXFP4_PASSA_BN * MXFP4_PASSA_LD],
+    const uint gating_sel SPECIALIZE,
+    const uint n_tile_idx GROUPS(INDIRECT),
+    const uint row_tile_idx GROUPS(INDIRECT),
+    const uint lin THREADS(128),
+    const ThreadContext thread_context
+) {
+  if (lin < 16)
+    mxfp4_values[lin] = MXFP4_PREFILL_VALUES[lin];
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  const uint map_offset = row_tile_idx * 3;
+  const uint expert_idx = tile_map[map_offset];
+  if (expert_idx >= e)
+    return;
+
+  const uint segment_start = expert_offsets[expert_idx];
+  const uint segment_end = expert_offsets[expert_idx + 1];
+  const uint segment_length = segment_end - segment_start;
+  if (segment_length == 0)
+    return;
+
+  const uint row_tile_offset = tile_map[map_offset + 2];
+  const uint column_tile_offset = n_tile_idx * MXFP4_PASSA_BN;
+  if (row_tile_offset >= segment_length || column_tile_offset >= d_ff)
+    return;
+
+  const uint row_count = min(MXFP4_PASSA_BM, segment_length - row_tile_offset);
+  const uint column_count = min(MXFP4_PASSA_BN, d_ff - column_tile_offset);
+  const uint groups_per_row = d_model / 16;
+  const ulong expert_row_base = (ulong)expert_idx * (2 * d_ff);
+  const float global_scale = float(w13_global_scale[expert_idx]);
+
+  const uint column_simdgroup = thread_context.simdgroup_index;
+  metal::simdgroup_float8x8 output_up[MXFP4_PASSA_ROW_FRAGMENTS];
+  metal::simdgroup_float8x8 output_gate[MXFP4_PASSA_ROW_FRAGMENTS];
+  METAL_PRAGMA_UNROLL
+  for (uint row_fragment = 0; row_fragment < MXFP4_PASSA_ROW_FRAGMENTS; ++row_fragment) {
+    output_up[row_fragment] = metal::make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    output_gate[row_fragment] = metal::make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+  }
+
+  for (uint k_offset = 0; k_offset < d_model; k_offset += MXFP4_PASSA_BK) {
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint input_index = lin; input_index < MXFP4_PASSA_BM * 4; input_index += 128) {
+      const uint row = input_index / 4;
+      const uint element_offset = (input_index % 4) * 8;
+      threadgroup T* x_destination = Xs + row * MXFP4_PASSA_LD + element_offset;
+      if (row < row_count) {
+        const ulong input_base = (ulong)(segment_start + row_tile_offset + row) * d_model + k_offset + element_offset;
+        METAL_PRAGMA_UNROLL
+        for (uint index = 0; index < 8; ++index)
+          x_destination[index] = T(float(x_perm[input_base + index]));
+      } else {
+        METAL_PRAGMA_UNROLL
+        for (uint index = 0; index < 8; ++index)
+          x_destination[index] = T(0.0f);
+      }
+    }
+
+    if (lin < MXFP4_PASSA_BN * 4) {
+      const uint column = lin / 4;
+      const uint element_offset = (lin % 4) * 8;
+      const uint global_column = column_tile_offset + column;
+      threadgroup T* up_destination = Wk_up + column * MXFP4_PASSA_LD + element_offset;
+      threadgroup T* gate_destination = Wk_gate + column * MXFP4_PASSA_LD + element_offset;
+      if (column < column_count) {
+        const ulong up_row = expert_row_base + global_column;
+        const ulong gate_row = expert_row_base + d_ff + global_column;
+        stage_mxfp4_eight(
+            w13_blocks,
+            w13_scales,
+            mxfp4_values,
+            up_destination,
+            up_row,
+            groups_per_row,
+            16,
+            k_offset + element_offset,
+            d_model,
+            global_scale
+        );
+        if (gating_sel > 1) {
+          stage_mxfp4_eight(
+              w13_blocks,
+              w13_scales,
+              mxfp4_values,
+              gate_destination,
+              gate_row,
+              groups_per_row,
+              16,
+              k_offset + element_offset,
+              d_model,
+              global_scale
+          );
+        }
+      } else {
+        METAL_PRAGMA_UNROLL
+        for (uint index = 0; index < 8; ++index) {
+          up_destination[index] = T(0.0f);
+          gate_destination[index] = T(0.0f);
+        }
+      }
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    METAL_PRAGMA_UNROLL
+    for (uint k = 0; k < MXFP4_PASSA_BK; k += 8) {
+      metal::simdgroup_matrix<T, 8, 8> rhs_up;
+      simdgroup_load(rhs_up, Wk_up, MXFP4_PASSA_LD, ulong2(k, column_simdgroup * 8), true);
+      metal::simdgroup_matrix<T, 8, 8> rhs_gate;
+      if (gating_sel > 1) {
+        simdgroup_load(rhs_gate, Wk_gate, MXFP4_PASSA_LD, ulong2(k, column_simdgroup * 8), true);
+      }
+      METAL_PRAGMA_UNROLL
+      for (uint row_fragment = 0; row_fragment < MXFP4_PASSA_ROW_FRAGMENTS; ++row_fragment) {
+        metal::simdgroup_matrix<T, 8, 8> lhs;
+        const uint row = row_fragment * 8;
+        simdgroup_load(lhs, Xs, MXFP4_PASSA_LD, ulong2(k, row));
+        simdgroup_multiply_accumulate(output_up[row_fragment], lhs, rhs_up, output_up[row_fragment]);
+        if (gating_sel > 1)
+          simdgroup_multiply_accumulate(output_gate[row_fragment], lhs, rhs_gate, output_gate[row_fragment]);
+      }
+    }
+  }
+
+  const uint lane_quadrant = thread_context.simd_lane_id >> 2;
+  const uint lane_row = (lane_quadrant & 4) + ((thread_context.simd_lane_id >> 1) & 3);
+  const uint lane_column = ((lane_quadrant & 2) * 2) + ((thread_context.simd_lane_id & 1) * 2);
+  const uint local_column = column_simdgroup * 8 + lane_column;
+  if (local_column >= column_count)
+    return;
+
+  METAL_PRAGMA_UNROLL
+  for (uint row_fragment = 0; row_fragment < MXFP4_PASSA_ROW_FRAGMENTS; ++row_fragment) {
+    const uint local_row = row_fragment * 8 + lane_row;
+    if (local_row >= row_count)
+      continue;
+
+    const auto up = output_up[row_fragment].thread_elements();
+    const auto gate = output_gate[row_fragment].thread_elements();
+    const ulong output_row = segment_start + row_tile_offset + local_row;
+    METAL_PRAGMA_UNROLL
+    for (uint index = 0; index < 2; ++index) {
+      const uint column = local_column + index;
+      if (column >= column_count)
+        continue;
+
+      const uint global_column = column_tile_offset + column;
+      const ulong up_row = expert_row_base + global_column;
+      const ulong gate_row = expert_row_base + d_ff + global_column;
+      const float activated = activate_mxfp4_prefill_value(
+          up[index],
+          gate[index],
+          float(up_biases[up_row]),
+          float(up_biases[gate_row]),
+          gate_clip_min,
+          gate_clip_max,
+          up_clip_min,
+          up_clip_max,
+          silu_alpha,
+          gating_sel
+      );
+      hidden_out[output_row * (ulong)d_ff + global_column] = activated;
+    }
+  }
+}
+
+constant uint MXFP4_PASSB_BM = 16;
+constant uint MXFP4_PASSB_BN = 32;
+constant uint MXFP4_PASSB_BK = 32;
+constant uint MXFP4_PASSB_LD = 36;
+constant uint MXFP4_PASSB_ROW_FRAGMENTS = 2;
+
+// The down projection reuses each expanded tile across the same routed row block.
+template <typename T>
+VARIANTS(T, float, half, bfloat)
+PUBLIC KERNEL(MoeExpertsMxfp4PrefillPassB)(
+    device const float* hidden,
+    device const uint* expert_offsets,
+    device const uchar* w2_blocks,
+    device const uchar* w2_scales,
+    device const T* w2_global_scale,
+    device const T* down_biases,
+    device T* output,
+    constant uint& d_model,
+    constant uint& d_ff,
+    constant uint& e,
+    device const uint* tile_map,
+    threadgroup float mxfp4_values[16],
+    threadgroup float Hs[MXFP4_PASSB_BM * MXFP4_PASSB_LD],
+    threadgroup T Wk[MXFP4_PASSB_BN * MXFP4_PASSB_LD],
+    const uint n_tile_idx GROUPS(INDIRECT),
+    const uint row_tile_idx GROUPS(INDIRECT),
+    const uint lin THREADS(128),
+    const ThreadContext thread_context
+) {
+  if (lin < 16)
+    mxfp4_values[lin] = MXFP4_PREFILL_VALUES[lin];
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  const uint map_offset = row_tile_idx * 3;
+  const uint expert_idx = tile_map[map_offset];
+  if (expert_idx >= e)
+    return;
+
+  const uint segment_start = expert_offsets[expert_idx];
+  const uint segment_end = expert_offsets[expert_idx + 1];
+  const uint segment_length = segment_end - segment_start;
+  if (segment_length == 0)
+    return;
+
+  const uint row_tile_offset = tile_map[map_offset + 2];
+  const uint column_tile_offset = n_tile_idx * MXFP4_PASSB_BN;
+  if (row_tile_offset >= segment_length || column_tile_offset >= d_model)
+    return;
+
+  const uint row_count = min(MXFP4_PASSB_BM, segment_length - row_tile_offset);
+  const uint column_count = min(MXFP4_PASSB_BN, d_model - column_tile_offset);
+  const uint groups_per_row = d_ff / 32;
+  const ulong expert_row_base = (ulong)expert_idx * d_model;
+  const float global_scale = float(w2_global_scale[expert_idx]);
+
+  const uint column_simdgroup = thread_context.simdgroup_index;
+  metal::simdgroup_float8x8 output_tile[MXFP4_PASSB_ROW_FRAGMENTS];
+  METAL_PRAGMA_UNROLL
+  for (uint row_fragment = 0; row_fragment < MXFP4_PASSB_ROW_FRAGMENTS; ++row_fragment) {
+    output_tile[row_fragment] = metal::make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+  }
+
+  for (uint k_offset = 0; k_offset < d_ff; k_offset += MXFP4_PASSB_BK) {
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint input_index = lin; input_index < MXFP4_PASSB_BM * 4; input_index += 128) {
+      const uint row = input_index / 4;
+      const uint element_offset = (input_index % 4) * 8;
+      threadgroup float* destination = Hs + row * MXFP4_PASSB_LD + element_offset;
+      if (row < row_count) {
+        const ulong input_base = (ulong)(segment_start + row_tile_offset + row) * d_ff + k_offset + element_offset;
+        METAL_PRAGMA_UNROLL
+        for (uint index = 0; index < 8; ++index)
+          destination[index] = hidden[input_base + index];
+      } else {
+        METAL_PRAGMA_UNROLL
+        for (uint index = 0; index < 8; ++index)
+          destination[index] = 0.0f;
+      }
+    }
+
+    for (uint weight_index = lin; weight_index < MXFP4_PASSB_BN * 4; weight_index += 128) {
+      const uint column = weight_index / 4;
+      const uint element_offset = (weight_index % 4) * 8;
+      const uint global_column = column_tile_offset + column;
+      threadgroup T* destination = Wk + column * MXFP4_PASSB_LD + element_offset;
+      if (column < column_count) {
+        const ulong weight_row = expert_row_base + global_column;
+        stage_mxfp4_eight(
+            w2_blocks,
+            w2_scales,
+            mxfp4_values,
+            destination,
+            weight_row,
+            groups_per_row,
+            32,
+            k_offset + element_offset,
+            d_ff,
+            global_scale
+        );
+      } else {
+        METAL_PRAGMA_UNROLL
+        for (uint index = 0; index < 8; ++index)
+          destination[index] = T(0.0f);
+      }
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    METAL_PRAGMA_UNROLL
+    for (uint k = 0; k < MXFP4_PASSB_BK; k += 8) {
+      metal::simdgroup_matrix<T, 8, 8> rhs;
+      simdgroup_load(rhs, Wk, MXFP4_PASSB_LD, ulong2(k, column_simdgroup * 8), true);
+      METAL_PRAGMA_UNROLL
+      for (uint row_fragment = 0; row_fragment < MXFP4_PASSB_ROW_FRAGMENTS; ++row_fragment) {
+        metal::simdgroup_float8x8 lhs;
+        const uint row = row_fragment * 8;
+        simdgroup_load(lhs, Hs, MXFP4_PASSB_LD, ulong2(k, row));
+        simdgroup_multiply_accumulate(output_tile[row_fragment], lhs, rhs, output_tile[row_fragment]);
+      }
+    }
+  }
+
+  const uint lane_quadrant = thread_context.simd_lane_id >> 2;
+  const uint lane_row = (lane_quadrant & 4) + ((thread_context.simd_lane_id >> 1) & 3);
+  const uint lane_column = ((lane_quadrant & 2) * 2) + ((thread_context.simd_lane_id & 1) * 2);
+  METAL_PRAGMA_UNROLL
+  for (uint row_fragment = 0; row_fragment < MXFP4_PASSB_ROW_FRAGMENTS; ++row_fragment) {
+    const uint local_row = row_fragment * 8 + lane_row;
+    if (local_row >= row_count)
+      continue;
+
+    const ulong output_row = segment_start + row_tile_offset + local_row;
+    const auto values = output_tile[row_fragment].thread_elements();
+    const uint local_column = column_simdgroup * 8 + lane_column;
+    METAL_PRAGMA_UNROLL
+    for (uint index = 0; index < 2; ++index) {
+      const uint column = local_column + index;
+      if (column >= column_count)
+        continue;
+
+      const uint global_column = column_tile_offset + column;
+      const float value = values[index] + float(down_biases[expert_row_base + global_column]);
+      output[output_row * (ulong)d_model + global_column] = T(value);
+    }
+  }
+}

--- a/crates/backend-uzu/src/backends/metal/kernel/moe/tiles_map.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/moe/tiles_map.metal
@@ -2,19 +2,18 @@
 #include <metal_atomic>
 #include "../common/dsl.h"
 
-#define BM 16
-
-// Compute per-expert tile counts: tiles_e = ceil((seg_len)/BM)
+// Compute per-expert tile counts for the schedule's selected row tile.
 PUBLIC KERNEL(MoeTileCounts)(
     device const uint* offsets, // [e+1]
     device uint* tile_counts,   // [e]
     constant uint& e,
+    constant uint& row_tile_size,
     const uint gid AXIS(e, 256)
 ) {
   const uint start = offsets[gid];
   const uint end = offsets[gid + 1];
   const uint seg_len = (end > start) ? (end - start) : 0u;
-  const uint tiles = (seg_len == 0u) ? 0u : ((seg_len + BM - 1u) / BM);
+  const uint tiles = (seg_len == 0u) ? 0u : ((seg_len + row_tile_size - 1u) / row_tile_size);
   tile_counts[gid] = tiles;
 }
 
@@ -79,6 +78,7 @@ PUBLIC KERNEL(MoeBuildTileMap)(
     device const uint* tile_counts,      // [e]
     device uint* tile_map,               // [3*total_tiles]
     constant uint& e,
+    constant uint& row_tile_size,
     uint gid AXIS(e, 256)
 ) {
   const uint start = offsets[gid];
@@ -88,7 +88,7 @@ PUBLIC KERNEL(MoeBuildTileMap)(
     const uint idx = base + t;
     tile_map[3u * idx + 0u] = gid;
     tile_map[3u * idx + 1u] = start;
-    tile_map[3u * idx + 2u] = t * BM;
+    tile_map[3u * idx + 2u] = t * row_tile_size;
   }
 }
 

--- a/crates/backend-uzu/src/config/weight_matrix/microfloat_spec.rs
+++ b/crates/backend-uzu/src/config/weight_matrix/microfloat_spec.rs
@@ -1,0 +1,18 @@
+use proc_macros::uzu_config;
+
+use crate::config::weight_matrix::Layout;
+
+#[uzu_config]
+#[serde(rename_all = "snake_case")]
+pub enum MicrofloatScaleMode {
+    Mxfp4,
+    Nvfp4,
+}
+
+#[uzu_config(super::WeightMatrixSpec)]
+pub struct MicrofloatSpec {
+    pub bits: u32,
+    pub group_size: usize,
+    pub scale_mode: MicrofloatScaleMode,
+    pub layout: Layout,
+}

--- a/crates/backend-uzu/src/config/weight_matrix/mod.rs
+++ b/crates/backend-uzu/src/config/weight_matrix/mod.rs
@@ -4,6 +4,7 @@ pub mod full_precision_spec;
 pub mod hybrid_spec;
 pub mod int_spec;
 pub mod low_rank_spec;
+pub mod microfloat_spec;
 pub mod mlx_spec;
 
 #[uzu_config]
@@ -18,6 +19,7 @@ pub enum Layout {
     low_rank_spec::LowRankSpec,
     hybrid_spec::HybridSpec,
     int_spec::IntSpec,
+    microfloat_spec::MicrofloatSpec,
     mlx_spec::MLXSpec
 )]
 pub struct WeightMatrixSpec;

--- a/crates/backend-uzu/src/encodable_block/mlp/moe/experts_mxfp4_decode.rs
+++ b/crates/backend-uzu/src/encodable_block/mlp/moe/experts_mxfp4_decode.rs
@@ -1,0 +1,157 @@
+use crate::{
+    array::size_for_shape,
+    backends::common::{
+        Allocation, Backend, Encoder,
+        kernel::{
+            Kernels, MoeExpertsMxfp4DecodeDownFused2DKernel, MoeExpertsMxfp4DecodePassAKernel,
+            MoePassABuildRowMapKernel, MoePassABuildTileMapKernel, MoePassATileCountsKernel, MoePassATileScanKernel,
+            MoePassAWriteDispatchArgsKernel,
+        },
+    },
+    data_type::DataType,
+};
+
+/// Correctness-first decode path for native MXFP4 expert projections.
+pub struct MoeExpertsMxfp4DecodeBlock<B: Backend> {
+    counts: <B::Kernels as Kernels>::MoePassATileCountsKernel,
+    scan: <B::Kernels as Kernels>::MoePassATileScanKernel,
+    row_map: <B::Kernels as Kernels>::MoePassABuildRowMapKernel,
+    build_map: <B::Kernels as Kernels>::MoePassABuildTileMapKernel,
+    dispatch: <B::Kernels as Kernels>::MoePassAWriteDispatchArgsKernel,
+    pass_a: <B::Kernels as Kernels>::MoeExpertsMxfp4DecodePassAKernel,
+    down: <B::Kernels as Kernels>::MoeExpertsMxfp4DecodeDownFused2DKernel,
+    data_type: DataType,
+}
+
+impl<B: Backend> MoeExpertsMxfp4DecodeBlock<B> {
+    pub fn new(
+        context: &B::Context,
+        data_type: DataType,
+        gating_code: u32,
+    ) -> Result<Self, B::Error> {
+        Ok(Self {
+            counts: <B::Kernels as Kernels>::MoePassATileCountsKernel::new(context)?,
+            scan: <B::Kernels as Kernels>::MoePassATileScanKernel::new(context)?,
+            row_map: <B::Kernels as Kernels>::MoePassABuildRowMapKernel::new(context)?,
+            build_map: <B::Kernels as Kernels>::MoePassABuildTileMapKernel::new(context)?,
+            dispatch: <B::Kernels as Kernels>::MoePassAWriteDispatchArgsKernel::new(context)?,
+            pass_a: <B::Kernels as Kernels>::MoeExpertsMxfp4DecodePassAKernel::new(context, data_type, gating_code)?,
+            down: <B::Kernels as Kernels>::MoeExpertsMxfp4DecodeDownFused2DKernel::new(
+                context,
+                data_type,
+                DataType::F32,
+            )?,
+            data_type,
+        })
+    }
+
+    pub fn encode(
+        &self,
+        args: MoeExpertsMxfp4Arguments<'_, B>,
+        encoder: &mut Encoder<B>,
+    ) -> Result<Allocation<B>, B::Error> {
+        const HIDDEN_VALUES_PER_TILE: usize = 8;
+        let hidden_blocks = args.d_ff.div_ceil(HIDDEN_VALUES_PER_TILE) as u32;
+
+        let mut tile_counts = encoder.allocate_scratch(size_for_shape(&[args.num_routed_experts], DataType::U32))?;
+        self.counts.encode(
+            args.expert_offsets,
+            &mut tile_counts,
+            args.num_routed_experts as u32,
+            hidden_blocks,
+            encoder,
+        );
+
+        let mut tile_offsets =
+            encoder.allocate_scratch(size_for_shape(&[args.num_routed_experts + 1], DataType::U32))?;
+        let mut total_tiles = encoder.allocate_scratch(size_for_shape(&[1], DataType::U32))?;
+        self.scan.encode(&tile_counts, &mut tile_offsets, &mut total_tiles, args.num_routed_experts as u32, encoder);
+
+        let mut row_expert_map = encoder.allocate_scratch(size_for_shape(&[args.total_rows], DataType::U32))?;
+        self.row_map.encode(
+            args.expert_offsets,
+            &mut row_expert_map,
+            args.total_rows as u32,
+            args.num_routed_experts as u32,
+            encoder,
+        );
+
+        let mut tile_map =
+            encoder.allocate_scratch(size_for_shape(&[args.total_rows * hidden_blocks as usize * 3], DataType::U32))?;
+        self.build_map.encode(
+            args.expert_offsets,
+            &tile_offsets,
+            &row_expert_map,
+            &mut tile_map,
+            args.total_rows as u32,
+            hidden_blocks,
+            encoder,
+        );
+
+        let mut dispatch_args = encoder.allocate_scratch(size_for_shape(&[3], DataType::U32))?;
+        self.dispatch.encode(&total_tiles, &mut dispatch_args, 1, encoder);
+
+        let mut hidden = encoder.allocate_scratch(size_for_shape(&[args.total_rows, args.d_ff], DataType::F32))?;
+        self.pass_a.encode(
+            args.x_perm,
+            args.expert_offsets,
+            args.w13_blocks,
+            args.w13_scales,
+            args.w13_global_scale,
+            &mut hidden,
+            args.up_biases,
+            args.d_model as u32,
+            args.d_ff as u32,
+            args.num_routed_experts as u32,
+            args.gate_clip_min,
+            args.gate_clip_max,
+            args.up_clip_min,
+            args.up_clip_max,
+            args.silu_alpha,
+            &tile_map,
+            &dispatch_args,
+            encoder,
+        );
+
+        let mut output = encoder.allocate_scratch(size_for_shape(&[args.total_rows, args.d_model], self.data_type))?;
+        self.down.encode(
+            &hidden,
+            &row_expert_map,
+            args.w2_blocks,
+            args.w2_scales,
+            args.w2_global_scale,
+            args.down_biases,
+            &mut output,
+            args.total_rows as u32,
+            args.d_model as u32,
+            args.d_ff as u32,
+            args.num_routed_experts as u32,
+            encoder,
+        );
+
+        Ok(output)
+    }
+}
+
+/// Canonical Lalamo experts: W13 scales cover 16 values, while W2 scales cover 32.
+pub struct MoeExpertsMxfp4Arguments<'a, B: Backend> {
+    pub x_perm: &'a Allocation<B>,
+    pub expert_offsets: &'a Allocation<B>,
+    pub w13_blocks: &'a Allocation<B>,
+    pub w13_scales: &'a Allocation<B>,
+    pub w13_global_scale: &'a Allocation<B>,
+    pub w2_blocks: &'a Allocation<B>,
+    pub w2_scales: &'a Allocation<B>,
+    pub w2_global_scale: &'a Allocation<B>,
+    pub up_biases: &'a Allocation<B>,
+    pub down_biases: &'a Allocation<B>,
+    pub total_rows: usize,
+    pub d_model: usize,
+    pub d_ff: usize,
+    pub num_routed_experts: usize,
+    pub gate_clip_min: f32,
+    pub gate_clip_max: f32,
+    pub up_clip_min: f32,
+    pub up_clip_max: f32,
+    pub silu_alpha: f32,
+}

--- a/crates/backend-uzu/src/encodable_block/mlp/moe/experts_mxfp4_prefill.rs
+++ b/crates/backend-uzu/src/encodable_block/mlp/moe/experts_mxfp4_prefill.rs
@@ -3,43 +3,45 @@ use crate::{
     backends::common::{
         Allocation, Backend, Encoder, Kernels,
         kernel::{
-            MoeBuildTileMapKernel, MoeExpertsPrefillPassAKernel, MoeExpertsPrefillPassBKernel, MoeTileCountsKernel,
-            MoeTileScanKernel, MoeWriteDispatchArgsKernel,
+            MoeBuildTileMapKernel, MoeExpertsMxfp4PrefillPassAKernel, MoeExpertsMxfp4PrefillPassBKernel,
+            MoeTileCountsKernel, MoeTileScanKernel, MoeWriteDispatchArgsKernel,
         },
     },
     data_type::DataType,
+    encodable_block::mlp::moe::experts_mxfp4_decode::MoeExpertsMxfp4Arguments,
 };
 
-pub struct MoeExpertsTwoPassPrefillBlock<B: Backend> {
+/// Packed prefill schedule sized for GPT-OSS's sparse per-expert row occupancy.
+pub struct MoeExpertsMxfp4PrefillBlock<B: Backend> {
     counts: <B::Kernels as Kernels>::MoeTileCountsKernel,
     scan: <B::Kernels as Kernels>::MoeTileScanKernel,
     build: <B::Kernels as Kernels>::MoeBuildTileMapKernel,
     dispatch: <B::Kernels as Kernels>::MoeWriteDispatchArgsKernel,
-    pass_a_indirect: <B::Kernels as Kernels>::MoeExpertsPrefillPassAKernel,
-    pass_b_indirect: <B::Kernels as Kernels>::MoeExpertsPrefillPassBKernel,
+    pass_a: <B::Kernels as Kernels>::MoeExpertsMxfp4PrefillPassAKernel,
+    pass_b: <B::Kernels as Kernels>::MoeExpertsMxfp4PrefillPassBKernel,
     data_type: DataType,
 }
 
-impl<B: Backend> MoeExpertsTwoPassPrefillBlock<B> {
+impl<B: Backend> MoeExpertsMxfp4PrefillBlock<B> {
     pub fn new(
-        ctx: &B::Context,
+        context: &B::Context,
         data_type: DataType,
         gating_code: u32,
     ) -> Result<Self, B::Error> {
         Ok(Self {
-            counts: <B::Kernels as Kernels>::MoeTileCountsKernel::new(ctx)?,
-            scan: <B::Kernels as Kernels>::MoeTileScanKernel::new(ctx)?,
-            build: <B::Kernels as Kernels>::MoeBuildTileMapKernel::new(ctx)?,
-            dispatch: <B::Kernels as Kernels>::MoeWriteDispatchArgsKernel::new(ctx)?,
-            pass_a_indirect: <B::Kernels as Kernels>::MoeExpertsPrefillPassAKernel::new(ctx, data_type, gating_code)?,
-            pass_b_indirect: <B::Kernels as Kernels>::MoeExpertsPrefillPassBKernel::new(ctx, data_type)?,
+            counts: <B::Kernels as Kernels>::MoeTileCountsKernel::new(context)?,
+            scan: <B::Kernels as Kernels>::MoeTileScanKernel::new(context)?,
+            build: <B::Kernels as Kernels>::MoeBuildTileMapKernel::new(context)?,
+            dispatch: <B::Kernels as Kernels>::MoeWriteDispatchArgsKernel::new(context)?,
+            pass_a: <B::Kernels as Kernels>::MoeExpertsMxfp4PrefillPassAKernel::new(context, data_type, gating_code)?,
+            pass_b: <B::Kernels as Kernels>::MoeExpertsMxfp4PrefillPassBKernel::new(context, data_type)?,
             data_type,
         })
     }
 
     pub fn encode(
         &self,
-        args: MoeExpertsTwoPassArguments<B>,
+        args: MoeExpertsMxfp4Arguments<'_, B>,
         encoder: &mut Encoder<B>,
     ) -> Result<Allocation<B>, B::Error> {
         let mut tile_counts = encoder.allocate_scratch(size_for_shape(&[args.num_routed_experts], DataType::U32))?;
@@ -62,19 +64,18 @@ impl<B: Backend> MoeExpertsTwoPassPrefillBlock<B> {
             encoder,
         );
 
-        const COL_TILE_FF: usize = 32; // Must match PASSA_BN in kernel
-        let n_tiles_ff = args.d_ff.div_ceil(COL_TILE_FF) as u32;
-
-        let mut pass_a_dispatch_args = encoder.allocate_scratch(size_for_shape(&[3], DataType::U32))?;
-        self.dispatch.encode(&total_tiles, &mut pass_a_dispatch_args, n_tiles_ff, encoder);
+        const PASS_A_COLUMNS: usize = 32;
+        let pass_a_column_tiles = args.d_ff.div_ceil(PASS_A_COLUMNS) as u32;
+        let mut pass_a_dispatch = encoder.allocate_scratch(size_for_shape(&[3], DataType::U32))?;
+        self.dispatch.encode(&total_tiles, &mut pass_a_dispatch, pass_a_column_tiles, encoder);
 
         let mut hidden = encoder.allocate_scratch(size_for_shape(&[args.total_rows, args.d_ff], DataType::F32))?;
-        encoder.encode_fill(&mut hidden, 0);
-
-        self.pass_a_indirect.encode(
+        self.pass_a.encode(
             args.x_perm,
             args.expert_offsets,
-            args.w13_all,
+            args.w13_blocks,
+            args.w13_scales,
+            args.w13_global_scale,
             args.up_biases,
             &mut hidden,
             args.d_model as u32,
@@ -86,48 +87,31 @@ impl<B: Backend> MoeExpertsTwoPassPrefillBlock<B> {
             args.up_clip_max,
             args.silu_alpha,
             &tile_map,
-            &pass_a_dispatch_args,
+            &pass_a_dispatch,
             encoder,
         );
 
-        const COL_TILE_MODEL: usize = 64;
-        let n_tiles_model = args.d_model.div_ceil(COL_TILE_MODEL) as u32;
-
-        let mut pass_b_dispatch_args = encoder.allocate_scratch(size_for_shape(&[3], DataType::U32))?;
-        self.dispatch.encode(&total_tiles, &mut pass_b_dispatch_args, n_tiles_model, encoder);
+        const PASS_B_COLUMNS: usize = 32;
+        let pass_b_column_tiles = args.d_model.div_ceil(PASS_B_COLUMNS) as u32;
+        let mut pass_b_dispatch = encoder.allocate_scratch(size_for_shape(&[3], DataType::U32))?;
+        self.dispatch.encode(&total_tiles, &mut pass_b_dispatch, pass_b_column_tiles, encoder);
 
         let mut output = encoder.allocate_scratch(size_for_shape(&[args.total_rows, args.d_model], self.data_type))?;
-        self.pass_b_indirect.encode(
+        self.pass_b.encode(
             &hidden,
             args.expert_offsets,
-            args.w2_all,
+            args.w2_blocks,
+            args.w2_scales,
+            args.w2_global_scale,
             args.down_biases,
             &mut output,
             args.d_model as u32,
             args.d_ff as u32,
             args.num_routed_experts as u32,
             &tile_map,
-            &pass_b_dispatch_args,
+            &pass_b_dispatch,
             encoder,
         );
         Ok(output)
     }
-}
-
-pub struct MoeExpertsTwoPassArguments<'a, B: Backend> {
-    pub x_perm: &'a Allocation<B>,
-    pub expert_offsets: &'a Allocation<B>,
-    pub w13_all: &'a Allocation<B>,
-    pub w2_all: &'a Allocation<B>,
-    pub up_biases: &'a Allocation<B>,
-    pub down_biases: &'a Allocation<B>,
-    pub total_rows: usize,
-    pub d_model: usize,
-    pub d_ff: usize,
-    pub num_routed_experts: usize,
-    pub gate_clip_min: f32,
-    pub gate_clip_max: f32,
-    pub up_clip_min: f32,
-    pub up_clip_max: f32,
-    pub silu_alpha: f32,
 }

--- a/crates/backend-uzu/src/encodable_block/mlp/moe/gather.rs
+++ b/crates/backend-uzu/src/encodable_block/mlp/moe/gather.rs
@@ -44,8 +44,8 @@ impl<B: Backend> MoeGather<B> {
     ) -> Result<Allocation<B>, B::Error> {
         let mut x_perm =
             encoder.allocate_scratch(size_for_shape(&[batch_dim * num_active_experts, d_model], self.data_type))?;
-        encoder.encode_fill(&mut x_perm, 0);
 
+        // The routing invariants supply every routed row, so gather initializes the allocation completely.
         match &self.variant {
             MoeGatherVariant::OneD(kernel) => kernel.encode(
                 input,

--- a/crates/backend-uzu/src/encodable_block/mlp/moe/mod.rs
+++ b/crates/backend-uzu/src/encodable_block/mlp/moe/mod.rs
@@ -1,9 +1,13 @@
 //! MoE (Mixture of Experts) block encodable.
 
+mod experts_mxfp4_decode;
+mod experts_mxfp4_prefill;
 mod experts_two_pass_decode;
 mod experts_two_pass_prefill;
 mod gather;
 
+use experts_mxfp4_decode::{MoeExpertsMxfp4Arguments, MoeExpertsMxfp4DecodeBlock};
+use experts_mxfp4_prefill::MoeExpertsMxfp4PrefillBlock;
 use experts_two_pass_decode::MoeExpertsTwoPassDecodeBlock;
 use experts_two_pass_prefill::{MoeExpertsTwoPassArguments, MoeExpertsTwoPassPrefillBlock};
 use gather::MoeGather;
@@ -21,7 +25,11 @@ use crate::{
     },
     config::{
         mlp::{mixture_of_experts::MixtureOfExpertsConfig, routing_function::AnyRoutingFunction},
-        weight_matrix::{AnyWeightMatrixSpec, Layout, full_precision_spec::FullPrecisionSpec},
+        weight_matrix::{
+            AnyWeightMatrixSpec, Layout,
+            full_precision_spec::FullPrecisionSpec,
+            microfloat_spec::{MicrofloatScaleMode, MicrofloatSpec},
+        },
     },
     data_type::DataType,
     encodable_block::mlp::Mlp,
@@ -34,16 +42,11 @@ pub struct MoeBlock<B: Backend> {
     scatter_bases_kernel: <B::Kernels as Kernels>::MoeBlockBasesFromPartialsKernel,
     scatter_map_kernel: <B::Kernels as Kernels>::MoeScatterBucketsMapKernel,
     gather: MoeGather<B>,
-    experts_two_pass_decode_block: MoeExpertsTwoPassDecodeBlock<B>,
-    experts_two_pass_prefill_block: MoeExpertsTwoPassPrefillBlock<B>,
+    experts: MoeExperts<B>,
     finalize_kernel: <B::Kernels as Kernels>::MoeFinalizeKernel,
     router_weights: Allocation<B>,
     router_biases: Allocation<B>,
     router_renorm: bool,
-    w13: Allocation<B>,
-    w2: Allocation<B>,
-    up_biases: Allocation<B>,
-    down_biases: Allocation<B>,
     model_dim: usize,
     hidden_dim: usize,
     num_routed_experts: usize,
@@ -56,6 +59,124 @@ pub struct MoeBlock<B: Backend> {
     data_type: DataType,
 }
 
+/// Expert storage and execution stay coupled so packed weights cannot enter a dense kernel.
+enum MoeExperts<B: Backend> {
+    FullPrecision {
+        decode: MoeExpertsTwoPassDecodeBlock<B>,
+        prefill: MoeExpertsTwoPassPrefillBlock<B>,
+        w13: Allocation<B>,
+        w2: Allocation<B>,
+        up_biases: Allocation<B>,
+        down_biases: Allocation<B>,
+    },
+    Mxfp4 {
+        decode: MoeExpertsMxfp4DecodeBlock<B>,
+        prefill: MoeExpertsMxfp4PrefillBlock<B>,
+        w13_blocks: Allocation<B>,
+        w13_scales: Allocation<B>,
+        w13_global_scale: Allocation<B>,
+        w2_blocks: Allocation<B>,
+        w2_scales: Allocation<B>,
+        w2_global_scale: Allocation<B>,
+        up_biases: Allocation<B>,
+        down_biases: Allocation<B>,
+    },
+}
+
+struct MoeExpertArguments<'a, B: Backend> {
+    x_perm: &'a Allocation<B>,
+    expert_offsets: &'a Allocation<B>,
+    total_rows: usize,
+    d_model: usize,
+    d_ff: usize,
+    num_routed_experts: usize,
+    gate_clip_min: f32,
+    gate_clip_max: f32,
+    up_clip_min: f32,
+    up_clip_max: f32,
+    silu_alpha: f32,
+}
+
+impl<B: Backend> MoeExperts<B> {
+    fn encode(
+        &self,
+        args: MoeExpertArguments<'_, B>,
+        prefill: bool,
+        encoder: &mut Encoder<B>,
+    ) -> Result<Allocation<B>, B::Error> {
+        match self {
+            Self::FullPrecision {
+                decode,
+                prefill: prefill_block,
+                w13,
+                w2,
+                up_biases,
+                down_biases,
+            } => {
+                let args = MoeExpertsTwoPassArguments {
+                    x_perm: args.x_perm,
+                    expert_offsets: args.expert_offsets,
+                    w13_all: w13,
+                    w2_all: w2,
+                    up_biases,
+                    down_biases,
+                    total_rows: args.total_rows,
+                    d_model: args.d_model,
+                    d_ff: args.d_ff,
+                    num_routed_experts: args.num_routed_experts,
+                    gate_clip_min: args.gate_clip_min,
+                    gate_clip_max: args.gate_clip_max,
+                    up_clip_min: args.up_clip_min,
+                    up_clip_max: args.up_clip_max,
+                    silu_alpha: args.silu_alpha,
+                };
+                if prefill {
+                    return prefill_block.encode(args, encoder);
+                }
+                decode.encode(args, encoder)
+            },
+            Self::Mxfp4 {
+                decode,
+                prefill: prefill_block,
+                w13_blocks,
+                w13_scales,
+                w13_global_scale,
+                w2_blocks,
+                w2_scales,
+                w2_global_scale,
+                up_biases,
+                down_biases,
+            } => {
+                let args = MoeExpertsMxfp4Arguments {
+                    x_perm: args.x_perm,
+                    expert_offsets: args.expert_offsets,
+                    w13_blocks,
+                    w13_scales,
+                    w13_global_scale,
+                    w2_blocks,
+                    w2_scales,
+                    w2_global_scale,
+                    up_biases,
+                    down_biases,
+                    total_rows: args.total_rows,
+                    d_model: args.d_model,
+                    d_ff: args.d_ff,
+                    num_routed_experts: args.num_routed_experts,
+                    gate_clip_min: args.gate_clip_min,
+                    gate_clip_max: args.gate_clip_max,
+                    up_clip_min: args.up_clip_min,
+                    up_clip_max: args.up_clip_max,
+                    silu_alpha: args.silu_alpha,
+                };
+                if prefill {
+                    return prefill_block.encode(args, encoder);
+                }
+                decode.encode(args, encoder)
+            },
+        }
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum MoeBlockError<B: Backend> {
     #[error("Backend error: {0}")]
@@ -64,9 +185,9 @@ pub enum MoeBlockError<B: Backend> {
     ParameterLoaderError(#[from] ParameterLoaderError<B>),
     #[error("MoE requires model_dim % 4 == 0")]
     InvalidModelDim,
-    #[error("MoE num_routed_experts must be <= 512")]
+    #[error("MoE num_routed_experts must be > 0 and <= 512")]
     InvalidRoutedExpertCount,
-    #[error("MoE num_active_routed_experts must be > 0 and <= 128")]
+    #[error("MoE num_active_routed_experts must be > 0, <= 128, and <= num_routed_experts")]
     InvalidActiveExpertCount,
     #[error("MoE shared experts are not supported")]
     UnsupportedSharedExperts,
@@ -78,6 +199,8 @@ pub enum MoeBlockError<B: Backend> {
     UnsupportedRouterConfiguration(String),
     #[error("Unsupported MoE expert activation: {0:?}")]
     UnsupportedExpertActivation(ActivationType),
+    #[error("Unsupported MoE expert configuration: {0}")]
+    UnsupportedExpertConfiguration(String),
 }
 
 impl<B: Backend> MoeBlock<B> {
@@ -91,11 +214,14 @@ impl<B: Backend> MoeBlock<B> {
         if !model_dim.is_multiple_of(4) {
             return Err(MoeBlockError::InvalidModelDim);
         }
-        if moe_config.num_active_routed_experts == 0 || moe_config.num_active_routed_experts > 128 {
-            return Err(MoeBlockError::InvalidActiveExpertCount);
-        }
-        if moe_config.num_routed_experts > 512 {
+        if moe_config.num_routed_experts == 0 || moe_config.num_routed_experts > 512 {
             return Err(MoeBlockError::InvalidRoutedExpertCount);
+        }
+        if moe_config.num_active_routed_experts == 0
+            || moe_config.num_active_routed_experts > 128
+            || moe_config.num_active_routed_experts > moe_config.num_routed_experts
+        {
+            return Err(MoeBlockError::InvalidActiveExpertCount);
         }
         if moe_config.num_shared_experts != 0 {
             return Err(MoeBlockError::UnsupportedSharedExperts);
@@ -140,15 +266,6 @@ impl<B: Backend> MoeBlock<B> {
         let down_tree = experts_tree.subtree("down_projection");
         let up_weights_tree = up_tree.subtree("weights");
         let down_weights_tree = down_tree.subtree("weights");
-
-        let w13 = up_weights_tree
-            .leaf("weights")?
-            .validate(&[moe_config.num_routed_experts, moe_config.expert_hidden_dim * 2, model_dim], data_type)?
-            .read_allocation()?;
-        let w2 = down_weights_tree
-            .leaf("weights")?
-            .validate(&[moe_config.num_routed_experts, model_dim, moe_config.expert_hidden_dim], data_type)?
-            .read_allocation()?;
         let up_biases = up_tree
             .leaf("biases")?
             .validate(&[moe_config.num_routed_experts, moe_config.expert_hidden_dim * 2], data_type)?
@@ -169,10 +286,121 @@ impl<B: Backend> MoeBlock<B> {
             .map_err(MoeBlockError::BackendError)?;
 
         let gather = MoeGather::new(context, data_type).map_err(MoeBlockError::BackendError)?;
-        let experts_two_pass_decode_block =
-            MoeExpertsTwoPassDecodeBlock::new(context, data_type, gating_code).map_err(MoeBlockError::BackendError)?;
-        let experts_two_pass_prefill_block =
-            MoeExpertsTwoPassPrefillBlock::new(context, data_type, gating_code).map_err(MoeBlockError::BackendError)?;
+        let up_spec = up_weights_tree.metadata::<AnyWeightMatrixSpec>("spec")?;
+        let down_spec = down_weights_tree.metadata::<AnyWeightMatrixSpec>("spec")?;
+        let experts = match (up_spec, down_spec) {
+            (
+                AnyWeightMatrixSpec::FullPrecisionSpec(FullPrecisionSpec {
+                    layout: Layout::OutputInput,
+                    ..
+                }),
+                AnyWeightMatrixSpec::FullPrecisionSpec(FullPrecisionSpec {
+                    layout: Layout::OutputInput,
+                    ..
+                }),
+            ) => {
+                let w13 = up_weights_tree
+                    .leaf("weights")?
+                    .validate(&[moe_config.num_routed_experts, moe_config.expert_hidden_dim * 2, model_dim], data_type)?
+                    .read_allocation()?;
+                let w2 = down_weights_tree
+                    .leaf("weights")?
+                    .validate(&[moe_config.num_routed_experts, model_dim, moe_config.expert_hidden_dim], data_type)?
+                    .read_allocation()?;
+                let decode = MoeExpertsTwoPassDecodeBlock::new(context, data_type, gating_code)
+                    .map_err(MoeBlockError::BackendError)?;
+                let prefill = MoeExpertsTwoPassPrefillBlock::new(context, data_type, gating_code)
+                    .map_err(MoeBlockError::BackendError)?;
+                MoeExperts::FullPrecision {
+                    decode,
+                    prefill,
+                    w13,
+                    w2,
+                    up_biases,
+                    down_biases,
+                }
+            },
+            (
+                AnyWeightMatrixSpec::MicrofloatSpec(MicrofloatSpec {
+                    bits: 4,
+                    group_size: 16,
+                    scale_mode: MicrofloatScaleMode::Mxfp4,
+                    layout: Layout::OutputInput,
+                    ..
+                }),
+                AnyWeightMatrixSpec::MicrofloatSpec(MicrofloatSpec {
+                    bits: 4,
+                    group_size: 32,
+                    scale_mode: MicrofloatScaleMode::Mxfp4,
+                    layout: Layout::OutputInput,
+                    ..
+                }),
+            ) => {
+                if !model_dim.is_multiple_of(16) || !moe_config.expert_hidden_dim.is_multiple_of(32) {
+                    return Err(MoeBlockError::UnsupportedExpertConfiguration(format!(
+                        "MXFP4 requires model_dim divisible by 16 and hidden_dim divisible by 32, got model_dim={model_dim}, hidden_dim={}",
+                        moe_config.expert_hidden_dim
+                    )));
+                }
+                let w13_blocks = up_weights_tree
+                    .leaf("weights")?
+                    .validate(
+                        &[moe_config.num_routed_experts, moe_config.expert_hidden_dim * 2, model_dim / 2],
+                        DataType::U8,
+                    )?
+                    .read_allocation()?;
+                let w13_scales = up_weights_tree
+                    .leaf("scales")?
+                    .validate(
+                        &[moe_config.num_routed_experts, moe_config.expert_hidden_dim * 2, model_dim / 16],
+                        DataType::U8,
+                    )?
+                    .read_allocation()?;
+                let w13_global_scale = up_weights_tree
+                    .leaf("global_scale")?
+                    .validate(&[moe_config.num_routed_experts], data_type)?
+                    .read_allocation()?;
+                let w2_blocks = down_weights_tree
+                    .leaf("weights")?
+                    .validate(
+                        &[moe_config.num_routed_experts, model_dim, moe_config.expert_hidden_dim / 2],
+                        DataType::U8,
+                    )?
+                    .read_allocation()?;
+                let w2_scales = down_weights_tree
+                    .leaf("scales")?
+                    .validate(
+                        &[moe_config.num_routed_experts, model_dim, moe_config.expert_hidden_dim / 32],
+                        DataType::U8,
+                    )?
+                    .read_allocation()?;
+                let w2_global_scale = down_weights_tree
+                    .leaf("global_scale")?
+                    .validate(&[moe_config.num_routed_experts], data_type)?
+                    .read_allocation()?;
+                let decode = MoeExpertsMxfp4DecodeBlock::new(context, data_type, gating_code)
+                    .map_err(MoeBlockError::BackendError)?;
+                let prefill = MoeExpertsMxfp4PrefillBlock::new(context, data_type, gating_code)
+                    .map_err(MoeBlockError::BackendError)?;
+                MoeExperts::Mxfp4 {
+                    decode,
+                    prefill,
+                    w13_blocks,
+                    w13_scales,
+                    w13_global_scale,
+                    w2_blocks,
+                    w2_scales,
+                    w2_global_scale,
+                    up_biases,
+                    down_biases,
+                }
+            },
+            (up_spec, down_spec) => {
+                return Err(MoeBlockError::UnsupportedExpertConfiguration(format!(
+                    "up={up_spec:?}, down={down_spec:?}"
+                )));
+            },
+        };
         let finalize_kernel =
             <B::Kernels as Kernels>::MoeFinalizeKernel::new(context, data_type).map_err(MoeBlockError::BackendError)?;
 
@@ -185,16 +413,11 @@ impl<B: Backend> MoeBlock<B> {
             scatter_bases_kernel,
             scatter_map_kernel,
             gather,
-            experts_two_pass_decode_block,
-            experts_two_pass_prefill_block,
+            experts,
             finalize_kernel,
             router_weights,
             router_biases,
             router_renorm,
-            w13,
-            w2,
-            up_biases,
-            down_biases,
             model_dim,
             hidden_dim: moe_config.expert_hidden_dim,
             num_routed_experts: moe_config.num_routed_experts,
@@ -227,8 +450,7 @@ impl<B: Backend> Mlp<B> for MoeBlock<B> {
         let mut topk_probs =
             encoder.allocate_scratch(size_for_shape(&[batch_dim, self.num_active_experts], self.data_type))?;
 
-        encoder.encode_fill(&mut topk_ids, 0xFF);
-
+        // The constructor guarantees k <= E, so the router writes every top-k slot.
         self.router_topk_kernel.encode(
             &input,
             &self.router_weights,
@@ -268,8 +490,7 @@ impl<B: Backend> Mlp<B> for MoeBlock<B> {
         let mut bucketed_probs = encoder.allocate_scratch(size_for_shape(&[total_rows], self.data_type))?;
         let mut tok2row = encoder.allocate_scratch(size_for_shape(&[total_rows], DataType::I32))?;
 
-        encoder.encode_fill(&mut tok2row, 0xFF);
-
+        // Every routed slot is valid here, so scatter initializes the complete reverse map.
         self.scatter_bases_kernel.encode(
             &partials,
             &mut block_bases,
@@ -307,13 +528,9 @@ impl<B: Backend> Mlp<B> for MoeBlock<B> {
             encoder,
         )?;
 
-        let args = MoeExpertsTwoPassArguments {
+        let expert_args = MoeExpertArguments {
             x_perm: &x_perm,
             expert_offsets: &offsets,
-            w13_all: &self.w13,
-            w2_all: &self.w2,
-            up_biases: &self.up_biases,
-            down_biases: &self.down_biases,
             total_rows,
             d_model: self.model_dim,
             d_ff: self.hidden_dim,
@@ -324,12 +541,7 @@ impl<B: Backend> Mlp<B> for MoeBlock<B> {
             up_clip_max: self.up_clip_max,
             silu_alpha: self.silu_alpha,
         };
-
-        let y_partial = if batch_dim == 1 {
-            self.experts_two_pass_decode_block.encode(args, encoder)?
-        } else {
-            self.experts_two_pass_prefill_block.encode(args, encoder)?
-        };
+        let y_partial = self.experts.encode(expert_args, batch_dim > 1, encoder)?;
 
         let mut output = encoder.allocate_scratch(size_for_shape(&[batch_dim, self.model_dim], self.data_type))?;
         self.finalize_kernel.encode(

--- a/crates/backend-uzu/tests/unit/backends/common/kernel/moe/moe_counts_offsets_fused_test.rs
+++ b/crates/backend-uzu/tests/unit/backends/common/kernel/moe/moe_counts_offsets_fused_test.rs
@@ -47,8 +47,10 @@ fn get_output<B: Backend>(
     };
     let mut offsets = alloc_allocation::<B, u32>(&context, e + 1);
     let mut sum_k = alloc_allocation::<B, u32>(&context, 1);
+    let num_blocks = t.div_ceil(256);
     let num_tiles = e.div_ceil(512).max(1);
-    let mut partials = alloc_allocation::<B, u32>(&context, num_tiles * 512);
+    let partial_entries = (num_blocks * num_tiles * 512).max(1);
+    let mut partials = alloc_allocation::<B, u32>(&context, partial_entries);
 
     let mut encoder = Encoder::new(context.as_ref()).expect("Failed to create encoder");
     kernel.encode(
@@ -65,14 +67,24 @@ fn get_output<B: Backend>(
 
     let offsets = allocation_to_vec::<B, u32>(&offsets);
     let sum_k = allocation_to_vec::<B, u32>(&sum_k)[0];
-    let partials = allocation_prefix_to_vec::<B, u32>(&partials, e);
+    let partials = allocation_prefix_to_vec::<B, u32>(&partials, partial_entries);
+    let partials = (0..num_blocks)
+        .flat_map(|block_id| {
+            let partials = &partials;
+            (0..e).map(move |expert_id| {
+                let tile_id = expert_id / 512;
+                let tile_expert_id = expert_id % 512;
+                partials[(block_id * num_tiles + tile_id) * 512 + tile_expert_id]
+            })
+        })
+        .collect();
 
     (offsets, sum_k, partials)
 }
 
 #[uzu_test]
 fn test_counts_offsets_fused_parity_random() {
-    let shapes = vec![(1usize, 4usize), (7, 16), (64, 64), (1024, 128)];
+    let shapes = vec![(1usize, 4usize), (7, 16), (64, 64), (257, 160), (1024, 128)];
     let ks = vec![1usize, 2usize, 4usize];
 
     for &(t, e) in &shapes {
@@ -92,6 +104,23 @@ fn test_counts_offsets_fused_parity_random() {
             });
         }
     }
+}
+
+#[uzu_test]
+fn test_counts_offsets_fused_preserves_scatter_block_histograms() {
+    let (t, e, k) = (257usize, 2usize, 1usize);
+    let mut topk_ids = vec![0i32; t];
+    topk_ids[256] = 1;
+    let expected_offsets = vec![0, 256, 257];
+    let expected_partials = vec![256, 0, 0, 1];
+
+    for_each_backend!(|B| {
+        let (offsets, sum_k, partials) = get_output::<B>(&topk_ids, t, e, k);
+        let backend_name = std::any::type_name::<B>();
+        assert_eq!(offsets, expected_offsets, "offsets mismatch backend={}", backend_name);
+        assert_eq!(sum_k, t as u32, "sum mismatch backend={}", backend_name);
+        assert_eq!(partials, expected_partials, "scatter-block partials mismatch backend={}", backend_name);
+    });
 }
 
 #[uzu_test]

--- a/crates/backend-uzu/tests/unit/encodable_block/moe/mod.rs
+++ b/crates/backend-uzu/tests/unit/encodable_block/moe/mod.rs
@@ -1,10 +1,14 @@
 use super::{
+    experts_mxfp4_decode::{MoeExpertsMxfp4Arguments, MoeExpertsMxfp4DecodeBlock},
+    experts_mxfp4_prefill::MoeExpertsMxfp4PrefillBlock,
     experts_two_pass_decode::MoeExpertsTwoPassDecodeBlock,
     experts_two_pass_prefill::{MoeExpertsTwoPassArguments, MoeExpertsTwoPassPrefillBlock},
     gather::MoeGather,
 };
 
 mod moe_block_e2e_test;
+mod moe_block_mxfp4_test;
+mod moe_experts_mxfp4_test;
 mod moe_experts_perf_test;
 mod moe_experts_test;
 mod moe_perf_test;

--- a/crates/backend-uzu/tests/unit/encodable_block/moe/moe_block_mxfp4_test.rs
+++ b/crates/backend-uzu/tests/unit/encodable_block/moe/moe_block_mxfp4_test.rs
@@ -1,0 +1,259 @@
+use std::{
+    fs::{File, OpenOptions, remove_file},
+    io::Write,
+    path::PathBuf,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use half::bf16;
+use proc_macros::uzu_test;
+use serde_json::{Map, Value, json};
+
+use super::super::{MoeBlock, MoeBlockError};
+use crate::{
+    backends::common::Encoder,
+    config::mlp::mixture_of_experts::MixtureOfExpertsConfig,
+    data_type::DataType,
+    encodable_block::mlp::Mlp,
+    parameters::ParameterLoader,
+    tests::helpers::{alloc_allocation_with_data, allocation_prefix_to_vec, create_context, for_each_non_cpu_backend},
+};
+
+struct Tensor {
+    name: &'static str,
+    dtype: &'static str,
+    shape: Vec<usize>,
+    bytes: Vec<u8>,
+}
+
+struct TempFile {
+    file: File,
+    path: PathBuf,
+}
+
+impl Drop for TempFile {
+    fn drop(&mut self) {
+        let _ = remove_file(&self.path);
+    }
+}
+
+fn bf16_bytes(values: &[bf16]) -> Vec<u8> {
+    bytemuck::cast_slice(values).to_vec()
+}
+
+/// Minimal Lalamo-style safetensors file exercising the public ParameterTree contract.
+fn write_mxfp4_moe_file(mixed_expert_specs: bool) -> TempFile {
+    const EXPERTS: usize = 2;
+    const MODEL_DIM: usize = 32;
+    const HIDDEN_DIM: usize = 32;
+
+    let mut up_biases = vec![bf16::ZERO; EXPERTS * 2 * HIDDEN_DIM];
+    let (up_bias_rows, remainder) = up_biases.as_chunks_mut::<{ 2 * HIDDEN_DIM }>();
+    assert!(remainder.is_empty());
+    for rows in up_bias_rows {
+        for up_bias in &mut rows[..HIDDEN_DIM] {
+            *up_bias = bf16::ONE;
+        }
+    }
+    let tensors = vec![
+        Tensor {
+            name: "router.weights.weights",
+            dtype: "BF16",
+            shape: vec![EXPERTS, MODEL_DIM],
+            bytes: bf16_bytes(&[bf16::ZERO; EXPERTS * MODEL_DIM]),
+        },
+        Tensor {
+            name: "router.biases",
+            dtype: "BF16",
+            shape: vec![EXPERTS],
+            bytes: bf16_bytes(&[bf16::ZERO; EXPERTS]),
+        },
+        Tensor {
+            name: "experts.up_projection.weights.weights",
+            dtype: "U8",
+            shape: vec![EXPERTS, 2 * HIDDEN_DIM, MODEL_DIM / 2],
+            bytes: vec![0; EXPERTS * 2 * HIDDEN_DIM * MODEL_DIM / 2],
+        },
+        Tensor {
+            name: "experts.up_projection.weights.scales",
+            dtype: "U8",
+            shape: vec![EXPERTS, 2 * HIDDEN_DIM, MODEL_DIM / 16],
+            bytes: vec![127; EXPERTS * 2 * HIDDEN_DIM * MODEL_DIM / 16],
+        },
+        Tensor {
+            name: "experts.up_projection.weights.global_scale",
+            dtype: "BF16",
+            shape: vec![EXPERTS],
+            bytes: bf16_bytes(&[bf16::ONE; EXPERTS]),
+        },
+        Tensor {
+            name: "experts.up_projection.biases",
+            dtype: "BF16",
+            shape: vec![EXPERTS, 2 * HIDDEN_DIM],
+            bytes: bf16_bytes(&up_biases),
+        },
+        Tensor {
+            name: "experts.down_projection.weights.weights",
+            dtype: "U8",
+            shape: vec![EXPERTS, MODEL_DIM, HIDDEN_DIM / 2],
+            bytes: vec![0; EXPERTS * MODEL_DIM * HIDDEN_DIM / 2],
+        },
+        Tensor {
+            name: "experts.down_projection.weights.scales",
+            dtype: "U8",
+            shape: vec![EXPERTS, MODEL_DIM, HIDDEN_DIM / 32],
+            bytes: vec![127; EXPERTS * MODEL_DIM * HIDDEN_DIM / 32],
+        },
+        Tensor {
+            name: "experts.down_projection.weights.global_scale",
+            dtype: "BF16",
+            shape: vec![EXPERTS],
+            bytes: bf16_bytes(&[bf16::ONE; EXPERTS]),
+        },
+        Tensor {
+            name: "experts.down_projection.biases",
+            dtype: "BF16",
+            shape: vec![EXPERTS, MODEL_DIM],
+            bytes: bf16_bytes(&[bf16::ZERO; EXPERTS * MODEL_DIM]),
+        },
+    ];
+
+    let full_precision_spec = json!({"type": "FullPrecisionSpec", "layout": "output_input"}).to_string();
+    let gate_up_spec = json!({
+        "type": "MicrofloatSpec",
+        "bits": 4,
+        "group_size": 16,
+        "scale_mode": "mxfp4",
+        "layout": "output_input"
+    })
+    .to_string();
+    let down_spec = json!({
+        "type": "MicrofloatSpec",
+        "bits": 4,
+        "group_size": 32,
+        "scale_mode": "mxfp4",
+        "layout": "output_input"
+    })
+    .to_string();
+    let down_spec = if mixed_expert_specs {
+        full_precision_spec.clone()
+    } else {
+        down_spec
+    };
+    let metadata = json!({
+        "router.weights.spec": full_precision_spec,
+        "experts.up_projection.weights.spec": gate_up_spec,
+        "experts.down_projection.weights.spec": down_spec,
+    });
+
+    let mut offset = 0;
+    let mut header = Map::new();
+    header.insert("__metadata__".to_string(), metadata);
+    for tensor in &tensors {
+        let end = offset + tensor.bytes.len();
+        header.insert(
+            tensor.name.to_string(),
+            json!({"dtype": tensor.dtype, "shape": tensor.shape, "data_offsets": [offset, end]}),
+        );
+        offset = end;
+    }
+
+    let mut header = serde_json::to_vec(&Value::Object(header)).expect("serialize safetensors header");
+    header.resize(header.len().next_multiple_of(8), b' ');
+    let unique = SystemTime::now().duration_since(UNIX_EPOCH).expect("system clock").as_nanos();
+    let path = std::env::temp_dir().join(format!("uzu-mxfp4-{}-{unique}.safetensors", std::process::id()));
+    let mut file = OpenOptions::new().write(true).read(true).create_new(true).open(&path).expect("temporary file");
+    file.write_all(&(header.len() as u64).to_le_bytes()).expect("write header length");
+    file.write_all(&header).expect("write header");
+    for tensor in tensors {
+        file.write_all(&tensor.bytes).expect("write tensor");
+    }
+    file.flush().expect("flush safetensors file");
+    TempFile {
+        file,
+        path,
+    }
+}
+
+fn lalamo_moe_config() -> MixtureOfExpertsConfig {
+    serde_json::from_value(json!({
+        "type": "MixtureOfExpertsConfig",
+        "expert_config": {
+            "type": "DenseMLPConfig",
+            "linear_config": {},
+            "activation": {"type": "SiLU", "alpha": 1.702},
+            "has_up_biases": true,
+            "has_down_biases": true,
+            "gate_clipping": [null, 7.0],
+            "up_clipping": [-6.0, 8.0]
+        },
+        "router_config": {},
+        "routing_function": {"type": "SoftmaxRouting"},
+        "num_routed_experts": 2,
+        "num_active_routed_experts": 1,
+        "router_has_biases": true,
+        "num_shared_experts": 0,
+        "expert_hidden_dim": 32,
+        "gate_config": null
+    }))
+    .expect("Lalamo MoE config")
+}
+
+#[uzu_test]
+fn test_moe_block_loads_and_executes_lalamo_mxfp4_contract() {
+    for_each_non_cpu_backend!(|B| {
+        const MODEL_DIM: usize = 32;
+        let context = create_context::<B>();
+        let file = write_mxfp4_moe_file(false);
+        let loader = ParameterLoader::<B>::new(&file.file, context.as_ref()).expect("parameter loader");
+        let tree = loader.tree();
+        let config = lalamo_moe_config();
+
+        let block = MoeBlock::new(context.as_ref(), &config, MODEL_DIM, DataType::BF16, &tree).expect("packed MoE");
+        tree.assert_all_tensors_validated().expect("all packed tensors consumed");
+
+        // More than one row deliberately exercises the packed path for prefill too.
+        let input = alloc_allocation_with_data::<B, bf16>(&context, &[bf16::ONE; 2 * MODEL_DIM]);
+        let mut encoder = Encoder::new(context.as_ref()).expect("encoder");
+        let output_allocation = block.encode(input, 2, &mut encoder).expect("encode packed MoE");
+        let completed = encoder.end_encoding().submit().wait_until_completed().expect("run packed MoE");
+        let output = allocation_prefix_to_vec::<B, bf16>(&output_allocation, 2 * MODEL_DIM);
+
+        assert!(output.iter().all(|value| *value == bf16::ZERO));
+        drop(output_allocation);
+        drop(completed);
+    });
+}
+
+#[uzu_test]
+fn test_moe_block_rejects_more_active_than_routed_experts() {
+    for_each_non_cpu_backend!(|B| {
+        const MODEL_DIM: usize = 32;
+        let context = create_context::<B>();
+        let file = write_mxfp4_moe_file(false);
+        let loader = ParameterLoader::<B>::new(&file.file, context.as_ref()).expect("parameter loader");
+        let tree = loader.tree();
+        let mut config = lalamo_moe_config();
+        config.num_active_routed_experts = config.num_routed_experts + 1;
+
+        let result = MoeBlock::new(context.as_ref(), &config, MODEL_DIM, DataType::BF16, &tree);
+
+        assert!(matches!(result, Err(MoeBlockError::InvalidActiveExpertCount)));
+    });
+}
+
+#[uzu_test]
+fn test_moe_block_rejects_mixed_expert_specs() {
+    for_each_non_cpu_backend!(|B| {
+        const MODEL_DIM: usize = 32;
+        let context = create_context::<B>();
+        let file = write_mxfp4_moe_file(true);
+        let loader = ParameterLoader::<B>::new(&file.file, context.as_ref()).expect("parameter loader");
+        let tree = loader.tree();
+        let config = lalamo_moe_config();
+
+        let result = MoeBlock::new(context.as_ref(), &config, MODEL_DIM, DataType::BF16, &tree);
+
+        assert!(matches!(result, Err(MoeBlockError::UnsupportedExpertConfiguration(_))));
+    });
+}

--- a/crates/backend-uzu/tests/unit/encodable_block/moe/moe_experts_mxfp4_test.rs
+++ b/crates/backend-uzu/tests/unit/encodable_block/moe/moe_experts_mxfp4_test.rs
@@ -1,0 +1,577 @@
+use half::bf16;
+use proc_macros::uzu_test;
+
+use super::{MoeExpertsMxfp4Arguments, MoeExpertsMxfp4DecodeBlock, MoeExpertsMxfp4PrefillBlock};
+use crate::{
+    backends::common::Encoder,
+    data_type::DataType,
+    tests::{
+        assert::assert_eq_float,
+        helpers::{alloc_allocation_with_data, allocation_prefix_to_vec, create_context, for_each_non_cpu_backend},
+    },
+};
+
+const D_MODEL: usize = 32;
+const D_FF: usize = 4;
+
+// Captured from openai/gpt-oss-20b revision 6cee5e81ee83917806bbde320786a8fb61efebee,
+// model-00000-of-00002.safetensors (SHA-256 16d0f997dcfc4462089d536bffe51b4bcea2f872f5c430be09ef8ed392312427).
+// The fixture takes expert 0, the first input group, and the smallest row slices
+// that form a complete packed two-projection expert. INPUT is a real BF16 slice
+// from model.layers.0.input_layernorm.weight used as a stable probe vector.
+const INPUT_BF16: [u8; 64] = [
+    0xb2, 0x3f, 0xa1, 0x3f, 0x8a, 0x3f, 0x6e, 0x40, 0x94, 0x3f, 0x2e, 0x3f, 0x00, 0x40, 0x03, 0x40, 0x51, 0x3f, 0x83,
+    0x3f, 0x8b, 0x40, 0xba, 0x3f, 0x7b, 0x3f, 0x35, 0x3f, 0x70, 0x40, 0x18, 0x40, 0x44, 0x40, 0x98, 0x40, 0x96, 0x3f,
+    0xc4, 0x40, 0xa2, 0x3f, 0xa7, 0x40, 0x7e, 0x3f, 0xa3, 0x40, 0x94, 0x40, 0x4d, 0x40, 0x2c, 0x40, 0x08, 0x3f, 0x13,
+    0x40, 0xb6, 0x3f, 0x7c, 0x3f, 0xbb, 0x3f,
+];
+
+// Checkpoint order is [gate0, up0, gate1, up1, ...].
+const GATE_UP_BLOCKS_CHECKPOINT: [u8; 128] = [
+    0x00, 0xc0, 0x80, 0xa9, 0x10, 0x1b, 0x81, 0x22, 0x93, 0xe4, 0xa0, 0xb2, 0x3b, 0x19, 0xb2, 0x31, 0x82, 0xf8, 0xce,
+    0xa8, 0x6e, 0x82, 0xa2, 0x0f, 0xc5, 0x76, 0xc2, 0x7a, 0xcc, 0x8c, 0xc2, 0x24, 0x45, 0x65, 0xdd, 0xf5, 0xc2, 0x29,
+    0x81, 0xf5, 0x66, 0xe7, 0x43, 0xca, 0x04, 0xb1, 0x52, 0x91, 0x04, 0x0a, 0x58, 0x44, 0x68, 0x45, 0x82, 0xc7, 0x62,
+    0x26, 0x7a, 0x78, 0x8d, 0x02, 0x40, 0x0c, 0x4e, 0xc6, 0xa8, 0x5d, 0xa2, 0x45, 0x0a, 0x26, 0xaa, 0xd2, 0x44, 0xe7,
+    0x56, 0x47, 0x2e, 0xdf, 0x5b, 0xcc, 0xa9, 0xad, 0x59, 0xe4, 0x03, 0x51, 0x4d, 0xe4, 0x54, 0x58, 0x29, 0x1a, 0x28,
+    0xaa, 0x11, 0x21, 0x18, 0x12, 0xcc, 0x25, 0x00, 0xc8, 0x08, 0xe1, 0x88, 0x3b, 0x52, 0xa1, 0x0c, 0x13, 0xc5, 0x6d,
+    0xd6, 0x6a, 0xde, 0x6d, 0x28, 0x0a, 0xcc, 0xc8, 0xfa, 0xdd, 0x6d, 0xa2, 0xf6, 0xac,
+];
+const GATE_UP_SCALES_CHECKPOINT: [u8; 8] = [0x7a, 0x79, 0x78, 0x79, 0x78, 0x79, 0x79, 0x79];
+const GATE_UP_BIASES_CHECKPOINT: [u8; 16] =
+    [0x3e, 0xbf, 0x46, 0xbf, 0xd6, 0xbe, 0x67, 0xbf, 0xfa, 0xbe, 0x65, 0xbf, 0xc7, 0xbe, 0x50, 0xbf];
+
+const DOWN_BLOCKS: [u8; 512] = [
+    0x7b, 0xdc, 0x22, 0x5a, 0x31, 0xba, 0xc2, 0x18, 0x01, 0x4a, 0xea, 0x22, 0x44, 0xe9, 0x21, 0x82, 0x10, 0x9c, 0x41,
+    0x69, 0x3d, 0x44, 0x59, 0x1d, 0xcf, 0x52, 0xd9, 0x99, 0x63, 0xec, 0x2b, 0xd8, 0xac, 0x28, 0xf9, 0x2d, 0x05, 0xaa,
+    0x13, 0xc4, 0xa1, 0xde, 0x9d, 0xb2, 0x10, 0xc1, 0x4e, 0xd2, 0xea, 0x84, 0xe0, 0x43, 0x2c, 0x91, 0x1c, 0x31, 0x3d,
+    0x2b, 0xc9, 0x22, 0x9a, 0xb5, 0x3a, 0x14, 0xae, 0x86, 0xe7, 0xac, 0xe7, 0xa6, 0x5d, 0x2d, 0xc7, 0x87, 0xa6, 0x24,
+    0xaa, 0xa2, 0xcd, 0x8c, 0x7d, 0xa0, 0x66, 0xc5, 0x8a, 0x26, 0xef, 0x84, 0x4c, 0x24, 0xc4, 0xc0, 0x2a, 0x6d, 0x22,
+    0x2e, 0x1a, 0xc2, 0xa0, 0x12, 0xbd, 0x5b, 0xa9, 0x2a, 0x3c, 0x38, 0x9d, 0x41, 0x5a, 0xa0, 0xd6, 0xa2, 0x04, 0xa1,
+    0x53, 0x65, 0x03, 0x9a, 0x56, 0x65, 0xc4, 0x47, 0x8b, 0x29, 0x53, 0xd9, 0xa4, 0xed, 0x39, 0xec, 0x1c, 0x89, 0xa8,
+    0xd3, 0x30, 0xa4, 0xaf, 0x30, 0x89, 0xca, 0xb3, 0xbe, 0x51, 0x2c, 0x26, 0xad, 0xb4, 0xc3, 0x96, 0x9e, 0xc1, 0xbd,
+    0xbf, 0xd4, 0x5a, 0xb9, 0xdb, 0x1e, 0x50, 0x2d, 0x13, 0x24, 0x4a, 0xa4, 0x32, 0xaf, 0xcd, 0x1e, 0x47, 0x4a, 0x8c,
+    0x5a, 0xab, 0x56, 0x45, 0x80, 0x84, 0xc5, 0x67, 0x74, 0x2a, 0xd2, 0xe4, 0xca, 0xe0, 0x20, 0xa4, 0x28, 0x50, 0x57,
+    0x6e, 0xe0, 0xac, 0xac, 0xa2, 0xdc, 0x84, 0x04, 0x04, 0x7d, 0xad, 0xd6, 0xa5, 0x5e, 0xa2, 0x0c, 0xe8, 0x5a, 0x11,
+    0x84, 0x9d, 0x4b, 0x89, 0x91, 0xe9, 0xa9, 0x8c, 0x81, 0x3b, 0xb0, 0x08, 0x1b, 0x28, 0x9a, 0x09, 0xd5, 0x6a, 0xb1,
+    0x44, 0x92, 0xcc, 0x54, 0x84, 0xda, 0x59, 0x34, 0x1b, 0xbc, 0x19, 0xa1, 0xdc, 0x8a, 0x84, 0xd9, 0x48, 0x43, 0xbd,
+    0x48, 0xb5, 0x54, 0x04, 0x16, 0x46, 0xca, 0xaa, 0x63, 0x5a, 0xbb, 0x34, 0x12, 0x0d, 0x12, 0xf5, 0x9a, 0x09, 0x99,
+    0x53, 0x99, 0x3b, 0x3e, 0x92, 0x61, 0x18, 0xc0, 0x08, 0xa9, 0x9c, 0x12, 0x21, 0xc6, 0xba, 0x81, 0x12, 0x99, 0xb9,
+    0x24, 0x28, 0x1b, 0xba, 0xd5, 0x99, 0x6c, 0xc2, 0xe8, 0xd8, 0x47, 0xb5, 0x12, 0xeb, 0x9a, 0x94, 0x49, 0x4c, 0xcd,
+    0x1d, 0xfe, 0xd2, 0x43, 0x5a, 0x2e, 0xe9, 0x9e, 0xec, 0x65, 0x90, 0x46, 0x51, 0xb5, 0x95, 0xec, 0x06, 0x54, 0x28,
+    0x7c, 0x5a, 0xdf, 0xf5, 0x74, 0x88, 0x8e, 0xaa, 0xc8, 0x4e, 0xdc, 0x84, 0x7a, 0x1c, 0xb9, 0x66, 0x2c, 0x1e, 0x98,
+    0x0a, 0xa4, 0x69, 0x6a, 0x34, 0xa6, 0xd3, 0x59, 0x44, 0x9d, 0xe7, 0x66, 0x5e, 0xa8, 0x62, 0x42, 0x62, 0x07, 0x65,
+    0xed, 0xe4, 0x28, 0xdc, 0x2f, 0xfd, 0xe7, 0xcb, 0x5e, 0x3a, 0xe4, 0x35, 0x9d, 0x54, 0xa2, 0xbd, 0xa4, 0xeb, 0x99,
+    0xeb, 0x50, 0xce, 0x2b, 0x05, 0x41, 0x2c, 0x44, 0x5c, 0x19, 0xdd, 0x61, 0x56, 0x38, 0x2c, 0x65, 0x62, 0x37, 0x32,
+    0x29, 0xc9, 0x94, 0x3d, 0x0b, 0x19, 0x5b, 0xe0, 0x33, 0xcd, 0x42, 0x1d, 0xa9, 0x16, 0x29, 0x6d, 0x39, 0xfa, 0xdf,
+    0x6d, 0xd6, 0x75, 0xce, 0x4e, 0x15, 0x23, 0xc6, 0x08, 0xa3, 0x4a, 0x63, 0xe6, 0x6a, 0xd8, 0xa4, 0x1c, 0x94, 0x4b,
+    0x0a, 0xb3, 0x95, 0xdb, 0xde, 0x1a, 0xae, 0xa9, 0xa3, 0x99, 0x49, 0x60, 0x3b, 0x12, 0x4c, 0x51, 0x94, 0x30, 0x0a,
+    0x6a, 0x3d, 0x55, 0xb9, 0x31, 0x14, 0x25, 0x49, 0x7d, 0x08, 0x8a, 0xae, 0xd7, 0xdf, 0xa2, 0x67, 0x52, 0xc6, 0x54,
+    0x04, 0xea, 0x84, 0xc5, 0xae, 0x4e, 0xac, 0x74, 0xb0, 0xb8, 0x44, 0x2a, 0xc1, 0x16, 0xb9, 0x30, 0x34, 0xed, 0x91,
+    0x6c, 0x42, 0xc6, 0xf0, 0xd2, 0x40, 0x44, 0x4a, 0xe8, 0xae, 0xa6, 0x5a, 0x24, 0xe7, 0xe7, 0x87, 0x0f, 0x82,
+];
+const DOWN_SCALES: [u8; 32] = [
+    0x79, 0x79, 0x79, 0x78, 0x79, 0x7b, 0x78, 0x78, 0x7b, 0x7a, 0x77, 0x78, 0x7a, 0x7c, 0x78, 0x79, 0x78, 0x78, 0x79,
+    0x76, 0x7a, 0x77, 0x7a, 0x77, 0x77, 0x78, 0x77, 0x7c, 0x78, 0x79, 0x79, 0x79,
+];
+const DOWN_BIASES_BF16: [u8; 64] = [
+    0x05, 0x3d, 0x74, 0xbc, 0x0f, 0xbd, 0x52, 0xbc, 0xed, 0xbd, 0x11, 0x3e, 0x18, 0x3b, 0xe4, 0xbc, 0x8f, 0x3e, 0xa7,
+    0xbd, 0x04, 0xbd, 0x0d, 0x3d, 0xb5, 0x3e, 0xae, 0x3e, 0x91, 0x3c, 0x39, 0xbc, 0xa5, 0xbc, 0xed, 0x3c, 0x3f, 0xbd,
+    0x2d, 0x3b, 0xed, 0x3e, 0xa4, 0xbc, 0xd8, 0x3d, 0xf7, 0xbb, 0xa8, 0xbc, 0xb4, 0x3c, 0x9b, 0x3b, 0x9b, 0x3c, 0x12,
+    0xbc, 0xc4, 0xbd, 0x84, 0x3d, 0x8d, 0xbd,
+];
+
+// The multigroup fixture extends the same expert-0 capture to d_model=64 and
+// d_ff=32: 64 canonical gate/up rows across two input groups, plus 64 down
+// rows across one complete hidden group. Per-slice hashes make recapture drift
+// visible without requiring the 4.8 GB source shard in the test environment.
+// 128 bytes; SHA-256 fafbda6e284ed187210994f22df05e35eaff4296c4b4b0f2a9e6107b58ee4293
+const MULTIGROUP_INPUT_BF16_HEX: &str = concat!(
+    "b23fa13f8a3f6e40943f2e3f00400340513f833f8b40ba3f7b3f353f7040184044409840963fc440a23fa7407e3fa34094404d402c40083f1340b63f7c3fbb3f",
+    "614008406b40793f3840114049406a40a4403040d83f104062408a404140243f8340e73f013f05408c3f3140f83f0a40683f7e3f02409140c43f7140383fa43f",
+);
+
+// 2048 bytes; SHA-256 7a32089353adea970817b49379aef4b9474da270dfe0040c56e80362dbc60a22
+const MULTIGROUP_GATE_UP_BLOCKS_HEX: &str = concat!(
+    "00c080a9101b812293e4a0b23b19b231867222d2654a2288667a4dc2d2ce654a82f8cea86e82a20fc576c27acc8cc224a256407ecaea24dfcae28576ce0d7dca",
+    "4565ddf5c22981f566e743ca04b152912cacd9a2d990c1113971cd010ccb5240040a5844684582c762267a788d02400c2dbe232c66ba4dad2c109c0f1b3d59f8",
+    "4ec6a85da2450a26aad244e756472edf2b0c11252ec9312c0b48914c82345b085bcca9ad59e403514de45458291a28aa1928bc891115a89aeaa0118598d3b101",
+    "11211812cc2500c808e1883b52a10c1311a2918db4a8ea05aa28491c8192aae0c56dd66ade6d280accc8fadd6da2f6aca59ed4213adaed818649314c8b246e28",
+    "8250f8ad82820a06f4a0c202ae0acf87a345ccabeb23a88ab530b34589c41a90182834b3b84081b54b632bda8c918c32852d3a3cac93018ae6911214ac5194a8",
+    "98da11a000b9884f242bd45dd42434aac8cf2fad86c000c7a2d8f66770504ce054ea99aa99138048aa142a49918b9aaa9b0ca9931289932bc1909ba64c99cd98",
+    "1d3e13b6539e810352abc159b3a509b8c251c3b945da00ab1a30e2359acd3bd818081b93111b00bba468041a0108a383a4ad28fa8e2a2a8aae087e82058aefc8",
+    "822c1b946c120129585a9a2cc4a8ab08be2308324fdf2124143aa9a311434cc0c9b11915d3b90963c4a1756a5e8924c4911690562caa318fa1b8bc2519892390",
+    "a9b2b112451d01c06aa3a1816922a2919525ce56891b22254c182a50a3abb4c0b119901193808152928544109615208b333031c1829a305bcc11028c293645a8",
+    "a4a33364498c011130bd99e94b8d4db49da298b1b14126462e98d2b2b92288e9ae5008a5233c01cc4cd9a08130944a24dbb219f4fec73702897120c3e24dfd28",
+    "2b21b120b92e88e2db5a9c0cb58d39c1bb323c4994c214162bb08101425981b80adaa0ffd22a0ac6cccd588224a2d50eaf6a4d5e0227a5d62fa80c0ed2d4c740",
+    "d1b9294c1b03009cd2354ae12918aca9999a990230889d09479139121a2c61485b19ab536f3511e6199fc9a12eae5902aa8b9419d34a5c0ea981aa8b904519b0",
+    "582121b2104988a4cb38b2d3ac86999619c6e01a5d3c32293180a929598d52990c3ac272ba6c8a35404054682fb45596213cc53fc5dd4b5838c91b5f4c5d4120",
+    "04da442242ea02cd4870285ae70a8a8ab3b4119b15db5419ead1bbd3db62b999dae0545c54831197abf5387922b0a92e0dd2fcd02082255048d04f22aa640520",
+    "7c65cc4fd2c68af27e7c76ec74848e8a173bca31c4b15813e6a9c1b5da391999ec8c4c5a2a4c8826da76a8420a2f8c20102b893bc33a5dbab288a801896108a9",
+    "90d91252a220099ec2d9ba599c9c2d61235325d3b51694c49049a984c28d0820433128292ac8090ba93aea3103181999a224dcc7cc457ec08d5a440220d026a0",
+    "101418c5c9c402d6cc4139121d96bb9d8cb241b5bb80fd87aa311922de155d80a1c0a24da1d1902698689adb501b39cf829a6de5bec11c2914a213a91380ab90",
+    "58a1925319ba094a0b83abd97d9c8d1155d9cb6ca4c2251c3cc9c298829451811c69b29a6bda980b8ee3909b9b9b62aa0a555fc2e4e7c42c40c0dad58cd77202",
+    "e852a276eac8025e7677227a6c87cdafbc212910e7a1c4035a21b103bcb5cbe01ccc1b4519250104c1864ef0d616221e3a902e3a4f4a930e92c038a929009090",
+    "285d436c92d28102b5522c1c93262198aa27246ee2a2d84226d842224a5c6c5820ac92bac19099a200b853e21a2182095a2aaf74a7d462aca2dafc45a6e4c240",
+    "ca2ed2c7ea4d85ac76eaa055f4accf46ba2131919ac893b2162039094ac2b938da528a20c22f00ad78ea6a488080aa2244a8454f50e42dc7062850482026caaa",
+    "2212911b992f8156af4391c93c934a148530dd64a0c861bcd9b9243b21e5e941890b11144a9b08b53043923c4e18a9a3c22c872d8d467ae4e46aef0d4226ecd0",
+    "d10c2119341b9981095dfbd85a05c00c828c9696cb093c93dca1311ac9d36e102174c062d6d91a4529995b9124119aa2a221a9935422b5092529a2b69982c220",
+    "025a880119d888c98ae209acbb01b41100cc2c88c4cccb0e9830e13232a25990ada49a1b1bab898899e6c4809912ba1015da15552c333ca329c9f2bc5ca55d4a",
+    "4b94a2f1494110b1cdd868c311aa90cc99135d31e0dc02a5044842a19b622e58ccea2588ceaa022c57cef842cf2d4a5c9545d10ba620bc8c35c1c91398452b20",
+    "3212382c41b5918902233ac98e05ad2c8dab5ccba33c64183211a5530a115149c4a430d0504f0956ed32bcdebc160f95d5240272ef02a0245aaac05a0ad6a452",
+    "a8231a1a331481806de35c29cd0b1cb993a6eb2caeb2430dc332189d9440c8c931e01c33b51592cd0ed5e199d4091187525c09c4c295ca30763a5d66a2445e2a",
+    "0f4d4842dac284864e68a2e02725ce472d00a84002913a1c2399c22282a6b320428b14ce9b5c102b945f986b500bb4919acfc284863aa5a106e2c8ea42112cd1",
+    "42614451d22e11ac5f3cb3423fbabaa1b4ebe55a498bad95dcd169e7029c35b0ca9a91552292880422451319cf0944020c1d84ccc9411701a949d1c93aa2da49",
+    "d44cacd6a4d705e50cf4445a2cad6d229a10a1ab9dba5132b4a2624264cc2218862e12c84946930c8d9449e46905b32cb41b121aa24a223b44604a31112b1928",
+    "64d130294a20892d91431349cb81981531baa94d1d802eaab358c5a49141bc50681e95421c6e90a6aa81dc81d1878c9e19338b21be109015931a1a2cba915110",
+    "ac0acd24082882aa8e722244e226a8280a93aa85b5cb40265411598d9a4ed919f6134946302c0b65e6de65c4b614bbc11a093243194954c289a0394bdb826cb8",
+);
+
+// 128 bytes; SHA-256 355f9ba021dba78991e6192e5c29c9054a0b19ad20a476811a687814f350584b
+const MULTIGROUP_GATE_UP_SCALES_HEX: &str = concat!(
+    "7a787979787979797879797a7979797a78797a7a79787a7a79797a797979797a79797a7a79797a79797979797979797a79797979797979797879797a79797a79",
+    "7979797a797979797879797a79797a797879797979797a797979797a79797a797979797a79797979797979797879797979797a7a7879797a7979797a7979797a",
+);
+
+// 128 bytes; SHA-256 7d20460fac732a4491d43f3593719df16df30ca8044a718548d5822ee2dd1142
+const MULTIGROUP_GATE_UP_BIASES_BF16_HEX: &str = concat!(
+    "3ebf46bfd6be67bffabe65bfc7be50bfbcbe69bf13bf2cbfb6be82bffabe63bf10bf49bf17bf76bfe9be45bf25bf52bfcebe75bf0abf50bf03bf82bfa0be46bf",
+    "10bf7abfd9be74bf04bf4cbf47bf59bf94be38bfc5be66bfe6be7ebfd5be6dbfa0be78bfffbe78bfbcbe69bfc1bd82bf1ebf77bfe0be48bfe8bc4ebfb0be54bf",
+);
+
+// 1024 bytes; SHA-256 0b2527d6952156a2bc676e4a270aebc38f8d706ab5f62e42dbd5ed3bec10b006
+const MULTIGROUP_DOWN_BLOCKS_HEX: &str = concat!(
+    "7bdc225a31bac218014aea2244e92182109c41693d44591dcf52d99963ec2bd8ac28f92d05aa13c4a1de9db210c14ed2ea84e0432c911c313d2bc9229ab53a14",
+    "ae86e7ace7a65d2dc787a624aaa2cd8c7da066c58a26ef844c24c4c02a6d222e1ac2a012bd5ba92a3c389d415aa0d6a204a15365039a5665c4478b2953d9a4ed",
+    "39ec1c89a8d330a4af3089cab3be512c26adb4c3969ec1bdbfd45ab9db1e502d13244aa432afcd1e474a8c5aab56458084c567742ad2e4cae020a42850576ee0",
+    "acaca2dc8404047dadd6a55ea20ce85a11849d4b8991e9a98c813bb0081b289a09d56ab14492cc5484da59341bbc19a1dc8a84d94843bd48b554041646caaa63",
+    "5abb34120d12f59a099953993b3e926118c008a99c1221c6ba811299b924281bbad5996cc2e8d847b512eb9a94494ccd1dfed2435a2ee99eec65904651b595ec",
+    "0654287c5adff574888eaac84edc847a1cb9662c1e980aa4696a34a6d359449de7665ea86242620765ede428dc2ffde7cb5e3ae4359d54a2bda4eb99eb50ce2b",
+    "05412c445c19dd6156382c6562373229c9943d0b195be033cd421da916296d39fadf6dd675ce4e1523c608a34a63e66ad8a41c944b0ab395dbde1aaea9a39949",
+    "603b124c5194300a6a3d55b9311425497d088aaed7dfa26752c65404ea84c5ae4eac74b0b8442ac116b93034ed916c42c6f0d240444ae8aea65a24e7e7870f82",
+    "b3ac12b01d6d2ba6b9901cbb80c05a1d2984a21a51c240846b521355c2244ba1d582422257688246a54248a24d2e22ca56d2eabc8be9df9c1a914dd83a2ad814",
+    "8a11c4b430384a158cd33c859d18a246ccc5200aa422a22085e02d40cca6467aab01a2b2943a50b0270412403bc10a49d8660eac7a2a8ecccda24474c0ad2e5a",
+    "1b0a4ca028a94da45641eba5c8c041b9c55032cca1a98b9a90bc89e39b1311c18c5a9b147dc4646ac95bced356b7ad99b4552c0c4ed5cd55e974da6303d8a016",
+    "138e2a251155a3932029b3740b8199992270a6ad52a8da22e260ceac428842ccb52a1c615c302490ab5d2239bd39da9c189d53d899e02aa488290d9d2cba019d",
+    "0444893b6a18b14c9adc5241912998ac36289b481a39119c9ac2a92abe89351392d3b1b4ab19b88e923398ab3a2951a428a3824a0c211892e2429204440a2981",
+    "92619c23d5631ae1690c365dd96b1a513dea4ee248e1058ec41da6ded49c5622a15544255e6bbd5aac95cee4e2549d4a5a0afd2722428c72d66caadd02022080",
+    "c5939c1ac13d693ca2135ca112941cb29bcedbdaaaab59c5c91493d33a22b911ac20ed84440ed02800222aaa48a207adc5ee890e62d27ac644e54713cc97a670",
+    "a3e5ad5adc9d5d3a4c994e398b4e5c11964132219294401812cbbb23a29a2c9c93d41832899352528641ac21ac81dbbbac44055ca2a4a2ca8aa268728aa2d558",
+);
+
+// 64 bytes; SHA-256 53f8fcb3c56234db5f8c9649c51ee10b307dd1bcd4a649bb7099188a8e5c7218
+const MULTIGROUP_DOWN_SCALES_HEX: &str = "79797978797b78787b7a77787a7c7879787879767a777a777778777c78797979787a777a78787877777878787877787b78797c79797778787a7a787778787b79";
+
+// 128 bytes; SHA-256 c3e120bc74bf9251f35b00a216a9ebeb3d3ffda950fc1b82c32b03ee6646414e
+const MULTIGROUP_DOWN_BIASES_BF16_HEX: &str = concat!(
+    "053d74bc0fbd52bcedbd113e183be4bc8f3ea7bd04bd0d3db53eae3e913c39bca5bced3c3fbd2d3bed3ea4bcd83df7bba8bcb43c9b3b9b3c12bcc4bd843d8dbd",
+    "51bcf03cf23ce53dbabcc0bd1bbd673cbfbbecbc403d623d47bb01bc083cbebd64bb84bcc33d72bd1d3ece3beabb98bc353ea23d8a3c0bbd573de4bc513e7a3c",
+);
+
+fn bf16_from_le_bytes(bytes: &[u8]) -> Vec<bf16> {
+    let (bytes, remainder) = bytes.as_chunks::<2>();
+    assert!(remainder.is_empty(), "BF16 fixture must contain complete values");
+    bytes.iter().map(|bytes| bf16::from_bits(u16::from_le_bytes(*bytes))).collect()
+}
+
+fn bytes_from_hex(hex: &str) -> Vec<u8> {
+    assert!(hex.len().is_multiple_of(2), "hex fixture must contain complete bytes");
+    hex.as_bytes()
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|digits| {
+            let decode = |digit| match digit {
+                b'0'..=b'9' => digit - b'0',
+                b'a'..=b'f' => digit - b'a' + 10,
+                _ => panic!("fixture contains a non-hex digit"),
+            };
+            decode(digits[0]) << 4 | decode(digits[1])
+        })
+        .collect()
+}
+
+/// Lalamo's canonical group-16 gate/up payload, derived losslessly from checkpoint pairs.
+fn stack_gate_up_mxfp4(
+    blocks: &[u8],
+    scales: &[u8],
+    biases: &[bf16],
+    d_model: usize,
+    d_ff: usize,
+) -> (Vec<u8>, Vec<u8>, Vec<bf16>) {
+    let bytes_per_row = d_model / 2;
+    let checkpoint_groups_per_row = d_model / 32;
+    let rows = (0..d_ff).map(|row| 2 * row + 1).chain((0..d_ff).map(|row| 2 * row)).collect::<Vec<_>>();
+    let blocks =
+        rows.iter().flat_map(|&row| blocks[row * bytes_per_row..(row + 1) * bytes_per_row].iter().copied()).collect();
+    let scales = rows
+        .iter()
+        .flat_map(|&row| {
+            scales[row * checkpoint_groups_per_row..(row + 1) * checkpoint_groups_per_row]
+                .iter()
+                .flat_map(|&scale| [scale, scale])
+        })
+        .collect();
+    let biases = rows
+        .iter()
+        .enumerate()
+        .map(|(row, &checkpoint_row)| {
+            let bias = biases[checkpoint_row];
+            if row < d_ff {
+                return bf16::from_f32(f32::from(bias) + 1.0);
+            }
+            bias
+        })
+        .collect();
+    (blocks, scales, biases)
+}
+
+fn decode_mxfp4(
+    blocks: &[u8],
+    scales: &[u8],
+    row: usize,
+    row_width: usize,
+    column: usize,
+) -> f32 {
+    const VALUES: [f32; 16] = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0];
+
+    let groups_per_row = row_width.div_ceil(32);
+    let group = column / 32;
+    let element = column % 32;
+    let packed = blocks[(row * groups_per_row + group) * 16 + element / 2];
+    let code = if element.is_multiple_of(2) {
+        packed & 0x0f
+    } else {
+        packed >> 4
+    };
+    let exponent = i32::from(scales[row * groups_per_row + group]) - 127;
+    VALUES[usize::from(code)] * 2.0f32.powi(exponent)
+}
+
+fn dense_reference(
+    input: &[bf16],
+    w13_blocks: &[u8],
+    w13_scales: &[u8],
+    w2_blocks: &[u8],
+    w2_scales: &[u8],
+    w13_global_scale: f32,
+    w2_global_scale: f32,
+    up_biases: &[bf16],
+    down_biases: &[bf16],
+    d_model: usize,
+    d_ff: usize,
+) -> Vec<bf16> {
+    let mut hidden = vec![0.0f32; d_ff];
+    for hidden_idx in 0..d_ff {
+        let gate_row = 2 * hidden_idx;
+        let up_row = gate_row + 1;
+        let mut gate = 0.0f32;
+        let mut up = 0.0f32;
+        for model_idx in 0..d_model {
+            let input = f32::from(input[model_idx]);
+            gate = input.mul_add(decode_mxfp4(w13_blocks, w13_scales, gate_row, d_model, model_idx), gate);
+            up = input.mul_add(decode_mxfp4(w13_blocks, w13_scales, up_row, d_model, model_idx), up);
+        }
+        gate = gate * w13_global_scale + f32::from(up_biases[gate_row]);
+        up = up * w13_global_scale + f32::from(up_biases[up_row]);
+        let up = up.clamp(-7.0, 7.0) + 1.0;
+        let gate = gate.min(7.0);
+        hidden[hidden_idx] = (gate / (1.0 + (-1.702 * gate).exp())) * up;
+    }
+
+    (0..d_model)
+        .map(|model_idx| {
+            let mut output = 0.0f32;
+            for hidden_idx in 0..d_ff {
+                output =
+                    hidden[hidden_idx].mul_add(decode_mxfp4(w2_blocks, w2_scales, model_idx, d_ff, hidden_idx), output);
+            }
+            output = output * w2_global_scale + f32::from(down_biases[model_idx]);
+            bf16::from_f32(output)
+        })
+        .collect()
+}
+
+#[uzu_test]
+fn test_real_gpt_oss_mxfp4_expert_decode_matches_dense_reference() {
+    for_each_non_cpu_backend!(|B| {
+        let context = create_context::<B>();
+        let input = bf16_from_le_bytes(&INPUT_BF16);
+        let checkpoint_up_biases = bf16_from_le_bytes(&GATE_UP_BIASES_CHECKPOINT);
+        let down_biases = bf16_from_le_bytes(&DOWN_BIASES_BF16);
+        let expected = dense_reference(
+            &input,
+            &GATE_UP_BLOCKS_CHECKPOINT,
+            &GATE_UP_SCALES_CHECKPOINT,
+            &DOWN_BLOCKS,
+            &DOWN_SCALES,
+            0.5,
+            2.0,
+            &checkpoint_up_biases,
+            &down_biases,
+            D_MODEL,
+            D_FF,
+        );
+        let (w13_blocks, w13_scales, up_biases) = stack_gate_up_mxfp4(
+            &GATE_UP_BLOCKS_CHECKPOINT,
+            &GATE_UP_SCALES_CHECKPOINT,
+            &checkpoint_up_biases,
+            D_MODEL,
+            D_FF,
+        );
+
+        assert_eq!(w13_blocks.len(), 2 * D_FF * (D_MODEL / 16) * 8);
+        assert_eq!(w13_scales.len(), 2 * D_FF * (D_MODEL / 16));
+        assert_eq!(DOWN_BLOCKS.len(), D_MODEL * D_FF.div_ceil(32) * 16);
+
+        let input = alloc_allocation_with_data::<B, bf16>(&context, &input);
+        let offsets = alloc_allocation_with_data::<B, u32>(&context, &[0, 1]);
+        let w13_blocks = alloc_allocation_with_data::<B, u8>(&context, &w13_blocks);
+        let w13_scales = alloc_allocation_with_data::<B, u8>(&context, &w13_scales);
+        let w13_global_scale = alloc_allocation_with_data::<B, bf16>(&context, &[bf16::from_f32(0.5)]);
+        let w2_blocks = alloc_allocation_with_data::<B, u8>(&context, &DOWN_BLOCKS);
+        let w2_scales = alloc_allocation_with_data::<B, u8>(&context, &DOWN_SCALES);
+        let w2_global_scale = alloc_allocation_with_data::<B, bf16>(&context, &[bf16::from_f32(2.0)]);
+        let up_biases = alloc_allocation_with_data::<B, bf16>(&context, &up_biases);
+        let down_biases = alloc_allocation_with_data::<B, bf16>(&context, &down_biases);
+
+        let block = MoeExpertsMxfp4DecodeBlock::<B>::new(&context, DataType::BF16, 2).expect("MXFP4 decode block");
+        let mut encoder = Encoder::new(context.as_ref()).expect("encoder");
+        let output = block
+            .encode(
+                MoeExpertsMxfp4Arguments {
+                    x_perm: &input,
+                    expert_offsets: &offsets,
+                    w13_blocks: &w13_blocks,
+                    w13_scales: &w13_scales,
+                    w13_global_scale: &w13_global_scale,
+                    w2_blocks: &w2_blocks,
+                    w2_scales: &w2_scales,
+                    w2_global_scale: &w2_global_scale,
+                    up_biases: &up_biases,
+                    down_biases: &down_biases,
+                    total_rows: 1,
+                    d_model: D_MODEL,
+                    d_ff: D_FF,
+                    num_routed_experts: 1,
+                    gate_clip_min: f32::NEG_INFINITY,
+                    gate_clip_max: 7.0,
+                    up_clip_min: -6.0,
+                    up_clip_max: 8.0,
+                    silu_alpha: 1.702,
+                },
+                &mut encoder,
+            )
+            .expect("encode packed expert");
+
+        let completed = encoder.end_encoding().submit().wait_until_completed().expect("run packed expert");
+        let actual = allocation_prefix_to_vec::<B, bf16>(&output, D_MODEL);
+        assert_eq_float(&expected, &actual, 0.02, "real GPT-OSS MXFP4 expert output");
+        drop(output);
+        drop(completed);
+    });
+}
+
+#[uzu_test]
+fn test_real_gpt_oss_multigroup_mxfp4_expert_decode_matches_dense_reference() {
+    const MULTIGROUP_D_MODEL: usize = 64;
+    const MULTIGROUP_D_FF: usize = 32;
+    const PREFILL_ROWS: usize = 33;
+
+    for_each_non_cpu_backend!(|B| {
+        let context = create_context::<B>();
+        let input_bytes = bytes_from_hex(MULTIGROUP_INPUT_BF16_HEX);
+        let w13_blocks = bytes_from_hex(MULTIGROUP_GATE_UP_BLOCKS_HEX);
+        let w13_scales = bytes_from_hex(MULTIGROUP_GATE_UP_SCALES_HEX);
+        let checkpoint_up_bias_bytes = bytes_from_hex(MULTIGROUP_GATE_UP_BIASES_BF16_HEX);
+        let w2_blocks = bytes_from_hex(MULTIGROUP_DOWN_BLOCKS_HEX);
+        let w2_scales = bytes_from_hex(MULTIGROUP_DOWN_SCALES_HEX);
+        let down_bias_bytes = bytes_from_hex(MULTIGROUP_DOWN_BIASES_BF16_HEX);
+
+        let input = bf16_from_le_bytes(&input_bytes);
+        let checkpoint_up_biases = bf16_from_le_bytes(&checkpoint_up_bias_bytes);
+        let down_biases = bf16_from_le_bytes(&down_bias_bytes);
+        let expected = dense_reference(
+            &input,
+            &w13_blocks,
+            &w13_scales,
+            &w2_blocks,
+            &w2_scales,
+            1.0,
+            1.0,
+            &checkpoint_up_biases,
+            &down_biases,
+            MULTIGROUP_D_MODEL,
+            MULTIGROUP_D_FF,
+        );
+        // Repeat the captured checkpoint row once beyond the scheduler boundary.
+        let prefill_input = input.repeat(PREFILL_ROWS);
+        let prefill_expected = expected.repeat(PREFILL_ROWS);
+        let (w13_blocks, w13_scales, up_biases) =
+            stack_gate_up_mxfp4(&w13_blocks, &w13_scales, &checkpoint_up_biases, MULTIGROUP_D_MODEL, MULTIGROUP_D_FF);
+
+        // These dimensions force four group-16 w13 groups and one complete group-32 w2 group.
+        assert_eq!(w13_blocks.len(), 2 * MULTIGROUP_D_FF * (MULTIGROUP_D_MODEL / 16) * 8);
+        assert_eq!(w13_scales.len(), 2 * MULTIGROUP_D_FF * (MULTIGROUP_D_MODEL / 16));
+        assert_eq!(w2_blocks.len(), MULTIGROUP_D_MODEL * (MULTIGROUP_D_FF / 32) * 16);
+        assert_eq!(w2_scales.len(), MULTIGROUP_D_MODEL * (MULTIGROUP_D_FF / 32));
+
+        let input = alloc_allocation_with_data::<B, bf16>(&context, &input);
+        let offsets = alloc_allocation_with_data::<B, u32>(&context, &[0, 1]);
+        let prefill_input = alloc_allocation_with_data::<B, bf16>(&context, &prefill_input);
+        let prefill_offsets = alloc_allocation_with_data::<B, u32>(&context, &[0, PREFILL_ROWS as u32]);
+        let w13_blocks = alloc_allocation_with_data::<B, u8>(&context, &w13_blocks);
+        let w13_scales = alloc_allocation_with_data::<B, u8>(&context, &w13_scales);
+        let w13_global_scale = alloc_allocation_with_data::<B, bf16>(&context, &[bf16::ONE]);
+        let w2_blocks = alloc_allocation_with_data::<B, u8>(&context, &w2_blocks);
+        let w2_scales = alloc_allocation_with_data::<B, u8>(&context, &w2_scales);
+        let w2_global_scale = alloc_allocation_with_data::<B, bf16>(&context, &[bf16::ONE]);
+        let up_biases = alloc_allocation_with_data::<B, bf16>(&context, &up_biases);
+        let down_biases = alloc_allocation_with_data::<B, bf16>(&context, &down_biases);
+
+        let block = MoeExpertsMxfp4DecodeBlock::<B>::new(&context, DataType::BF16, 2).expect("MXFP4 decode block");
+        let mut encoder = Encoder::new(context.as_ref()).expect("encoder");
+        let output = block
+            .encode(
+                MoeExpertsMxfp4Arguments {
+                    x_perm: &input,
+                    expert_offsets: &offsets,
+                    w13_blocks: &w13_blocks,
+                    w13_scales: &w13_scales,
+                    w13_global_scale: &w13_global_scale,
+                    w2_blocks: &w2_blocks,
+                    w2_scales: &w2_scales,
+                    w2_global_scale: &w2_global_scale,
+                    up_biases: &up_biases,
+                    down_biases: &down_biases,
+                    total_rows: 1,
+                    d_model: MULTIGROUP_D_MODEL,
+                    d_ff: MULTIGROUP_D_FF,
+                    num_routed_experts: 1,
+                    gate_clip_min: f32::NEG_INFINITY,
+                    gate_clip_max: 7.0,
+                    up_clip_min: -6.0,
+                    up_clip_max: 8.0,
+                    silu_alpha: 1.702,
+                },
+                &mut encoder,
+            )
+            .expect("encode packed multigroup expert");
+
+        let completed = encoder.end_encoding().submit().wait_until_completed().expect("run packed multigroup expert");
+        let actual = allocation_prefix_to_vec::<B, bf16>(&output, MULTIGROUP_D_MODEL);
+        assert_eq_float(&expected, &actual, 0.02, "real GPT-OSS multigroup MXFP4 expert output");
+        drop(output);
+        drop(completed);
+
+        let block = MoeExpertsMxfp4PrefillBlock::<B>::new(&context, DataType::BF16, 2).expect("MXFP4 prefill block");
+        let mut encoder = Encoder::new(context.as_ref()).expect("encoder");
+        let output = block
+            .encode(
+                MoeExpertsMxfp4Arguments {
+                    x_perm: &prefill_input,
+                    expert_offsets: &prefill_offsets,
+                    w13_blocks: &w13_blocks,
+                    w13_scales: &w13_scales,
+                    w13_global_scale: &w13_global_scale,
+                    w2_blocks: &w2_blocks,
+                    w2_scales: &w2_scales,
+                    w2_global_scale: &w2_global_scale,
+                    up_biases: &up_biases,
+                    down_biases: &down_biases,
+                    total_rows: PREFILL_ROWS,
+                    d_model: MULTIGROUP_D_MODEL,
+                    d_ff: MULTIGROUP_D_FF,
+                    num_routed_experts: 1,
+                    gate_clip_min: f32::NEG_INFINITY,
+                    gate_clip_max: 7.0,
+                    up_clip_min: -6.0,
+                    up_clip_max: 8.0,
+                    silu_alpha: 1.702,
+                },
+                &mut encoder,
+            )
+            .expect("encode packed multigroup prefill expert");
+
+        let completed =
+            encoder.end_encoding().submit().wait_until_completed().expect("run packed multigroup prefill expert");
+        let actual = allocation_prefix_to_vec::<B, bf16>(&output, PREFILL_ROWS * MULTIGROUP_D_MODEL);
+        assert_eq_float(&prefill_expected, &actual, 0.02, "real GPT-OSS multigroup MXFP4 prefill output");
+        drop(output);
+        drop(completed);
+    });
+}
+
+#[uzu_test]
+#[ignore]
+fn test_gpt_oss_mxfp4_expert_decode_perf() {
+    for_each_non_cpu_backend!(|B| {
+        const MODEL_DIM: usize = 2880;
+        const EXPERT_HIDDEN_DIM: usize = 2880;
+
+        let context = create_context::<B>();
+        let model_groups = MODEL_DIM / 16;
+        let hidden_groups = EXPERT_HIDDEN_DIM / 32;
+
+        let input = alloc_allocation_with_data::<B, bf16>(&context, &vec![bf16::ZERO; MODEL_DIM]);
+        let offsets = alloc_allocation_with_data::<B, u32>(&context, &[0, 1]);
+        let w13_blocks =
+            alloc_allocation_with_data::<B, u8>(&context, &vec![0; 2 * EXPERT_HIDDEN_DIM * model_groups * 8]);
+        let w13_scales =
+            alloc_allocation_with_data::<B, u8>(&context, &vec![127; 2 * EXPERT_HIDDEN_DIM * model_groups]);
+        let w13_global_scale = alloc_allocation_with_data::<B, bf16>(&context, &[bf16::ONE]);
+        let w2_blocks = alloc_allocation_with_data::<B, u8>(&context, &vec![0; MODEL_DIM * hidden_groups * 16]);
+        let w2_scales = alloc_allocation_with_data::<B, u8>(&context, &vec![127; MODEL_DIM * hidden_groups]);
+        let w2_global_scale = alloc_allocation_with_data::<B, bf16>(&context, &[bf16::ONE]);
+        let up_biases = alloc_allocation_with_data::<B, bf16>(&context, &vec![bf16::ZERO; 2 * EXPERT_HIDDEN_DIM]);
+        let down_biases = alloc_allocation_with_data::<B, bf16>(&context, &vec![bf16::ZERO; MODEL_DIM]);
+
+        const ENCODE_COUNT: usize = 100;
+        let block = MoeExpertsMxfp4DecodeBlock::<B>::new(&context, DataType::BF16, 2).expect("MXFP4 block");
+        let run = |block: &MoeExpertsMxfp4DecodeBlock<B>| {
+            let mut encoder = Encoder::new(context.as_ref()).expect("encoder");
+            for _ in 0..ENCODE_COUNT {
+                let output = block
+                    .encode(
+                        MoeExpertsMxfp4Arguments {
+                            x_perm: &input,
+                            expert_offsets: &offsets,
+                            w13_blocks: &w13_blocks,
+                            w13_scales: &w13_scales,
+                            w13_global_scale: &w13_global_scale,
+                            w2_blocks: &w2_blocks,
+                            w2_scales: &w2_scales,
+                            w2_global_scale: &w2_global_scale,
+                            up_biases: &up_biases,
+                            down_biases: &down_biases,
+                            total_rows: 1,
+                            d_model: MODEL_DIM,
+                            d_ff: EXPERT_HIDDEN_DIM,
+                            num_routed_experts: 1,
+                            gate_clip_min: f32::NEG_INFINITY,
+                            gate_clip_max: 7.0,
+                            up_clip_min: -6.0,
+                            up_clip_max: 8.0,
+                            silu_alpha: 1.702,
+                        },
+                        &mut encoder,
+                    )
+                    .expect("encode packed expert");
+                drop(output);
+            }
+            let completed = encoder.end_encoding().submit().wait_until_completed().expect("run packed expert");
+            completed.gpu_execution_time().as_secs_f64() * 1000.0 / ENCODE_COUNT as f64
+        };
+
+        for _ in 0..3 {
+            run(&block);
+        }
+        let mut times = (0..20).map(|_| run(&block)).collect::<Vec<_>>();
+        times.sort_by(|a, b| a.partial_cmp(b).expect("finite GPU time"));
+        let mean = times.iter().sum::<f64>() / times.len() as f64;
+        let median = times[times.len() / 2];
+        let min = times[0];
+        let max = times[times.len() - 1];
+
+        eprintln!("  GPT-OSS MXFP4  mean={mean:.3}ms median={median:.3}ms min={min:.3}ms max={max:.3}ms");
+    });
+}

--- a/crates/backend-uzu/tests/unit/encodable_block/moe/moe_tiles_test.rs
+++ b/crates/backend-uzu/tests/unit/encodable_block/moe/moe_tiles_test.rs
@@ -42,7 +42,7 @@ fn test_tile_counts_correctness() {
                 <<B as Backend>::Kernels as Kernels>::MoeTileCountsKernel::new(&ctx).expect("MoeTileCountsKernel::new");
             let mut encoder = Encoder::new(ctx.as_ref()).expect("Failed to create encoder");
             let mut tile_counts_buf = alloc_allocation::<B, u32>(&ctx, e);
-            counts_kernel.encode(&offsets_buf, &mut tile_counts_buf, e as u32, &mut encoder);
+            counts_kernel.encode(&offsets_buf, &mut tile_counts_buf, e as u32, 16, &mut encoder);
             let completed = encoder.end_encoding().submit().wait_until_completed().unwrap();
 
             let tile_counts_gpu = allocation_prefix_to_vec::<B, u32>(&tile_counts_buf, e);
@@ -117,7 +117,7 @@ fn test_tile_edge_cases() {
                 <<B as Backend>::Kernels as Kernels>::MoeTileCountsKernel::new(&ctx).expect("MoeTileCountsKernel::new");
             let mut encoder = Encoder::new(ctx.as_ref()).expect("Failed to create encoder");
             let mut tile_counts_buf = alloc_allocation::<B, u32>(&ctx, e);
-            counts_kernel.encode(&offsets_buf, &mut tile_counts_buf, e as u32, &mut encoder);
+            counts_kernel.encode(&offsets_buf, &mut tile_counts_buf, e as u32, 16, &mut encoder);
             let completed = encoder.end_encoding().submit().wait_until_completed().unwrap();
 
             let tile_counts_gpu = allocation_prefix_to_vec::<B, u32>(&tile_counts_buf, e);
@@ -142,7 +142,7 @@ fn test_tile_edge_cases() {
                 <<B as Backend>::Kernels as Kernels>::MoeTileCountsKernel::new(&ctx).expect("MoeTileCountsKernel::new");
             let mut encoder = Encoder::new(ctx.as_ref()).expect("Failed to create encoder");
             let mut tile_counts_buf = alloc_allocation::<B, u32>(&ctx, e);
-            counts_kernel.encode(&offsets_buf, &mut tile_counts_buf, e as u32, &mut encoder);
+            counts_kernel.encode(&offsets_buf, &mut tile_counts_buf, e as u32, 16, &mut encoder);
             let completed = encoder.end_encoding().submit().wait_until_completed().unwrap();
 
             let tile_counts_gpu = allocation_prefix_to_vec::<B, u32>(&tile_counts_buf, e);
@@ -153,6 +153,30 @@ fn test_tile_edge_cases() {
             // With BM=16: seg_lens=[10, 5, 15, 20] -> tile_counts=[1, 1, 1, 2]
             assert_eq!(tile_counts_gpu, &[1, 1, 1, 2]);
             eprintln!("[TileEdgeCases] ✓ Small segments PASSED");
+        }
+
+        // Test the MXFP4 row-tile boundary and its first partial second tile.
+        {
+            let e = 3;
+            let row_tile_size = 64;
+            let offsets = vec![0, 64, 129, 130];
+            let tile_counts_cpu = cpu_tile_counts(&offsets, row_tile_size);
+            let offsets_buf = alloc_allocation_with_data::<B, u32>(&ctx, &offsets);
+
+            let counts_kernel =
+                <<B as Backend>::Kernels as Kernels>::MoeTileCountsKernel::new(&ctx).expect("MoeTileCountsKernel::new");
+            let mut encoder = Encoder::new(ctx.as_ref()).expect("Failed to create encoder");
+            let mut tile_counts_buf = alloc_allocation::<B, u32>(&ctx, e);
+            counts_kernel.encode(&offsets_buf, &mut tile_counts_buf, e as u32, row_tile_size as u32, &mut encoder);
+            let completed = encoder.end_encoding().submit().wait_until_completed().unwrap();
+
+            let tile_counts_gpu = allocation_prefix_to_vec::<B, u32>(&tile_counts_buf, e);
+            drop(tile_counts_buf);
+            drop(completed);
+
+            assert_eq!(tile_counts_gpu, tile_counts_cpu);
+            assert_eq!(tile_counts_gpu, &[1, 2, 1]);
+            eprintln!("[TileEdgeCases] ✓ MXFP4 row tiles PASSED");
         }
     });
 }


### PR DESCRIPTION
Dear Mirai team!

Thank you for making Uzu. I am building a CLI called `please`, whose current model support is centered on `gpt-oss`, and I would like to contribute that model path upstream.

This PR adds native GPT-OSS MXFP4 mixture-of-experts execution. Lalamo exports remain packed instead of expanding the large expert matrices to BF16, while Uzu's existing full-precision MoE path remains unchanged.

## Artifact contract

The official GPT-OSS checkpoint stores its fused projection as adjacent `[gate, up]` rows with group-32 MXFP4. The approved update in [Lalamo #339](https://github.com/trymirai/lalamo/pull/339) canonicalizes that representation during import:

- W13 rows become `[all up, all gate]`.
- Each original 32-value W13 block becomes two 16-value groups with the original E8M0 scale duplicated, so the represented values do not change.
- W2 remains ordinary group-32 MXFP4.
- The exported `MicrofloatSpec` fully describes the result; no GPT-OSS-specific layout mode is required.

Uzu validates that exact pair of specs (group-16 W13 and group-32 W2), keeps packed storage coupled to the MoE execution path, and dispatches dedicated decode and prefill kernels.

## Correctness

The branch is checked at several boundaries:

- Captured real GPT-OSS blocks, scales, biases, and global scales match a scalar dense reference.
- A multigroup fixture covers group-16 W13, group-32 W2, decode, and a 33-row prefill crossing the scheduler boundary.
- The block loader executes a Lalamo-shaped safetensors artifact and rejects mixed or unsupported expert specs.
- The focused MXFP4 suite passes 5 tests with 1 performance-only test ignored.
- The broader MoE suite passes 50 tests with 9 performance/production-scale tests ignored.

## Kernel work

The Metal kernels and host scheduling are adapted from the working GPT-OSS path in `llama.cpp` and expressed through Uzu's existing encoder, allocation, routing, and kernel abstractions. The branch also retains correctness-gated MXFP4-local improvements developed during testing: threadgroup lookup tables, vectorized prefill loads, and tuned decode/prefill tile geometry. It does not include the unrelated dense-Q8 work or any experimental packed layout.

The implementation is currently limited to Metal MoE experts using the canonical GPT-OSS combination of 4-bit group-16 W13 and group-32 W2. A generic arbitrary-group-size microfloat matmul API, NVFP4 kernels, and the suggested M5 integer-in-SRAM path remain follow-ups.

## Prerequisite

This PR consumes the artifact contract from [Lalamo #339](https://github.com/trymirai/lalamo/pull/339) or an equivalent.
