### PR TITLE
 Fix GDN state precision across update paths

### DIFF
--- a/crates/backend-uzu/src/backends/cpu/kernel/gdn/prefill_prep.rs
+++ b/crates/backend-uzu/src/backends/cpu/kernel/gdn/prefill_prep.rs
@@ -15,6 +15,7 @@ pub fn delta_net_prefill_prep<T: ArrayElement + Float, QKT: ArrayElement + Float
     dt_bias: *const f32,
     q_norm_out: *mut QKT,
     k_norm_out: *mut QKT,
+    #[optional(write_state_k_norm)] state_k_norm_out: Option<*mut f32>,
     #[optional(write_compact_v)] compact_v_out: Option<*mut T>,
     beta_out: *mut f32,
     decay_out: *mut f32,
@@ -25,9 +26,8 @@ pub fn delta_net_prefill_prep<T: ArrayElement + Float, QKT: ArrayElement + Float
     suffix_len: u32,
     #[specialize] write_log_decay: bool,
     #[specialize] write_compact_v: bool,
+    #[specialize] write_state_k_norm: bool,
 ) {
-    assert_eq!(compact_v_out.is_some(), write_compact_v, "compact V output presence mismatch");
-
     let num_v_heads = num_v_heads as usize;
     let num_k_heads = num_k_heads as usize;
     let head_k_dim = HEAD_K_DIM as usize;
@@ -41,7 +41,8 @@ pub fn delta_net_prefill_prep<T: ArrayElement + Float, QKT: ArrayElement + Float
     for token in 0..suffix_len {
         let tok_offset = token * total_proj_dim;
 
-        if let Some(compact_v_out) = compact_v_out {
+        if write_compact_v {
+            let compact_v_out = compact_v_out.unwrap();
             unsafe {
                 in_proj
                     .add(tok_offset + 2 * key_dim)
@@ -76,7 +77,12 @@ pub fn delta_net_prefill_prep<T: ArrayElement + Float, QKT: ArrayElement + Float
             let k_inv = 1.0 / (k_sq + 1e-6).sqrt();
             for j in 0..head_k_dim {
                 let v = unsafe { (*in_proj.add(k_off + j)).to_f32().unwrap() };
-                unsafe { *k_norm_out.add(token * key_dim + hk * head_k_dim + j) = QKT::from(v * k_inv).unwrap() };
+                let k_norm = v * k_inv;
+                unsafe { *k_norm_out.add(token * key_dim + hk * head_k_dim + j) = QKT::from(k_norm).unwrap() };
+                if write_state_k_norm {
+                    let state_k_norm_out = state_k_norm_out.unwrap();
+                    unsafe { *state_k_norm_out.add(token * key_dim + hk * head_k_dim + j) = k_norm };
+                }
             }
 
             // Beta and decay for each v-head of this k-head

--- a/crates/backend-uzu/src/backends/cpu/kernel/gdn/tree_verify/state_advance.rs
+++ b/crates/backend-uzu/src/backends/cpu/kernel/gdn/tree_verify/state_advance.rs
@@ -8,7 +8,7 @@ use crate::array::ArrayElement;
 #[variants(T, f32, bf16)]
 #[variants(HEAD_K_DIM, 128)]
 pub fn state_advance<T: ArrayElement + Float, const HEAD_K_DIM: u32>(
-    k_norm: *const T,
+    state_k_norm: *const f32,
     v: *const T,
     log_decay_buf: *const f32,
     beta_buf: *const f32,
@@ -42,16 +42,13 @@ pub fn state_advance<T: ArrayElement + Float, const HEAD_K_DIM: u32>(
                 for dk_idx in 0..head_k_dim {
                     let state_element_ptr = unsafe { state.add(state_row_offset + dk_idx) };
                     unsafe { *state_element_ptr *= decay };
-                    kv_mem += unsafe { *state_element_ptr * (*k_norm.add(k_offset + dk_idx)).to_f32().unwrap() };
+                    kv_mem += unsafe { *state_element_ptr * *state_k_norm.add(k_offset + dk_idx) };
                 }
                 let v_value =
                     unsafe { (*v.add(tree_idx * value_dim + hv_idx * head_v_dim + dv_idx)).to_f32().unwrap() };
                 let delta = beta * (v_value - kv_mem);
                 for dk_idx in 0..head_k_dim {
-                    unsafe {
-                        *state.add(state_row_offset + dk_idx) +=
-                            (*k_norm.add(k_offset + dk_idx)).to_f32().unwrap() * delta
-                    };
+                    unsafe { *state.add(state_row_offset + dk_idx) += *state_k_norm.add(k_offset + dk_idx) * delta };
                 }
             }
         }

--- a/crates/backend-uzu/src/backends/metal/kernel/gdn/chunked/a_diag_inv.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/gdn/chunked/a_diag_inv.metal
@@ -66,7 +66,7 @@ KERNEL(DeltaNetChunkedADiagInv)(
       const float beta_row = beta[row_token * num_v_heads + hv_idx];
       const float g_row = g_head[row_token];
       const float g_col = g_head[col_token];
-      value = beta_row * fast::exp(g_row - g_col) * kk[kk_base + row * CHUNK_SIZE + col];
+      value = beta_row * exp(g_row - g_col) * kk[kk_base + row * CHUNK_SIZE + col];
     }
 
     const uint out_idx =

--- a/crates/backend-uzu/src/backends/metal/kernel/gdn/chunked/gram.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/gdn/chunked/gram.metal
@@ -105,7 +105,7 @@ KERNEL(DeltaNetChunkedGram)(
       }
       const float g_row = g_head[chunk_token_base + row];
       const float g_col = g_head[chunk_token_base + col];
-      return value * fast::exp(g_row - g_col);
+      return value * exp(g_row - g_col);
     });
     const uint dst_base =
         (chunk_idx * num_v_heads + hv_idx) * CHUNK_SIZE * CHUNK_SIZE + row_base * CHUNK_SIZE + col_base;

--- a/crates/backend-uzu/src/backends/metal/kernel/gdn/chunked/mod.rs
+++ b/crates/backend-uzu/src/backends/metal/kernel/gdn/chunked/mod.rs
@@ -54,7 +54,15 @@ impl DeltaNetChunkedPrefill<Metal> for MetalDeltaNetChunkedPrefill {
 
         Ok(Some(Self {
             min_t: MXU_MIN_T,
-            prep: DeltaNetPrefillPrepMetalKernel::new(context, outer_data_type, DataType::F32, head_dim, true, false)?,
+            prep: DeltaNetPrefillPrepMetalKernel::new(
+                context,
+                outer_data_type,
+                DataType::F32,
+                head_dim,
+                true,
+                false,
+                false,
+            )?,
             cumsum: DeltaNetChunkedCumsumMetalKernel::new(context, CHUNK_SIZE as u32)?,
             gram: DeltaNetChunkedGramMetalKernel::new(context, head_dim, CHUNK_SIZE as u32)?,
             a_diag_inv: DeltaNetChunkedADiagInvMetalKernel::new(context, CHUNK_SIZE as u32)?,
@@ -124,6 +132,7 @@ impl DeltaNetChunkedPrefill<Metal> for MetalDeltaNetChunkedPrefill {
             args.dt_bias,
             &mut q_norm,
             &mut k_norm,
+            None::<&mut crate::backends::common::Allocation<Metal>>,
             None::<&mut crate::backends::common::Allocation<Metal>>,
             &mut beta,
             &mut log_decay,

--- a/crates/backend-uzu/src/backends/metal/kernel/gdn/chunked/output_and_state.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/gdn/chunked/output_and_state.metal
@@ -146,7 +146,7 @@ KERNEL(DeltaNetChunkedOutputAndState)(
         const float beta_t = beta[token * num_v_heads + hv_idx];
         const float g_t = g_head[token];
         const float value_input = float(value_input_tile[uint(row) * total_proj_dim + uint(col)]);
-        return beta_t * (value_input - fast::exp(g_t) * state_projection);
+        return beta_t * (value_input - exp(g_t) * state_projection);
       });
       residual_acc.store(lane, residual_new_value_tile + token_tile_base * VT, int(VT));
     }
@@ -200,7 +200,7 @@ KERNEL(DeltaNetChunkedOutputAndState)(
           return 0.0f;
         }
         const uint token = token_base + token_tile_base + uint(row);
-        return value * fast::exp(g_head[token]);
+        return value * exp(g_head[token]);
       });
 
       const uint qk_tile_base =
@@ -235,7 +235,7 @@ KERNEL(DeltaNetChunkedOutputAndState)(
       const uint key_tile_base = simdgroup_idx * OUTPUT_STATE_KEY_TILE;
       const uint g_last_token = token_base + (valid_tokens > 0 ? valid_tokens - 1 : 0u);
       const float g_last = g_head[g_last_token];
-      const float state_decay = fast::exp(g_last);
+      const float state_decay = exp(g_last);
 
       ValueKeyFragment state_update_acc;
       state_update_acc.clear();
@@ -262,7 +262,7 @@ KERNEL(DeltaNetChunkedOutputAndState)(
           }
           const uint token = token_base + source_token_block_start + uint(row);
           // beta is already folded into Vnew through R.
-          return value * fast::exp(g_last - g_head[token]);
+          return value * exp(g_last - g_head[token]);
         });
         fragment_mma(state_update_acc, new_value_frag, key_frag);
       }

--- a/crates/backend-uzu/src/backends/metal/kernel/gdn/prefill_prep.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/gdn/prefill_prep.metal
@@ -15,6 +15,7 @@ PUBLIC KERNEL(DeltaNetPrefillPrep)(
     device const float* dt_bias,
     device QKT* q_norm_out,
     device QKT* k_norm_out,
+    device float* state_k_norm_out OPTIONAL(write_state_k_norm),
     device T* compact_v_out OPTIONAL(write_compact_v),
     device float* beta_out,
     device float* decay_out,
@@ -27,6 +28,7 @@ PUBLIC KERNEL(DeltaNetPrefillPrep)(
     const uint hk_idx GROUPS(num_k_heads),
     const bool write_log_decay SPECIALIZE,
     const bool write_compact_v SPECIALIZE,
+    const bool write_state_k_norm SPECIALIZE,
     const uint lane THREADS(METAL_SIMD_SIZE)
 ) {
   static_assert(HEAD_K_DIM % METAL_SIMD_SIZE == 0, "HEAD_K_DIM must be a multiple of METAL_SIMD_SIZE");
@@ -60,21 +62,25 @@ PUBLIC KERNEL(DeltaNetPrefillPrep)(
   const uint out_base = token_idx * key_dim + hk_idx * HEAD_K_DIM;
   for (uint i = 0; i < elems_per_thread; ++i) {
     const uint idx = lane + i * METAL_SIMD_SIZE;
+    const float k_norm = k_vals[i] * k_inv_norm;
     q_norm_out[out_base + idx] = static_cast<QKT>(q_vals[i] * q_inv_norm * q_scale);
-    k_norm_out[out_base + idx] = static_cast<QKT>(k_vals[i] * k_inv_norm);
+    k_norm_out[out_base + idx] = static_cast<QKT>(k_norm);
+    if (write_state_k_norm) {
+      state_k_norm_out[out_base + idx] = k_norm;
+    }
   }
 
   for (uint group = lane; group < groups_per_head; group += METAL_SIMD_SIZE) {
     const uint hv = hk_idx * groups_per_head + group;
     const float beta_raw = float(in_proj[tok_offset + conv_dim + value_dim + hv]);
     const float a_raw = float(in_proj[tok_offset + conv_dim + value_dim + num_v_heads + hv]);
-    const float log_decay = -fast::exp(a_log[hv]) * activate_softplus(a_raw + dt_bias[hv]);
+    const float log_decay = -exp(a_log[hv]) * activate_softplus(a_raw + dt_bias[hv]);
 
-    beta_out[token_idx * num_v_heads + hv] = 1.0f / (1.0f + fast::exp(-beta_raw));
+    beta_out[token_idx * num_v_heads + hv] = 1.0f / (1.0f + exp(-beta_raw));
     if (write_log_decay) {
       decay_out[token_idx * num_v_heads + hv] = log_decay;
     } else {
-      decay_out[token_idx * num_v_heads + hv] = fast::exp(log_decay);
+      decay_out[token_idx * num_v_heads + hv] = exp(log_decay);
     }
   }
 

--- a/crates/backend-uzu/src/backends/metal/kernel/gdn/tree_verify.rs
+++ b/crates/backend-uzu/src/backends/metal/kernel/gdn/tree_verify.rs
@@ -66,7 +66,7 @@ impl DeltaNetTreeVerify<Metal> for MetalDeltaNetTreeVerify {
         context: &MetalContext,
         arguments: &TreeVerifyNewArguments,
     ) -> Result<Self, MetalError> {
-        let use_mxu = arguments.data_type == DataType::BF16 && context.supports_mxu();
+        let use_mxu = false;
         let transposed_h0 =
             !use_mxu && matches!(context.device_tier(), DeviceTier::SmallLegacy | DeviceTier::SmallApple8);
         Ok(Self {

--- a/crates/backend-uzu/src/backends/metal/kernel/gdn/tree_verify/state_advance.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/gdn/tree_verify/state_advance.metal
@@ -14,8 +14,8 @@ template <typename T, uint HEAD_K_DIM>
 VARIANTS(T, float, bfloat)
 VARIANTS(HEAD_K_DIM, 128)
 PUBLIC KERNEL(StateAdvance)(
-    // [tree_size, num_k_heads, HEAD_K_DIM]
-    device const T* k_norm,
+    // F32 normalized key for the persistent-state update.
+    device const float* state_k_norm,
     // [tree_size, num_v_heads, HEAD_K_DIM]
     device const T* v,
     // [tree_size, num_v_heads]
@@ -57,10 +57,10 @@ PUBLIC KERNEL(StateAdvance)(
   for (uint accepted_idx = 0; accepted_idx < accepted_len; ++accepted_idx) {
     const uint tree_idx = accepted_indices[accepted_idx];
     const uint tree_head_offset = tree_idx * num_v_heads + hv_idx;
-    const float decay = fast::exp(log_decay_buf[tree_head_offset]);
+    const float decay = exp(log_decay_buf[tree_head_offset]);
     const float beta = beta_buf[tree_head_offset];
     const uint k_offset = tree_idx * key_dim + hk_idx * HEAD_K_DIM + dk_base;
-    const float4 k = float4(*reinterpret_cast<const device vec<T, 4>*>(k_norm + k_offset));
+    const float4 k = *reinterpret_cast<const device float4*>(state_k_norm + k_offset);
 
     state_rows[0] *= decay;
     state_rows[1] *= decay;

--- a/crates/backend-uzu/src/backends/metal/kernel/gdn/update.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/gdn/update.metal
@@ -71,10 +71,10 @@ PUBLIC KERNEL(DeltaNetUpdate)(
 
   // beta / decay (scalar per head)
   const float beta_raw = float(in_proj[conv_dim + value_dim + hv_idx]);
-  const float beta = 1.0f / (1.0f + fast::exp(-beta_raw));
+  const float beta = 1.0f / (1.0f + exp(-beta_raw));
   const float a_raw = float(in_proj[conv_dim + value_dim + num_v_heads + hv_idx]);
   const float sp = activate_softplus(a_raw + float(dt_bias[hv_idx]));
-  const float decay = fast::exp(-fast::exp(float(a_log[hv_idx])) * sp);
+  const float decay = exp(-exp(float(a_log[hv_idx])) * sp);
 
   // Delta rule over the dv owned by this simd group. State is [Hv, Dv, Dk].
   for (uint dv = sg; dv < head_v_dim; dv += NUM_SG) {

--- a/crates/backend-uzu/src/encodable_block/mixer/delta_net.rs
+++ b/crates/backend-uzu/src/encodable_block/mixer/delta_net.rs
@@ -38,7 +38,7 @@ enum DeltaNetSuffixStatus<B: Backend> {
     },
     Tree {
         conv_states: Allocation<B>,
-        k: Allocation<B>,
+        state_k_norm: Allocation<B>,
         v: Allocation<B>,
         log_decay: Allocation<B>,
         beta: Allocation<B>,
@@ -79,7 +79,7 @@ impl<B: Backend> MixerState<B> for DeltaNetState<B> {
             },
             DeltaNetSuffixStatus::Tree {
                 conv_states,
-                k,
+                state_k_norm,
                 v,
                 log_decay,
                 beta,
@@ -102,7 +102,7 @@ impl<B: Backend> MixerState<B> for DeltaNetState<B> {
                     encoder.allocate_constant(accepted_indices.len() * DataType::U32.size_in_bytes())?;
                 accepted_indices_buffer.copyin(&accepted_indices);
                 self.state_advance.encode(
-                    &k,
+                    &state_k_norm,
                     &v,
                     &log_decay,
                     &beta,
@@ -251,6 +251,7 @@ impl<B: Backend> DeltaNet<B> {
             config.head_dim as u32,
             false,
             false,
+            false,
         )
         .map_err(DeltaNetNewError::Backend)?;
         let delta_net_tree_prep = <B::Kernels as Kernels>::DeltaNetPrefillPrepKernel::new(
@@ -258,6 +259,7 @@ impl<B: Backend> DeltaNet<B> {
             outer_data_type,
             outer_data_type,
             config.head_dim as u32,
+            true,
             true,
             true,
         )
@@ -354,6 +356,7 @@ impl<B: Backend> DeltaNet<B> {
         let mut conv_states = encoder
             .allocate_scratch(size_for_shape(&[tree_size, self.conv_dim, self.kernel_size - 1], DataType::F32))?;
         let mut k = encoder.allocate_scratch(size_for_shape(&[tree_size, self.key_dim], self.outer_data_type))?;
+        let mut state_k_norm = encoder.allocate_scratch(size_for_shape(&[tree_size, self.key_dim], DataType::F32))?;
         let mut v = encoder.allocate_scratch(size_for_shape(&[tree_size, self.value_dim], self.outer_data_type))?;
         let mut beta = encoder.allocate_scratch(size_for_shape(&[tree_size, self.num_heads], DataType::F32))?;
         let mut log_decay = encoder.allocate_scratch(size_for_shape(&[tree_size, self.num_heads], DataType::F32))?;
@@ -382,6 +385,7 @@ impl<B: Backend> DeltaNet<B> {
             &self.dt_bias,
             &mut q,
             &mut k,
+            Some(&mut state_k_norm),
             Some(&mut v),
             &mut beta,
             &mut log_decay,
@@ -423,7 +427,7 @@ impl<B: Backend> DeltaNet<B> {
         let output = self.out_projection.encode(delta_output, tree_size, encoder)?;
         state.suffix_status = Some(DeltaNetSuffixStatus::Tree {
             conv_states,
-            k,
+            state_k_norm,
             v,
             log_decay,
             beta,
@@ -598,6 +602,7 @@ impl<B: Backend> Mixer<B> for DeltaNet<B> {
                     &self.dt_bias,
                     &mut prep_q_norm,
                     &mut prep_k_norm,
+                    None::<&mut Allocation<B>>,
                     None::<&mut Allocation<B>>,
                     &mut prep_beta,
                     &mut prep_decay,

--- a/crates/backend-uzu/tests/unit/backends/common/kernel/gdn/delta_net_test.rs
+++ b/crates/backend-uzu/tests/unit/backends/common/kernel/gdn/delta_net_test.rs
@@ -333,6 +333,7 @@ fn run_prefill_with_norm_gate_typed<T: ArrayElement>(
         head_k_dim as u32,
         false,
         false,
+        false,
     )
     .unwrap();
     let prefill_k = <<Metal as Backend>::Kernels as Kernels>::DeltaNetPrefillKernel::new(
@@ -351,6 +352,7 @@ fn run_prefill_with_norm_gate_typed<T: ArrayElement>(
         &dt_bias_array,
         &mut q_norm_array,
         &mut k_norm_array,
+        None::<&mut crate::backends::common::Allocation<Metal>>,
         None::<&mut crate::backends::common::Allocation<Metal>>,
         &mut beta_array,
         &mut decay_array,
@@ -506,6 +508,7 @@ fn test_delta_net_prefill_prep() {
     let cpu_dt_bias = alloc_allocation_with_data::<Cpu, f32>(&cpu_ctx, &dt_bias);
     let mut cpu_q = alloc_allocation::<Cpu, bf16>(&cpu_ctx, suffix_len * key_dim);
     let mut cpu_k = alloc_allocation::<Cpu, bf16>(&cpu_ctx, suffix_len * key_dim);
+    let mut cpu_state_k_norm = alloc_allocation::<Cpu, f32>(&cpu_ctx, suffix_len * key_dim);
     let mut cpu_v = alloc_allocation::<Cpu, bf16>(&cpu_ctx, suffix_len * value_dim);
     let mut cpu_beta = alloc_allocation::<Cpu, f32>(&cpu_ctx, suffix_len * num_v_heads);
     let mut cpu_decay = alloc_allocation::<Cpu, f32>(&cpu_ctx, suffix_len * num_v_heads);
@@ -517,6 +520,7 @@ fn test_delta_net_prefill_prep() {
         head_k_dim as u32,
         false,
         true,
+        true,
     )
     .unwrap();
     let mut cpu_enc = Encoder::new(cpu_ctx.as_ref()).expect("encoder");
@@ -526,6 +530,7 @@ fn test_delta_net_prefill_prep() {
         &cpu_dt_bias,
         &mut cpu_q,
         &mut cpu_k,
+        Some(&mut cpu_state_k_norm),
         Some(&mut cpu_v),
         &mut cpu_beta,
         &mut cpu_decay,
@@ -540,6 +545,7 @@ fn test_delta_net_prefill_prep() {
 
     let ref_q = allocation_to_vec::<Cpu, bf16>(&cpu_q).into_iter().map(f32::from).collect::<Vec<_>>();
     let ref_k = allocation_to_vec::<Cpu, bf16>(&cpu_k).into_iter().map(f32::from).collect::<Vec<_>>();
+    let ref_state_k_norm = allocation_to_vec::<Cpu, f32>(&cpu_state_k_norm);
     let ref_v: Vec<bf16> = allocation_to_vec(&cpu_v);
     let ref_beta: Vec<f32> = allocation_to_vec(&cpu_beta);
     let ref_decay: Vec<f32> = allocation_to_vec(&cpu_decay);
@@ -547,7 +553,17 @@ fn test_delta_net_prefill_prep() {
         .chunks_exact(total_proj_dim)
         .flat_map(|row| row[2 * key_dim..2 * key_dim + value_dim].iter().copied())
         .collect::<Vec<_>>();
+    let mut expected_state_k_norm = Vec::with_capacity(suffix_len * key_dim);
+    for row in in_proj.chunks_exact(total_proj_dim) {
+        for hk in 0..num_k_heads {
+            let key = &row[key_dim + hk * head_k_dim..key_dim + (hk + 1) * head_k_dim];
+            let norm_sq = key.iter().map(|value| f32::from(*value).powi(2)).sum::<f32>();
+            let inv_norm = 1.0 / (norm_sq + 1e-6).sqrt();
+            expected_state_k_norm.extend(key.iter().map(|value| f32::from(*value) * inv_norm));
+        }
+    }
     assert_eq!(ref_v, expected_v);
+    assert_close(&ref_state_k_norm, &expected_state_k_norm, 1e-7, 1e-6, "CPU prep state_k_norm");
 
     // Metal
     let context = <Metal as Backend>::Context::new().expect("context");
@@ -556,6 +572,7 @@ fn test_delta_net_prefill_prep() {
     let dt_bias_array = alloc_allocation_with_data::<Metal, f32>(&context, &dt_bias);
     let mut q_norm_array = alloc_allocation::<Metal, bf16>(&context, suffix_len * key_dim);
     let mut k_norm_array = alloc_allocation::<Metal, bf16>(&context, suffix_len * key_dim);
+    let mut state_k_norm_array = alloc_allocation::<Metal, f32>(&context, suffix_len * key_dim);
     let mut compact_v_array = alloc_allocation::<Metal, bf16>(&context, suffix_len * value_dim);
 
     let mut beta_array = alloc_allocation::<Metal, f32>(&context, suffix_len * num_v_heads);
@@ -568,6 +585,7 @@ fn test_delta_net_prefill_prep() {
         head_k_dim as u32,
         false,
         true,
+        true,
     )
     .unwrap();
 
@@ -578,6 +596,7 @@ fn test_delta_net_prefill_prep() {
         &dt_bias_array,
         &mut q_norm_array,
         &mut k_norm_array,
+        Some(&mut state_k_norm_array),
         Some(&mut compact_v_array),
         &mut beta_array,
         &mut decay_array,
@@ -592,12 +611,14 @@ fn test_delta_net_prefill_prep() {
 
     let gpu_q = allocation_to_vec::<Metal, bf16>(&q_norm_array).into_iter().map(f32::from).collect::<Vec<_>>();
     let gpu_k = allocation_to_vec::<Metal, bf16>(&k_norm_array).into_iter().map(f32::from).collect::<Vec<_>>();
+    let gpu_state_k_norm = allocation_to_vec::<Metal, f32>(&state_k_norm_array);
     let gpu_v: Vec<bf16> = allocation_to_vec(&compact_v_array);
     let gpu_beta: Vec<f32> = allocation_to_vec(&beta_array);
     let gpu_decay: Vec<f32> = allocation_to_vec(&decay_array);
 
     assert_close(&gpu_q, &ref_q, 1e-4, 1e-3, "prep q_norm");
     assert_close(&gpu_k, &ref_k, 1e-4, 1e-3, "prep k_norm");
+    assert_close(&gpu_state_k_norm, &expected_state_k_norm, 1e-6, 1e-5, "Metal prep state_k_norm");
     assert_eq!(gpu_v, ref_v);
     assert_close(&gpu_beta, &ref_beta, 1e-4, 1e-3, "prep beta");
     assert_close(&gpu_decay, &ref_decay, 1e-4, 1e-3, "prep decay");
@@ -646,6 +667,7 @@ fn bench_delta_net_prefill() {
         head_k_dim as u32,
         false,
         false,
+        false,
     )
     .unwrap();
     let prefill_k = <<Metal as Backend>::Kernels as Kernels>::DeltaNetPrefillKernel::new(
@@ -672,6 +694,7 @@ fn bench_delta_net_prefill() {
             &mut q_norm_array,
             &mut k_norm_array,
             None::<&mut crate::backends::common::Allocation<Metal>>,
+            None::<&mut crate::backends::common::Allocation<Metal>>,
             &mut beta_array,
             &mut decay_array,
             num_v_heads as u32,
@@ -697,6 +720,7 @@ fn bench_delta_net_prefill() {
             &dt_bias_array,
             &mut q_norm_array,
             &mut k_norm_array,
+            None::<&mut crate::backends::common::Allocation<Metal>>,
             None::<&mut crate::backends::common::Allocation<Metal>>,
             &mut beta_array,
             &mut decay_array,

--- a/crates/backend-uzu/tests/unit/backends/common/kernel/gdn/tree_verify/state_advance_test.rs
+++ b/crates/backend-uzu/tests/unit/backends/common/kernel/gdn/tree_verify/state_advance_test.rs
@@ -47,13 +47,13 @@ fn run<B: Backend, T: ArrayElement + Float>(accepted_indices: &[u32]) -> Vec<f32
     let value_len = TREE_SIZE * TEST_NUM_V_HEADS * HEAD_DIM;
     let scalar_len = TREE_SIZE * TEST_NUM_V_HEADS;
     let state_len = TEST_NUM_V_HEADS * HEAD_DIM * HEAD_DIM;
-    let k_norm = (0..key_len).map(|i| T::from((i % 17) as f32 * 0.002 - 0.016).unwrap()).collect::<Vec<_>>();
+    let state_k_norm = (0..key_len).map(|i| (i % 17) as f32 * 0.002 - 0.016).collect::<Vec<_>>();
     let v = (0..value_len).map(|i| T::from((i % 19) as f32 * 0.003 - 0.027).unwrap()).collect::<Vec<_>>();
     let log_decay = (0..scalar_len).map(|i| -0.01 - (i % 7) as f32 * 0.002).collect::<Vec<_>>();
     let beta = (0..scalar_len).map(|i| 0.2 + (i % 5) as f32 * 0.03).collect::<Vec<_>>();
     let initial_state = (0..state_len).map(|i| (i % 23) as f32 * 0.001 - 0.011).collect::<Vec<_>>();
 
-    let k_norm = alloc_allocation_with_data::<B, T>(&context, &k_norm);
+    let state_k_norm = alloc_allocation_with_data::<B, f32>(&context, &state_k_norm);
     let v = alloc_allocation_with_data::<B, T>(&context, &v);
     let log_decay = alloc_allocation_with_data::<B, f32>(&context, &log_decay);
     let beta = alloc_allocation_with_data::<B, f32>(&context, &beta);
@@ -63,7 +63,7 @@ fn run<B: Backend, T: ArrayElement + Float>(accepted_indices: &[u32]) -> Vec<f32
 
     let mut encoder = Encoder::new(context.as_ref()).expect("encoder");
     kernel.encode(
-        &k_norm,
+        &state_k_norm,
         &v,
         &log_decay,
         &beta,
@@ -102,10 +102,8 @@ fn bench_state_advance(c: &mut Criterion) {
         NUM_K_HEADS as u32,
     )
     .expect("kernel");
-    let k_norm = alloc_allocation_with_data::<Metal, bf16>(
-        &context,
-        &vec![bf16::from_f32(0.001); TREE_SIZE * NUM_K_HEADS * HEAD_DIM],
-    );
+    let state_k_norm =
+        alloc_allocation_with_data::<Metal, f32>(&context, &vec![0.001; TREE_SIZE * NUM_K_HEADS * HEAD_DIM]);
     let v = alloc_allocation_with_data::<Metal, bf16>(
         &context,
         &vec![bf16::from_f32(0.01); TREE_SIZE * NUM_V_HEADS * HEAD_DIM],
@@ -124,7 +122,7 @@ fn bench_state_advance(c: &mut Criterion) {
         group.bench_function(format!("L{accepted_len}"), |bencher| {
             iter_encode_loop_named::<Metal, _>(&context, bencher, &format!("{BENCHMARK}/L{accepted_len}"), |encoder| {
                 kernel.encode(
-                    &k_norm,
+                    &state_k_norm,
                     &v,
                     &log_decay,
                     &beta,

--- a/crates/backend-uzu/tests/unit/backends/metal/kernel/gdn/chunked_test.rs
+++ b/crates/backend-uzu/tests/unit/backends/metal/kernel/gdn/chunked_test.rs
@@ -86,6 +86,7 @@ fn run_prefill<T: ArrayElement>(
                 HEAD_K_DIM as u32,
                 false,
                 false,
+                false,
             )
             .expect("prep")
             .encode(
@@ -94,6 +95,7 @@ fn run_prefill<T: ArrayElement>(
                 &dt_bias,
                 &mut q,
                 &mut k,
+                None::<&mut crate::backends::common::Allocation<Metal>>,
                 None::<&mut crate::backends::common::Allocation<Metal>>,
                 &mut beta,
                 &mut decay,


### PR DESCRIPTION
  - Preserve F32 normalized K for persistent-state updates while retaining activation-dtype K for tensor-core computations.
  - Apply consistent ordinary exp/log/rsqrt math across recurrent, chunked-prefill, and tree-verification kernels.
  - Remove explicit metal::precise overrides and precise SiLU handling.
  - Keep the strict out.metal MXU path.
  - Add coverage for the F32 state-key preparation and state advancement paths.