### PR TITLE
Reliable MoE Routing Beyond 256 Tokens

### DIFF
--- a/crates/backend-uzu/src/backends/cpu/kernel/moe/counts_offsets_fused.rs
+++ b/crates/backend-uzu/src/backends/cpu/kernel/moe/counts_offsets_fused.rs
@@ -2,67 +2,69 @@ use proc_macros::kernel;
 
 #[kernel(MoeCountsOffsetsFused)]
 pub fn moe_counts_offsets_fused(
-    topk_ids: *const i32,
-    offsets: *mut u32,
-    sum_k_out: *mut u32,
-    partials: *mut u32,
-    t_input: u32,
-    e_input: u32,
-    k_input: u32,
+    selected_expert_ids: *const i32,
+    expert_offsets: *mut u32,
+    total_routed_row_count: *mut u32,
+    scatter_block_expert_counts: *mut u32,
+    token_count: u32,
+    expert_count: u32,
+    selected_experts_per_token: u32,
 ) {
-    let e = e_input as usize;
-    let t = t_input as usize;
-    let k = k_input as usize;
+    let expert_count = expert_count as usize;
+    let token_count = token_count as usize;
+    let selected_experts_per_token = selected_experts_per_token as usize;
 
-    if e == 0 {
+    if expert_count == 0 {
         unsafe {
-            *offsets = 0;
-            *sum_k_out = 0;
+            *expert_offsets = 0;
+            *total_routed_row_count = 0;
         }
         return;
     }
 
     const SCATTER_BLOCK_SIZE: usize = 256;
-    const TILE_E: usize = 512;
-    let num_blocks = t.div_ceil(SCATTER_BLOCK_SIZE);
-    let num_tiles = e.div_ceil(TILE_E);
+    const EXPERT_TILE_SIZE: usize = 512;
+    let scatter_block_count = token_count.div_ceil(SCATTER_BLOCK_SIZE);
+    let expert_tile_count = expert_count.div_ceil(EXPERT_TILE_SIZE);
 
     // Phase 1: Count tokens per expert and per scatter block.
-    let mut counts = vec![0u32; e];
-    for block_id in 0..num_blocks {
-        let mut block_counts = vec![0u32; e];
-        let t_start = block_id * SCATTER_BLOCK_SIZE;
-        let t_end = (t_start + SCATTER_BLOCK_SIZE).min(t);
-        for ti in t_start..t_end {
-            let base = ti * k;
-            for kk in 0..k {
-                let eid = unsafe { *topk_ids.add(base + kk) };
-                if eid >= 0 {
-                    let ue = eid as usize;
-                    if ue < e {
-                        counts[ue] += 1;
-                        block_counts[ue] += 1;
+    let mut total_expert_counts = vec![0u32; expert_count];
+    for scatter_block_index in 0..scatter_block_count {
+        let mut expert_counts_in_block = vec![0u32; expert_count];
+        let token_block_start = scatter_block_index * SCATTER_BLOCK_SIZE;
+        let token_block_end = (token_block_start + SCATTER_BLOCK_SIZE).min(token_count);
+        for token_index in token_block_start..token_block_end {
+            let selected_expert_row_start = token_index * selected_experts_per_token;
+            for selected_expert_slot in 0..selected_experts_per_token {
+                let selected_expert_id =
+                    unsafe { *selected_expert_ids.add(selected_expert_row_start + selected_expert_slot) };
+                if selected_expert_id >= 0 {
+                    let expert_index = selected_expert_id as usize;
+                    if expert_index < expert_count {
+                        total_expert_counts[expert_index] += 1;
+                        expert_counts_in_block[expert_index] += 1;
                     }
                 }
             }
         }
 
-        for (expert_id, count) in block_counts.into_iter().enumerate() {
-            let tile_id = expert_id / TILE_E;
-            let tile_expert_id = expert_id % TILE_E;
-            let partial_idx = (block_id * num_tiles + tile_id) * TILE_E + tile_expert_id;
-            unsafe { *partials.add(partial_idx) = count };
+        for (expert_index, expert_count_in_block) in expert_counts_in_block.into_iter().enumerate() {
+            let expert_tile_index = expert_index / EXPERT_TILE_SIZE;
+            let expert_index_in_tile = expert_index % EXPERT_TILE_SIZE;
+            let partial_count_index =
+                (scatter_block_index * expert_tile_count + expert_tile_index) * EXPERT_TILE_SIZE + expert_index_in_tile;
+            unsafe { *scatter_block_expert_counts.add(partial_count_index) = expert_count_in_block };
         }
     }
 
     // Phase 2: Exclusive prefix scan to produce offsets
-    let mut sum = 0u32;
-    for i in 0..e {
-        unsafe { *offsets.add(i) = sum };
-        sum += counts[i];
+    let mut expert_offset_carry = 0u32;
+    for expert_index in 0..expert_count {
+        unsafe { *expert_offsets.add(expert_index) = expert_offset_carry };
+        expert_offset_carry += total_expert_counts[expert_index];
     }
     unsafe {
-        *offsets.add(e) = sum;
-        *sum_k_out = sum;
+        *expert_offsets.add(expert_count) = expert_offset_carry;
+        *total_routed_row_count = expert_offset_carry;
     }
 }

--- a/crates/backend-uzu/src/backends/cpu/kernel/moe/counts_offsets_fused.rs
+++ b/crates/backend-uzu/src/backends/cpu/kernel/moe/counts_offsets_fused.rs
@@ -22,24 +22,37 @@ pub fn moe_counts_offsets_fused(
         return;
     }
 
-    // Phase 1: Count tokens per expert (histogram)
+    const SCATTER_BLOCK_SIZE: usize = 256;
+    const TILE_E: usize = 512;
+    let num_blocks = t.div_ceil(SCATTER_BLOCK_SIZE);
+    let num_tiles = e.div_ceil(TILE_E);
+
+    // Phase 1: Count tokens per expert and per scatter block.
     let mut counts = vec![0u32; e];
-    for ti in 0..t {
-        let base = ti * k;
-        for kk in 0..k {
-            let eid = unsafe { *topk_ids.add(base + kk) };
-            if eid >= 0 {
-                let ue = eid as usize;
-                if ue < e {
-                    counts[ue] += 1;
+    for block_id in 0..num_blocks {
+        let mut block_counts = vec![0u32; e];
+        let t_start = block_id * SCATTER_BLOCK_SIZE;
+        let t_end = (t_start + SCATTER_BLOCK_SIZE).min(t);
+        for ti in t_start..t_end {
+            let base = ti * k;
+            for kk in 0..k {
+                let eid = unsafe { *topk_ids.add(base + kk) };
+                if eid >= 0 {
+                    let ue = eid as usize;
+                    if ue < e {
+                        counts[ue] += 1;
+                        block_counts[ue] += 1;
+                    }
                 }
             }
         }
-    }
 
-    // Write partials (same as counts for single-threadgroup case)
-    for i in 0..e {
-        unsafe { *partials.add(i) = counts[i] };
+        for (expert_id, count) in block_counts.into_iter().enumerate() {
+            let tile_id = expert_id / TILE_E;
+            let tile_expert_id = expert_id % TILE_E;
+            let partial_idx = (block_id * num_tiles + tile_id) * TILE_E + tile_expert_id;
+            unsafe { *partials.add(partial_idx) = count };
+        }
     }
 
     // Phase 2: Exclusive prefix scan to produce offsets

--- a/crates/backend-uzu/src/backends/metal/kernel/moe/counts_offsets_fused.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/moe/counts_offsets_fused.metal
@@ -35,32 +35,32 @@ static T threadgroup_raking_prefix_exclusive_sum(T value, threadgroup T* shared,
   return result;
 }
 
-#define BLOCK_SIZE 128
+#define THREADGROUP_SIZE 128
 #define SCATTER_BLOCK_SIZE 256
-#define TILE_E 512
+#define EXPERT_TILE_SIZE 512
 
 // Single-kernel fused: count all experts + scan to offsets
 // This kernel is launched with SINGLE threadgroup
 PUBLIC KERNEL(MoeCountsOffsetsFused)(
-    device const int* topk_ids,
-    device uint* offsets,   // output: exclusive scan [E+1]
-    device uint* sum_k_out, // output: total count [1]
-    device uint* partials,  // output: partials [num_blocks * num_tiles * TILE_E] (for block_bases)
-    constant uint& t_input,
-    constant uint& e_input,
-    constant uint& k_input,
-    threadgroup _atomic<uint> tg_hist[TILE_E],
-    threadgroup uint scan_shared[BLOCK_SIZE],
-    threadgroup uint reduce_shared[BLOCK_SIZE],
-    threadgroup uint counts_shared[TILE_E], // Cache global counts in threadgroup memory
-    threadgroup uint& carry,
+    device const int* selected_expert_ids,
+    device uint* expert_offsets,              // output: exclusive scan [expert_count + 1]
+    device uint* total_routed_row_count,      // output: total count [1]
+    device uint* scatter_block_expert_counts, // output: partial histograms for block_bases
+    constant uint& token_count,
+    constant uint& expert_count,
+    constant uint& selected_experts_per_token,
+    threadgroup _atomic<uint> threadgroup_expert_histogram[EXPERT_TILE_SIZE],
+    threadgroup uint prefix_scan_scratch[THREADGROUP_SIZE],
+    threadgroup uint reduction_scratch[THREADGROUP_SIZE],
+    threadgroup uint total_expert_counts[EXPERT_TILE_SIZE], // Cache global counts in threadgroup memory
+    threadgroup uint& expert_offset_carry,
     const ThreadContext thread_context,
-    const uint lid THREADS(128)
+    const uint thread_index_in_threadgroup THREADS(128)
 ) {
-  if (e_input == 0) {
-    if (lid == 0) {
-      offsets[0] = 0u;
-      sum_k_out[0] = 0u;
+  if (expert_count == 0) {
+    if (thread_index_in_threadgroup == 0) {
+      expert_offsets[0] = 0u;
+      total_routed_row_count[0] = 0u;
     }
     return;
   }
@@ -68,48 +68,55 @@ PUBLIC KERNEL(MoeCountsOffsetsFused)(
   // ═══════════════════════════════════════════════════════════
   // PHASE 1: Count tokens per expert using tiled histogram
   // ═══════════════════════════════════════════════════════════
-  const uint num_blocks = (t_input + SCATTER_BLOCK_SIZE - 1) / SCATTER_BLOCK_SIZE;
-  const uint num_tiles = (e_input + TILE_E - 1) / TILE_E;
+  const uint scatter_block_count = (token_count + SCATTER_BLOCK_SIZE - 1) / SCATTER_BLOCK_SIZE;
+  const uint expert_tile_count = (expert_count + EXPERT_TILE_SIZE - 1) / EXPERT_TILE_SIZE;
 
-  // Tile over E dimension.
-  for (uint e0 = 0; e0 < e_input; e0 += TILE_E) {
-    const uint tile_e = (e0 + TILE_E <= e_input) ? TILE_E : (e_input - e0);
-    const uint tile_id = e0 / TILE_E;
+  // Tile over the expert dimension.
+  for (uint expert_tile_start = 0; expert_tile_start < expert_count; expert_tile_start += EXPERT_TILE_SIZE) {
+    const uint expert_tile_size =
+        (expert_tile_start + EXPERT_TILE_SIZE <= expert_count) ? EXPERT_TILE_SIZE : (expert_count - expert_tile_start);
+    const uint expert_tile_index = expert_tile_start / EXPERT_TILE_SIZE;
 
-    for (uint e = lid; e < tile_e; e += BLOCK_SIZE) {
-      counts_shared[e0 + e] = 0u;
+    for (uint expert_index_in_tile = thread_index_in_threadgroup; expert_index_in_tile < expert_tile_size;
+         expert_index_in_tile += THREADGROUP_SIZE) {
+      total_expert_counts[expert_tile_start + expert_index_in_tile] = 0u;
     }
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
     // Scatter consumes one partial histogram per 256-token block.
-    for (uint block_id = 0; block_id < num_blocks; ++block_id) {
-      for (uint e = lid; e < tile_e; e += BLOCK_SIZE) {
-        atomic_store_explicit(&tg_hist[e], 0u, memory_order_relaxed);
+    for (uint scatter_block_index = 0; scatter_block_index < scatter_block_count; ++scatter_block_index) {
+      for (uint expert_index_in_tile = thread_index_in_threadgroup; expert_index_in_tile < expert_tile_size;
+           expert_index_in_tile += THREADGROUP_SIZE) {
+        atomic_store_explicit(&threadgroup_expert_histogram[expert_index_in_tile], 0u, memory_order_relaxed);
       }
       threadgroup_barrier(mem_flags::mem_threadgroup);
 
-      const uint t_start = block_id * SCATTER_BLOCK_SIZE;
-      const uint t_end = min(t_start + SCATTER_BLOCK_SIZE, t_input);
-      for (uint t = t_start + lid; t < t_end; t += BLOCK_SIZE) {
-        const uint base = t * k_input;
-        for (uint k = 0; k < k_input; ++k) {
-          int eid = topk_ids[base + k];
-          if (eid >= 0) {
-            uint ue = uint(eid);
-            if (ue >= e0 && ue < e0 + tile_e) {
-              uint te = ue - e0;
-              atomic_fetch_add_explicit(&tg_hist[te], 1u, memory_order_relaxed);
+      const uint token_block_start = scatter_block_index * SCATTER_BLOCK_SIZE;
+      const uint token_block_end = min(token_block_start + SCATTER_BLOCK_SIZE, token_count);
+      for (uint token_index = token_block_start + thread_index_in_threadgroup; token_index < token_block_end;
+           token_index += THREADGROUP_SIZE) {
+        const uint selected_expert_row_start = token_index * selected_experts_per_token;
+        for (uint selected_expert_slot = 0; selected_expert_slot < selected_experts_per_token; ++selected_expert_slot) {
+          int selected_expert_id = selected_expert_ids[selected_expert_row_start + selected_expert_slot];
+          if (selected_expert_id >= 0) {
+            uint expert_index = uint(selected_expert_id);
+            if (expert_index >= expert_tile_start && expert_index < expert_tile_start + expert_tile_size) {
+              uint expert_index_in_tile = expert_index - expert_tile_start;
+              atomic_fetch_add_explicit(&threadgroup_expert_histogram[expert_index_in_tile], 1u, memory_order_relaxed);
             }
           }
         }
       }
       threadgroup_barrier(mem_flags::mem_threadgroup);
 
-      for (uint e = lid; e < tile_e; e += BLOCK_SIZE) {
-        const uint count_val = atomic_load_explicit(&tg_hist[e], memory_order_relaxed);
-        counts_shared[e0 + e] += count_val;
-        const uint partial_idx = (block_id * num_tiles + tile_id) * TILE_E + e;
-        partials[partial_idx] = count_val;
+      for (uint expert_index_in_tile = thread_index_in_threadgroup; expert_index_in_tile < expert_tile_size;
+           expert_index_in_tile += THREADGROUP_SIZE) {
+        const uint scatter_block_expert_count =
+            atomic_load_explicit(&threadgroup_expert_histogram[expert_index_in_tile], memory_order_relaxed);
+        total_expert_counts[expert_tile_start + expert_index_in_tile] += scatter_block_expert_count;
+        const uint partial_count_index =
+            (scatter_block_index * expert_tile_count + expert_tile_index) * EXPERT_TILE_SIZE + expert_index_in_tile;
+        scatter_block_expert_counts[partial_count_index] = scatter_block_expert_count;
       }
       threadgroup_barrier(mem_flags::mem_threadgroup);
     }
@@ -118,33 +125,43 @@ PUBLIC KERNEL(MoeCountsOffsetsFused)(
   // ═══════════════════════════════════════════════════════════
   // PHASE 2: Compute exclusive prefix scan on counts
   // ═══════════════════════════════════════════════════════════
-  if (lid == 0) {
-    carry = 0u;
+  if (thread_index_in_threadgroup == 0) {
+    expert_offset_carry = 0u;
   }
   threadgroup_barrier(mem_flags::mem_threadgroup);
 
-  for (uint base = 0; base < e_input; base += BLOCK_SIZE) {
-    uint remaining = e_input - base;
-    uint chunk_n = remaining < BLOCK_SIZE ? remaining : BLOCK_SIZE;
+  for (uint expert_chunk_start = 0; expert_chunk_start < expert_count; expert_chunk_start += THREADGROUP_SIZE) {
+    uint remaining_expert_count = expert_count - expert_chunk_start;
+    uint expert_chunk_size = remaining_expert_count < THREADGROUP_SIZE ? remaining_expert_count : THREADGROUP_SIZE;
 
-    uint v = (lid < chunk_n) ? counts_shared[base + lid] : 0u;
+    uint expert_route_count = (thread_index_in_threadgroup < expert_chunk_size)
+                                  ? total_expert_counts[expert_chunk_start + thread_index_in_threadgroup]
+                                  : 0u;
 
-    uint prefix_local = threadgroup_raking_prefix_exclusive_sum<BLOCK_SIZE>(v, scan_shared, (ushort)lid);
-    uint prefix_global = prefix_local + carry;
-    if (lid < chunk_n) {
-      offsets[base + lid] = prefix_global;
+    uint expert_offset_in_chunk = threadgroup_raking_prefix_exclusive_sum<THREADGROUP_SIZE>(
+        expert_route_count,
+        prefix_scan_scratch,
+        (ushort)thread_index_in_threadgroup
+    );
+    uint expert_offset = expert_offset_in_chunk + expert_offset_carry;
+    if (thread_index_in_threadgroup < expert_chunk_size) {
+      expert_offsets[expert_chunk_start + thread_index_in_threadgroup] = expert_offset;
     }
 
-    uint block_sum = threadgroup_cooperative_reduce<SimdReduceSum<uint>, BLOCK_SIZE>(v, reduce_shared, thread_context);
-    if (lid == 0) {
-      carry += block_sum;
+    uint expert_chunk_route_count = threadgroup_cooperative_reduce<SimdReduceSum<uint>, THREADGROUP_SIZE>(
+        expert_route_count,
+        reduction_scratch,
+        thread_context
+    );
+    if (thread_index_in_threadgroup == 0) {
+      expert_offset_carry += expert_chunk_route_count;
     }
     threadgroup_barrier(mem_flags::mem_threadgroup);
   }
 
   // Write final offset and total
-  if (lid == 0) {
-    offsets[e_input] = carry;
-    sum_k_out[0] = carry;
+  if (thread_index_in_threadgroup == 0) {
+    expert_offsets[expert_count] = expert_offset_carry;
+    total_routed_row_count[0] = expert_offset_carry;
   }
 }

--- a/crates/backend-uzu/src/backends/metal/kernel/moe/counts_offsets_fused.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/moe/counts_offsets_fused.metal
@@ -36,6 +36,7 @@ static T threadgroup_raking_prefix_exclusive_sum(T value, threadgroup T* shared,
 }
 
 #define BLOCK_SIZE 128
+#define SCATTER_BLOCK_SIZE 256
 #define TILE_E 512
 
 // Single-kernel fused: count all experts + scan to offsets
@@ -44,14 +45,14 @@ PUBLIC KERNEL(MoeCountsOffsetsFused)(
     device const int* topk_ids,
     device uint* offsets,   // output: exclusive scan [E+1]
     device uint* sum_k_out, // output: total count [1]
-    device uint* partials,  // output: partials [num_tiles * TILE_E] (for block_bases)
+    device uint* partials,  // output: partials [num_blocks * num_tiles * TILE_E] (for block_bases)
     constant uint& t_input,
     constant uint& e_input,
     constant uint& k_input,
     threadgroup _atomic<uint> tg_hist[TILE_E],
     threadgroup uint scan_shared[BLOCK_SIZE],
     threadgroup uint reduce_shared[BLOCK_SIZE],
-    threadgroup uint counts_shared[BLOCK_SIZE], // Cache counts in threadgroup memory
+    threadgroup uint counts_shared[TILE_E], // Cache global counts in threadgroup memory
     threadgroup uint& carry,
     const ThreadContext thread_context,
     const uint lid THREADS(128)
@@ -67,40 +68,51 @@ PUBLIC KERNEL(MoeCountsOffsetsFused)(
   // ═══════════════════════════════════════════════════════════
   // PHASE 1: Count tokens per expert using tiled histogram
   // ═══════════════════════════════════════════════════════════
-  // Tile over E dimension
+  const uint num_blocks = (t_input + SCATTER_BLOCK_SIZE - 1) / SCATTER_BLOCK_SIZE;
+  const uint num_tiles = (e_input + TILE_E - 1) / TILE_E;
+
+  // Tile over E dimension.
   for (uint e0 = 0; e0 < e_input; e0 += TILE_E) {
     const uint tile_e = (e0 + TILE_E <= e_input) ? TILE_E : (e_input - e0);
+    const uint tile_id = e0 / TILE_E;
 
-    // Zero threadgroup histogram
     for (uint e = lid; e < tile_e; e += BLOCK_SIZE) {
-      atomic_store_explicit(&tg_hist[e], 0u, memory_order_relaxed);
+      counts_shared[e0 + e] = 0u;
     }
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    // Process all tokens in strided fashion
-    // Since we have only 1 threadgroup, we need to cover all T tokens
-    for (uint t = lid; t < t_input; t += BLOCK_SIZE) {
-      const uint base = t * k_input;
-      for (uint k = 0; k < k_input; ++k) {
-        int eid = topk_ids[base + k];
-        if (eid >= 0) {
-          uint ue = uint(eid);
-          if (ue >= e0 && ue < e0 + tile_e) {
-            uint te = ue - e0;
-            atomic_fetch_add_explicit(&tg_hist[te], 1u, memory_order_relaxed);
+    // Scatter consumes one partial histogram per 256-token block.
+    for (uint block_id = 0; block_id < num_blocks; ++block_id) {
+      for (uint e = lid; e < tile_e; e += BLOCK_SIZE) {
+        atomic_store_explicit(&tg_hist[e], 0u, memory_order_relaxed);
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+
+      const uint t_start = block_id * SCATTER_BLOCK_SIZE;
+      const uint t_end = min(t_start + SCATTER_BLOCK_SIZE, t_input);
+      for (uint t = t_start + lid; t < t_end; t += BLOCK_SIZE) {
+        const uint base = t * k_input;
+        for (uint k = 0; k < k_input; ++k) {
+          int eid = topk_ids[base + k];
+          if (eid >= 0) {
+            uint ue = uint(eid);
+            if (ue >= e0 && ue < e0 + tile_e) {
+              uint te = ue - e0;
+              atomic_fetch_add_explicit(&tg_hist[te], 1u, memory_order_relaxed);
+            }
           }
         }
       }
-    }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
+      threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    // Write final counts and partials for this tile
-    for (uint e = lid; e < tile_e; e += BLOCK_SIZE) {
-      const uint count_val = atomic_load_explicit(&tg_hist[e], memory_order_relaxed);
-      counts_shared[e0 + e] = count_val;
-      partials[e0 + e] = count_val;
+      for (uint e = lid; e < tile_e; e += BLOCK_SIZE) {
+        const uint count_val = atomic_load_explicit(&tg_hist[e], memory_order_relaxed);
+        counts_shared[e0 + e] += count_val;
+        const uint partial_idx = (block_id * num_tiles + tile_id) * TILE_E + e;
+        partials[partial_idx] = count_val;
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
     }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
   }
 
   // ═══════════════════════════════════════════════════════════
@@ -115,7 +127,7 @@ PUBLIC KERNEL(MoeCountsOffsetsFused)(
     uint remaining = e_input - base;
     uint chunk_n = remaining < BLOCK_SIZE ? remaining : BLOCK_SIZE;
 
-    uint v = (lid < chunk_n) ? counts_shared[lid] : 0u;
+    uint v = (lid < chunk_n) ? counts_shared[base + lid] : 0u;
 
     uint prefix_local = threadgroup_raking_prefix_exclusive_sum<BLOCK_SIZE>(v, scan_shared, (ushort)lid);
     uint prefix_global = prefix_local + carry;

--- a/crates/backend-uzu/tests/unit/backends/common/kernel/moe/moe_counts_offsets_fused_test.rs
+++ b/crates/backend-uzu/tests/unit/backends/common/kernel/moe/moe_counts_offsets_fused_test.rs
@@ -47,8 +47,10 @@ fn get_output<B: Backend>(
     };
     let mut offsets = alloc_allocation::<B, u32>(&context, e + 1);
     let mut sum_k = alloc_allocation::<B, u32>(&context, 1);
+    let num_blocks = t.div_ceil(256);
     let num_tiles = e.div_ceil(512).max(1);
-    let mut partials = alloc_allocation::<B, u32>(&context, num_tiles * 512);
+    let partial_entries = (num_blocks * num_tiles * 512).max(1);
+    let mut partials = alloc_allocation::<B, u32>(&context, partial_entries);
 
     let mut encoder = Encoder::new(context.as_ref()).expect("Failed to create encoder");
     kernel.encode(
@@ -65,14 +67,24 @@ fn get_output<B: Backend>(
 
     let offsets = allocation_to_vec::<B, u32>(&offsets);
     let sum_k = allocation_to_vec::<B, u32>(&sum_k)[0];
-    let partials = allocation_prefix_to_vec::<B, u32>(&partials, e);
+    let partials = allocation_prefix_to_vec::<B, u32>(&partials, partial_entries);
+    let partials = (0..num_blocks)
+        .flat_map(|block_id| {
+            let partials = &partials;
+            (0..e).map(move |expert_id| {
+                let tile_id = expert_id / 512;
+                let tile_expert_id = expert_id % 512;
+                partials[(block_id * num_tiles + tile_id) * 512 + tile_expert_id]
+            })
+        })
+        .collect();
 
     (offsets, sum_k, partials)
 }
 
 #[uzu_test]
 fn test_counts_offsets_fused_parity_random() {
-    let shapes = vec![(1usize, 4usize), (7, 16), (64, 64), (1024, 128)];
+    let shapes = vec![(1usize, 4usize), (7, 16), (64, 64), (257, 160), (1024, 128)];
     let ks = vec![1usize, 2usize, 4usize];
 
     for &(t, e) in &shapes {
@@ -92,6 +104,23 @@ fn test_counts_offsets_fused_parity_random() {
             });
         }
     }
+}
+
+#[uzu_test]
+fn test_counts_offsets_fused_preserves_scatter_block_histograms() {
+    let (t, e, k) = (257usize, 2usize, 1usize);
+    let mut topk_ids = vec![0i32; t];
+    topk_ids[256] = 1;
+    let expected_offsets = vec![0, 256, 257];
+    let expected_partials = vec![256, 0, 0, 1];
+
+    for_each_backend!(|B| {
+        let (offsets, sum_k, partials) = get_output::<B>(&topk_ids, t, e, k);
+        let backend_name = std::any::type_name::<B>();
+        assert_eq!(offsets, expected_offsets, "offsets mismatch backend={}", backend_name);
+        assert_eq!(sum_k, t as u32, "sum mismatch backend={}", backend_name);
+        assert_eq!(partials, expected_partials, "scatter-block partials mismatch backend={}", backend_name);
+    });
 }
 
 #[uzu_test]

--- a/crates/backend-uzu/tests/unit/encodable_block/moe/moe_block_e2e_test.rs
+++ b/crates/backend-uzu/tests/unit/encodable_block/moe/moe_block_e2e_test.rs
@@ -143,6 +143,35 @@ fn moe_cpu_reference(
     output
 }
 
+/// Every routed top-k entry occupies exactly one expert-major row.
+fn assert_route_map_is_bijection<B: Backend>(
+    bucketed_ids: &Allocation<B>,
+    tok2row: &Allocation<B>,
+    sumk: &Allocation<B>,
+    t: usize,
+    k: usize,
+) {
+    let expected_routes = t * k;
+    let sumk = allocation_to_vec::<B, u32>(sumk);
+    let sumk = sumk[0] as usize;
+    assert_eq!(sumk, expected_routes, "all router outputs should be valid");
+
+    let bucketed_ids = allocation_prefix_to_vec::<B, i32>(bucketed_ids, sumk);
+    let tok2row = allocation_prefix_to_vec::<B, i32>(tok2row, expected_routes);
+    let mut rows = Vec::with_capacity(expected_routes);
+
+    for (route_idx, row) in tok2row.into_iter().enumerate() {
+        let row = usize::try_from(row).unwrap_or_else(|_| panic!("route {route_idx} maps to negative row {row}"));
+        assert!(row < sumk, "route {route_idx} maps past the {sumk}-row output: {row}");
+        assert_eq!(bucketed_ids[row], (route_idx / k) as i32, "route {route_idx} maps to the wrong token at row {row}");
+        rows.push(row);
+    }
+
+    rows.sort_unstable();
+    let expected_rows = (0..sumk).collect::<Vec<_>>();
+    assert_eq!(rows, expected_rows, "route map must contain every output row exactly once");
+}
+
 // Main entry point - automatically tests both modes for T>1
 fn run_moe_parity_test<B: Backend>(
     ctx: &B::Context,
@@ -423,6 +452,8 @@ fn run_moe_parity_test_internal<B: Backend>(
     eprintln!("[E2E] All kernels encoded. Committing ONCE and waiting...");
     let completed = encoder.end_encoding().submit().wait_until_completed().unwrap();
     eprintln!("[E2E] GPU execution completed");
+
+    assert_route_map_is_bijection::<B>(&bucketed_ids_buf, &tok2row_buf, &sumk_buf, t, k);
 
     // Read GPU output
     let y_out_bf16 = allocation_prefix_to_vec::<B, bf16>(&y_out_buf, t * d_model);
@@ -851,6 +882,27 @@ fn test_bucket_stress() {
             (f32::NEG_INFINITY, f32::INFINITY),
             0xE2E_0010,
             "BucketStress_T8_E8_K2",
+        );
+    })
+}
+
+#[uzu_test]
+fn test_scatter_block_boundary() {
+    for_each_non_cpu_backend!(|B| {
+        let ctx = create_context::<B>();
+        run_moe_parity_test_internal::<B>(
+            &ctx,
+            257, // t (crosses the 256-token scatter block)
+            2,   // e
+            1,   // k
+            4,   // d_model
+            4,   // d_ff
+            2,   // gating_code (SwiGLU)
+            1.0,
+            (f32::NEG_INFINITY, f32::INFINITY),
+            (f32::NEG_INFINITY, f32::INFINITY),
+            0xE2E_0032,
+            "ScatterBlockBoundary_T257",
         );
     })
 }


### PR DESCRIPTION
MoE routing processes tokens in 256-token blocks, but its counting kernel emitted one global expert histogram while scatter expected one histogram per block. Beyond 256 tokens, later routes could overlap existing expert rows or address rows outside the routed output.

This change gives every token block its own expert histogram while preserving global expert offsets, so longer prefills retain a one-to-one mapping between routed tokens and expert rows. It also corrects offset scanning above 128 experts. Routing decisions, expert computation, model formats, and public APIs remain unchanged. This issue was discovered during #698 but is independent of its MXFP4 work.
