### PR TITLE
Cpu backend perf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,6 +241,7 @@ opt-level = 2
 
 [profile.release]
 lto = "thin"
+codegen-units = 1
 
 [profile.test]
 opt-level = 2

--- a/crates/backend-uzu/build/metal/bindgen/arguments.rs
+++ b/crates/backend-uzu/build/metal/bindgen/arguments.rs
@@ -405,7 +405,9 @@ pub fn encode_accesses_call(arguments: &[ArgumentEmission]) -> TokenStream {
         quote! {}
     } else {
         quote! {
-            encoder.access(&[#(#access_expressions),*].into_iter().flatten().collect::<Vec<_>>());
+            if <crate::backends::metal::Metal as crate::backends::common::Backend>::NEEDS_BARRIERS {
+                encoder.access(&[#(#access_expressions),*].into_iter().flatten().collect::<Vec<_>>());
+            }
         }
     }
 }

--- a/crates/backend-uzu/src/backends/common/allocator/allocator.rs
+++ b/crates/backend-uzu/src/backends/common/allocator/allocator.rs
@@ -83,6 +83,13 @@ pub struct AllocationPool<B: Backend> {
     pool_number: usize,
 }
 
+impl<B: Backend> AllocationPool<B> {
+    #[cfg(test)]
+    pub(crate) fn pool_number(&self) -> usize {
+        self.pool_number
+    }
+}
+
 impl<B: Backend> Drop for AllocationPool<B> {
     fn drop(&mut self) {
         self.allocator.free_pool(self)
@@ -106,6 +113,7 @@ pub struct Allocator<B: Backend> {
     context: Weak<B::Context>,
     allocator_buffers: Mutex<Vec<AllocatorBuffer<B>>>,
     next_pool_number: AtomicUsize,
+    free_pool_numbers: Mutex<Vec<usize>>,
     peak_memory_usage: AtomicUsize,
 }
 
@@ -115,6 +123,7 @@ impl<B: Backend> Allocator<B> {
             context,
             allocator_buffers: Mutex::new(Vec::new()),
             next_pool_number: AtomicUsize::new(0),
+            free_pool_numbers: Mutex::new(Vec::new()),
             peak_memory_usage: AtomicUsize::new(0),
         })
     }
@@ -187,7 +196,11 @@ impl<B: Backend> Allocator<B> {
         self: &Arc<Self>,
         reusable: bool,
     ) -> AllocationPool<B> {
-        let pool_number = self.next_pool_number.fetch_add(1, Ordering::Relaxed);
+        let pool_number = self
+            .free_pool_numbers
+            .lock()
+            .pop()
+            .unwrap_or_else(|| self.next_pool_number.fetch_add(1, Ordering::Relaxed));
 
         AllocationPool {
             reusable,
@@ -238,6 +251,8 @@ impl<B: Backend> Allocator<B> {
         if allocator_buffers.len() > 1 {
             allocator_buffers.sort_by_key(|allocator_buffer| allocator_buffer.range_allocator.total_available());
         }
+
+        self.free_pool_numbers.lock().push(pool.pool_number);
     }
 
     fn restore_buffer_order(
@@ -265,3 +280,7 @@ impl<B: Backend> Allocator<B> {
 #[cfg(all(test, backend = "metal"))]
 #[path = "../../../../tests/unit/backends/common/allocator/allocator.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "../../../../tests/unit/backends/common/allocator/pool_recycling_test.rs"]
+mod pool_recycling_tests;

--- a/crates/backend-uzu/src/backends/common/allocator/range_allocator.rs
+++ b/crates/backend-uzu/src/backends/common/allocator/range_allocator.rs
@@ -285,6 +285,11 @@ impl RangeAllocator {
         self.total_available
     }
 
+    #[cfg(test)]
+    pub(crate) fn pool_slot_count(&self) -> usize {
+        self.pool_live_allocations.len()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.free_ranges.total_len() == self.full_len
     }

--- a/crates/backend-uzu/src/backends/common/backend.rs
+++ b/crates/backend-uzu/src/backends/common/backend.rs
@@ -11,6 +11,8 @@ pub trait Backend: Debug + Clone + Send + Sync + 'static {
     type Error: Error + Debug;
 
     const NAME: &'static str;
+    /// False when `encode_barrier` is a no-op; the encoder then skips hazard tracking.
+    const NEEDS_BARRIERS: bool;
     const MIN_ALLOCATION_ALIGNMENT: usize;
     const MAX_ALLOCATION_ALIGNMENT: usize;
     const ALLOCATION_GRANULARITY: usize;

--- a/crates/backend-uzu/src/backends/common/encoder.rs
+++ b/crates/backend-uzu/src/backends/common/encoder.rs
@@ -187,6 +187,9 @@ impl<'encoding, B: Backend> Encoder<'encoding, B> {
         &mut self,
         accesses: &[Access],
     ) {
+        if !B::NEEDS_BARRIERS {
+            return;
+        }
         if let Some((after, before)) = self.hazard_tracker.access(accesses) {
             self.command_buffer.encode_barrier(after, before);
         }

--- a/crates/backend-uzu/src/backends/cpu/backend.rs
+++ b/crates/backend-uzu/src/backends/cpu/backend.rs
@@ -16,6 +16,7 @@ impl Backend for Cpu {
     type Error = CpuError;
 
     const NAME: &'static str = "cpu";
+    const NEEDS_BARRIERS: bool = false;
     const MIN_ALLOCATION_ALIGNMENT: usize = 4;
     const MAX_ALLOCATION_ALIGNMENT: usize = 64;
     const ALLOCATION_GRANULARITY: usize = 8 * 1024 * 1024;

--- a/crates/backend-uzu/src/backends/cpu/context.rs
+++ b/crates/backend-uzu/src/backends/cpu/context.rs
@@ -6,18 +6,21 @@ use std::{
 
 use crate::backends::{
     common::{Allocation, AllocationPool, AllocationType, Allocator, Backend, Context, DeviceCapabilities},
-    cpu::{Cpu, command_buffer::CpuCommandBufferInitial, dense_buffer::CpuBuffer, error::CpuError},
+    cpu::{Cpu, command_buffer::CpuCommandBufferInitial, dense_buffer::CpuBuffer, error::CpuError, parallel::Pool},
 };
 
 pub struct CpuContext {
     allocator: Arc<Allocator<Cpu>>,
     command_queue: mpsc::Sender<Box<dyn FnOnce() + Send>>,
+    pool: Arc<Pool>,
 }
 
-impl Context for CpuContext {
-    type Backend = Cpu;
+impl CpuContext {
+    pub(crate) fn pool(&self) -> &Arc<Pool> {
+        &self.pool
+    }
 
-    fn new() -> Result<Arc<Self>, CpuError> {
+    pub(crate) fn with_threads(threads: usize) -> Arc<Self> {
         let (command_queue_sender, command_queue_receiever) = mpsc::channel::<Box<dyn FnOnce() + Send>>();
 
         thread::spawn(|| {
@@ -26,10 +29,21 @@ impl Context for CpuContext {
             }
         });
 
-        Ok(Arc::new_cyclic(|weak_self| CpuContext {
+        let pool = Arc::new(Pool::new(threads));
+
+        Arc::new_cyclic(|weak_self| CpuContext {
             allocator: Allocator::new(weak_self.clone()),
             command_queue: command_queue_sender,
-        }))
+            pool,
+        })
+    }
+}
+
+impl Context for CpuContext {
+    type Backend = Cpu;
+
+    fn new() -> Result<Arc<Self>, CpuError> {
+        Ok(Self::with_threads(crate::backends::cpu::parallel::available_threads()))
     }
 
     fn create_buffer(

--- a/crates/backend-uzu/src/backends/cpu/kernel/matmul/kernel.rs
+++ b/crates/backend-uzu/src/backends/cpu/kernel/matmul/kernel.rs
@@ -1,3 +1,5 @@
+use half::{bf16, f16};
+
 use super::reference::{WeightData, read_f32, write_f32};
 use crate::{
     backends::{
@@ -9,11 +11,213 @@ use crate::{
                 matmul::{MatmulA, MatmulArguments, MatmulB, MatmulError, MatmulKernel},
             },
         },
-        cpu::{Cpu, context::CpuContext, error::CpuError},
+        cpu::{Cpu, context::CpuContext, error::CpuError, parallel::Pool},
     },
     data_type::DataType,
     utils::pointers::{SendPtr, SendPtrMut},
 };
+
+const LANES: usize = 4;
+
+#[derive(Clone, Copy)]
+enum AData {
+    FullPrecision(SendPtr<u8>),
+    Int8 {
+        values: SendPtr<u8>,
+        scales: SendPtr<u8>,
+        group_size: usize,
+    },
+}
+
+#[inline(always)]
+unsafe fn decode_typed<W>(
+    out: &mut Vec<f32>,
+    base: *const W,
+    offset: usize,
+    k: usize,
+) where
+    W: Copy,
+    f32: From<W>,
+{
+    unsafe {
+        let source = base.add(offset);
+        out.extend((0..k).map(|index| f32::from(*source.add(index))));
+    }
+}
+
+unsafe fn decode_activation_row(
+    out: &mut Vec<f32>,
+    a: AData,
+    input_data_type: DataType,
+    row: usize,
+    k: usize,
+) {
+    unsafe {
+        match a {
+            AData::FullPrecision(values) => {
+                let base = values.as_ptr();
+                match input_data_type {
+                    DataType::F32 => decode_typed(out, base as *const f32, row * k, k),
+                    DataType::F16 => decode_typed(out, base as *const f16, row * k, k),
+                    DataType::BF16 => decode_typed(out, base as *const bf16, row * k, k),
+                    _ => unreachable!(),
+                }
+            },
+            AData::Int8 {
+                values,
+                scales,
+                group_size,
+            } => {
+                let groups = k.div_ceil(group_size);
+                let codes = (values.as_ptr() as *const i8).add(row * k);
+                let scales = (scales.as_ptr() as *const f32).add(row * groups);
+                out.extend((0..k).map(|index| *codes.add(index) as f32 * *scales.add(index / group_size)));
+            },
+        }
+    }
+}
+
+#[inline(always)]
+unsafe fn dot_full_precision_typed<W>(
+    a_row: &[f32],
+    base: *const W,
+    leading_dimension: usize,
+    transpose: bool,
+    b_col: usize,
+) -> f32
+where
+    W: Copy,
+    f32: From<W>,
+{
+    let mut accumulator = 0.0f32;
+    unsafe {
+        if transpose {
+            let column = base.add(b_col * leading_dimension);
+            let (blocks, remainder) = a_row.as_chunks::<LANES>();
+            let mut chains = [0.0f32; LANES];
+            let mut inner = 0usize;
+            for block in blocks {
+                for chain in 0..LANES {
+                    chains[chain] += block[chain] * f32::from(*column.add(inner + chain));
+                }
+                inner += LANES;
+            }
+            for activation in remainder {
+                accumulator += activation * f32::from(*column.add(inner));
+                inner += 1;
+            }
+            accumulator += (chains[0] + chains[1]) + (chains[2] + chains[3]);
+        } else {
+            for (inner, activation) in a_row.iter().enumerate() {
+                accumulator += activation * f32::from(*base.add(inner * leading_dimension + b_col));
+            }
+        }
+    }
+    accumulator
+}
+
+#[inline]
+unsafe fn dot_full_precision(
+    a_row: &[f32],
+    weights: *const u8,
+    weights_data_type: DataType,
+    leading_dimension: usize,
+    transpose: bool,
+    b_col: usize,
+) -> f32 {
+    unsafe {
+        match weights_data_type {
+            DataType::F32 => {
+                dot_full_precision_typed(a_row, weights as *const f32, leading_dimension, transpose, b_col)
+            },
+            DataType::F16 => {
+                dot_full_precision_typed(a_row, weights as *const f16, leading_dimension, transpose, b_col)
+            },
+            DataType::BF16 => {
+                dot_full_precision_typed(a_row, weights as *const bf16, leading_dimension, transpose, b_col)
+            },
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[inline]
+unsafe fn dot_quantized(
+    a_row: &[f32],
+    weight_data: &WeightData,
+    layout: (usize, usize, usize),
+    weights_data_type: DataType,
+    b_col: usize,
+) -> f32 {
+    let WeightData::Quantized {
+        weights,
+        scales,
+        zero_points,
+        biases,
+        bits,
+        group_size,
+        signed_codes,
+    } = weight_data
+    else {
+        unreachable!();
+    };
+    let (num_groups_k, zero_point_stride, pack_factor) = layout;
+    let bits = *bits;
+    let group_size = *group_size;
+    let code_mask = (1u32 << bits) - 1;
+    let midpoint = (1u32 << (bits - 1)) as f32;
+    let sign_flip = if *signed_codes {
+        1u8 << (bits - 1)
+    } else {
+        0
+    };
+    let k = a_row.len();
+
+    let mut accumulator = 0.0f32;
+    unsafe {
+        let words = weights.as_ptr() as *const u32;
+        let column_start = b_col * k;
+
+        let mut inner = 0usize;
+        let mut group = 0usize;
+        while inner < k {
+            let group_end = ((group + 1) * group_size).min(k);
+            let scale = read_f32(scales.as_ptr(), weights_data_type, b_col * num_groups_k + group);
+            let bias_term = if let Some(zero_points) = zero_points {
+                let zero_point = if bits == 4 {
+                    let byte = *zero_points.as_ptr().add(b_col * zero_point_stride + (group >> 1));
+                    if group & 1 == 0 {
+                        (byte & 0x0F) as f32
+                    } else {
+                        ((byte >> 4) & 0x0F) as f32
+                    }
+                } else {
+                    *zero_points.as_ptr().add(b_col * zero_point_stride + group) as f32
+                };
+                -scale * zero_point
+            } else if let Some(biases) = biases {
+                read_f32(biases.as_ptr(), weights_data_type, b_col * num_groups_k + group)
+            } else {
+                -scale * midpoint
+            };
+
+            while inner < group_end {
+                let linear = column_start + inner;
+                let word = words.add(linear / pack_factor).read_unaligned();
+                let mut slot = linear % pack_factor;
+                while slot < pack_factor && inner < group_end {
+                    let code = (((word >> (slot * bits)) & code_mask) as u8) ^ sign_flip;
+                    accumulator += a_row[inner] * (scale * f32::from(code) + bias_term);
+                    slot += 1;
+                    inner += 1;
+                }
+            }
+
+            group += 1;
+        }
+    }
+    accumulator
+}
 
 pub struct MatmulCpuKernel {
     weights_data_type: DataType,
@@ -21,6 +225,7 @@ pub struct MatmulCpuKernel {
     output_data_type: DataType,
     output_rht: ActivationTransform<Cpu>,
     bias_add: <<Cpu as Backend>::Kernels as Kernels>::TensorAddBiasKernel,
+    pool: std::sync::Arc<Pool>,
 }
 
 impl MatmulKernel for MatmulCpuKernel {
@@ -50,6 +255,7 @@ impl MatmulKernel for MatmulCpuKernel {
             output_data_type,
             output_rht,
             bias_add,
+            pool: context.pool().clone(),
         })
     }
 
@@ -84,15 +290,6 @@ impl MatmulKernel for MatmulCpuKernel {
         let input_data_type = self.input_data_type;
         let output_data_type = self.output_data_type;
 
-        #[derive(Clone, Copy)]
-        enum AData {
-            FullPrecision(SendPtr<u8>),
-            Int8 {
-                values: SendPtr<u8>,
-                scales: SendPtr<u8>,
-                group_size: usize,
-            },
-        }
         let a_data = match a {
             MatmulA::FullPrecision {
                 values,
@@ -160,6 +357,7 @@ impl MatmulKernel for MatmulCpuKernel {
         let weight_data = WeightData::from_b(b, b_leading_dimension, b_transpose, k_u, n_u);
 
         let bias_after_rht = post_rht.is_some();
+        let pool = self.pool.clone();
         let command_buffer = encoder.as_command_buffer_mut();
         command_buffer.push_command(move || {
             let quant_layout = match &weight_data {
@@ -186,96 +384,43 @@ impl MatmulKernel for MatmulCpuKernel {
                 } => None,
             };
 
-            unsafe {
+            let mut activations = Vec::with_capacity(m_u * k_u);
+            for row in 0..m_u {
+                unsafe { decode_activation_row(&mut activations, a_data, input_data_type, row, k_u) };
+            }
+
+            let compute_columns = |columns: std::ops::Range<usize>| unsafe {
                 for row in 0..m_u {
-                    for col in 0..n_u {
+                    let activation_row = &activations[row * k_u..(row + 1) * k_u];
+                    for col in columns.clone() {
                         // Gather remaps output column `col` to B-row `gather_indices[row * n + col]`.
                         let b_col = match gather_ptr {
                             Some(g) => *g.as_ptr().add(row * n_u + col) as usize,
                             None => col,
                         };
-                        let mut accumulator = 0.0f32;
-                        for inner in 0..k_u {
-                            let a_value = match a_data {
-                                AData::FullPrecision(ptr) => read_f32(ptr.as_ptr(), input_data_type, row * k_u + inner),
-                                AData::Int8 {
-                                    values,
-                                    scales,
-                                    group_size,
-                                } => {
-                                    let groups = k_u.div_ceil(group_size);
-                                    let group = inner / group_size;
-                                    let q = *(values.as_ptr() as *const i8).add(row * k_u + inner) as f32;
-                                    let scale = *(scales.as_ptr() as *const f32).add(row * groups + group);
-                                    q * scale
-                                },
-                            };
-                            let b_value = match &weight_data {
-                                WeightData::FullPrecision {
-                                    ptr,
-                                    leading_dimension,
-                                    transpose,
-                                } => {
-                                    let index = if *transpose {
-                                        b_col * leading_dimension + inner
-                                    } else {
-                                        inner * leading_dimension + b_col
-                                    };
-                                    read_f32(ptr.as_ptr(), weights_data_type, index)
-                                },
-                                WeightData::Quantized {
-                                    weights,
-                                    scales,
-                                    zero_points,
-                                    biases,
-                                    bits,
-                                    group_size,
-                                    signed_codes,
-                                } => {
-                                    let (num_groups_k, zero_point_stride, pack_factor) = quant_layout.unwrap();
-                                    let weight_linear_index = b_col * k_u + inner;
-                                    let word_index = weight_linear_index / pack_factor;
-                                    let bit_offset = (weight_linear_index % pack_factor) * *bits;
-                                    let weights_words = weights.as_ptr() as *const u32;
-                                    let word = weights_words.add(word_index).read_unaligned();
-                                    let code_mask = (1u32 << bits) - 1;
-                                    let mut weight_code = ((word >> bit_offset) & code_mask) as u8;
-                                    if *signed_codes {
-                                        weight_code ^= 1u8 << (bits - 1);
-                                    }
-                                    let quantized_value = f32::from(weight_code);
-                                    let group_index = inner / group_size;
-                                    let scale = read_f32(
-                                        scales.as_ptr(),
-                                        weights_data_type,
-                                        b_col * num_groups_k + group_index,
-                                    );
-                                    let midpoint = (1u32 << (bits - 1)) as f32;
-                                    let zero_point = zero_points.map(|zp| {
-                                        if *bits == 4 {
-                                            let byte_index = b_col * zero_point_stride + (group_index >> 1);
-                                            let byte_value = *zp.as_ptr().add(byte_index);
-                                            if (group_index & 1) == 0 {
-                                                (byte_value & 0x0F) as f32
-                                            } else {
-                                                ((byte_value >> 4) & 0x0F) as f32
-                                            }
-                                        } else {
-                                            *zp.as_ptr().add(b_col * zero_point_stride + group_index) as f32
-                                        }
-                                    });
-                                    let bias_term = if let Some(zp) = zero_point {
-                                        -scale * zp
-                                    } else if let Some(b) = biases {
-                                        read_f32(b.as_ptr(), weights_data_type, b_col * num_groups_k + group_index)
-                                    } else {
-                                        -scale * midpoint
-                                    };
-                                    scale * quantized_value + bias_term
-                                },
-                            };
-                            accumulator += a_value * b_value;
-                        }
+                        let accumulator = match &weight_data {
+                            WeightData::FullPrecision {
+                                ptr,
+                                leading_dimension,
+                                transpose,
+                            } => dot_full_precision(
+                                activation_row,
+                                ptr.as_ptr(),
+                                weights_data_type,
+                                *leading_dimension,
+                                *transpose,
+                                b_col,
+                            ),
+                            WeightData::Quantized {
+                                ..
+                            } => dot_quantized(
+                                activation_row,
+                                &weight_data,
+                                quant_layout.unwrap(),
+                                weights_data_type,
+                                b_col,
+                            ),
+                        };
 
                         let output_index = row * n_u + col;
                         let mut value = output_scale * accumulator;
@@ -291,7 +436,9 @@ impl MatmulKernel for MatmulCpuKernel {
                         write_f32(d_ptr.as_ptr(), output_data_type, output_index, value);
                     }
                 }
-            }
+            };
+
+            pool.for_each_chunk(n_u, m_u * n_u * k_u, compute_columns);
         });
 
         if let Some(factors) = post_rht {
@@ -305,3 +452,11 @@ impl MatmulKernel for MatmulCpuKernel {
         Ok(())
     }
 }
+
+#[cfg(test)]
+#[path = "../../../../../tests/unit/backends/cpu/kernel/matmul/parallel_matmul_test.rs"]
+mod tests;
+
+#[cfg(test)]
+#[path = "../../../../../tests/unit/backends/cpu/kernel/matmul/quant_matmul_test.rs"]
+mod quant_tests;

--- a/crates/backend-uzu/src/backends/cpu/kernel/sampling/unified_sampling.rs
+++ b/crates/backend-uzu/src/backends/cpu/kernel/sampling/unified_sampling.rs
@@ -9,6 +9,9 @@ use crate::{
     encodable_block::sampling::{gumbel_float, revidx},
 };
 
+const CANDIDATE_SEED: usize = 64;
+const CANDIDATE_GROWTH: usize = 8;
+
 // NOTE: top_k + top_p combination is not exactly matching lalamo ("parallel" here, should be top-k then top-p)
 #[kernel(UnifiedSampling)]
 #[variants(T, f32, bf16)]
@@ -30,13 +33,23 @@ pub fn unified_sampling<T: ArrayElement + Float>(
     #[specialize] has_top_p: bool,
     #[specialize] has_min_p: bool,
 ) {
+    let vocab = vocab_size as usize;
+    debug_assert!(vocab > 0, "vocab_size must be positive");
+    let filtered = has_top_k || has_top_p || has_min_p;
+
+    let mut scores = vec![0.0f32; vocab];
+    let mut candidates: Vec<u32> = if filtered {
+        (0..vocab_size).collect()
+    } else {
+        Vec::new()
+    };
+    let mut kept: Vec<(u32, f32)> = Vec::new();
+
     for batch_idx in 0..batch_size {
-        let mut logits = unsafe {
-            std::slice::from_raw_parts(logits.wrapping_add((vocab_size * batch_idx) as usize), vocab_size as usize)
+        let row = unsafe { std::slice::from_raw_parts(logits.wrapping_add((vocab_size * batch_idx) as usize), vocab) };
+        for (score, logit) in scores.iter_mut().zip(row) {
+            *score = logit.to_f32().unwrap();
         }
-        .iter()
-        .map(|logit| logit.to_f32().unwrap())
-        .collect::<Vec<f32>>();
 
         if has_bitmask {
             let bitmask = unsafe {
@@ -45,7 +58,7 @@ pub fn unified_sampling<T: ArrayElement + Float>(
                     vocab_size.div_ceil(u32::BITS) as usize,
                 )
             };
-            for (logit_index, logit) in logits.iter_mut().enumerate() {
+            for (logit_index, logit) in scores.iter_mut().enumerate() {
                 if bitmask[logit_index / (u32::BITS as usize)] & (1 << (logit_index % (u32::BITS as usize))) == 0 {
                     *logit = f32::NEG_INFINITY;
                 }
@@ -54,46 +67,130 @@ pub fn unified_sampling<T: ArrayElement + Float>(
 
         if has_temperature {
             let recip_temperature = 1.0 / temperature.unwrap();
-            for logit in logits.iter_mut() {
+            for logit in scores.iter_mut() {
                 *logit *= recip_temperature;
             }
         }
 
-        if has_top_k || has_top_p || has_min_p {
-            let mut sorted_logits = logits.iter().copied().enumerate().collect::<Vec<_>>();
-            sorted_logits.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal).then(a.0.cmp(&b.0)));
-
-            let logits_max = sorted_logits[0].1;
-            let logits_norm = sorted_logits.iter().map(|logit| (logit.1 - logits_max).exp()).sum::<f32>();
-
-            logits.fill(f32::NEG_INFINITY);
-            let mut top_p_mass = 0.0;
-            for (top_k_num, (index, logit)) in sorted_logits.into_iter().enumerate() {
-                if (has_top_k && top_k_num as u32 >= top_k.unwrap())
-                    || (has_top_p && top_p_mass >= top_p.unwrap())
-                    || (has_min_p && logit < logits_max + min_p.unwrap().ln())
-                {
-                    break;
-                }
-                logits[index] = logit;
-                top_p_mass += (logit - logits_max).exp() / logits_norm;
-            }
+        if filtered {
+            filter_candidates(
+                &mut scores,
+                &mut candidates,
+                &mut kept,
+                has_top_k.then(|| top_k.unwrap()),
+                has_top_p.then(|| top_p.unwrap()),
+                has_min_p.then(|| min_p.unwrap()),
+            );
         }
 
         if is_stochastic {
             let seed = unsafe { *seeds.unwrap().wrapping_add(batch_idx as usize) };
-            for (logit_index, logit) in logits.iter_mut().enumerate() {
-                *logit += gumbel_float(seed, revidx(logit_index as u32, vocab_size));
+            for (logit_index, logit) in scores.iter_mut().enumerate() {
+                if *logit != f32::NEG_INFINITY {
+                    *logit += gumbel_float(seed, revidx(logit_index as u32, vocab_size));
+                }
             }
         }
 
-        let argmax = logits
-            .into_iter()
-            .enumerate()
-            .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(Ordering::Equal).then(b.0.cmp(&a.0)))
-            .unwrap()
-            .0;
+        let mut argmax = 0usize;
+        let mut best = scores[0];
+        for (index, &value) in scores.iter().enumerate().skip(1) {
+            if value > best {
+                best = value;
+                argmax = index;
+            }
+        }
 
         unsafe { *output.wrapping_add(batch_idx as usize) = argmax as u32 }
     }
 }
+
+#[inline(always)]
+fn candidate_cmp(
+    scores: &[f32],
+    left: u32,
+    right: u32,
+) -> Ordering {
+    scores[right as usize].partial_cmp(&scores[left as usize]).unwrap_or(Ordering::Equal).then(left.cmp(&right))
+}
+
+fn filter_candidates(
+    scores: &mut [f32],
+    candidates: &mut [u32],
+    kept: &mut Vec<(u32, f32)>,
+    top_k: Option<u32>,
+    top_p: Option<f32>,
+    min_p: Option<f32>,
+) {
+    let vocab = scores.len();
+    let max = scores.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+
+    let mut limit = vocab;
+    if let Some(top_k) = top_k {
+        limit = limit.min(top_k as usize);
+    }
+    let min_p_threshold = min_p.map(|min_p| max + min_p.ln());
+    if let Some(threshold) = min_p_threshold
+        && threshold.is_finite()
+    {
+        limit = limit.min(scores.iter().filter(|score| **score >= threshold).count().max(1));
+    }
+    limit = limit.max(1);
+
+    let norm = top_p.map(|_| {
+        let mut sum = 0.0f32;
+        let mut compensation = 0.0f32;
+        for &score in scores.iter() {
+            let term = (score - max).exp() - compensation;
+            let next = sum + term;
+            compensation = (next - sum) - term;
+            sum = next;
+        }
+        sum
+    });
+
+    let mut cap = if top_p.is_some() {
+        CANDIDATE_SEED.min(limit)
+    } else {
+        limit
+    };
+
+    loop {
+        if cap < vocab {
+            candidates.select_nth_unstable_by(cap - 1, |left, right| candidate_cmp(scores, *left, *right));
+        }
+        candidates[..cap].sort_unstable_by(|left, right| candidate_cmp(scores, *left, *right));
+
+        kept.clear();
+        let mut mass = 0.0f32;
+        let mut stopped = false;
+        for (rank, &index) in candidates[..cap].iter().enumerate() {
+            let value = scores[index as usize];
+            if top_k.is_some_and(|top_k| rank as u32 >= top_k)
+                || top_p.is_some_and(|top_p| mass >= top_p)
+                || min_p_threshold.is_some_and(|threshold| value < threshold)
+            {
+                stopped = true;
+                break;
+            }
+            kept.push((index, value));
+            if let Some(norm) = norm {
+                mass += (value - max).exp() / norm;
+            }
+        }
+
+        if stopped || cap == limit {
+            break;
+        }
+        cap = (cap * CANDIDATE_GROWTH).min(limit);
+    }
+
+    scores.fill(f32::NEG_INFINITY);
+    for &(index, value) in kept.iter() {
+        scores[index as usize] = value;
+    }
+}
+
+#[cfg(test)]
+#[path = "../../../../../tests/unit/backends/cpu/kernel/sampling/unified_sampling_test.rs"]
+mod tests;

--- a/crates/backend-uzu/src/backends/cpu/mod.rs
+++ b/crates/backend-uzu/src/backends/cpu/mod.rs
@@ -5,6 +5,7 @@ mod context;
 mod dense_buffer;
 mod error;
 pub(crate) mod kernel;
+pub(crate) mod parallel;
 mod sparse;
 
 pub use backend::Cpu;

--- a/crates/backend-uzu/src/backends/cpu/parallel.rs
+++ b/crates/backend-uzu/src/backends/cpu/parallel.rs
@@ -1,0 +1,204 @@
+use std::{
+    ops::Range,
+    panic::{AssertUnwindSafe, catch_unwind},
+    sync::{
+        Arc, Condvar, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    thread::JoinHandle,
+};
+
+const MIN_WORK_PER_THREAD: usize = 1 << 16;
+// More than one chunk per thread: P and E cores differ several-fold in throughput.
+const CHUNKS_PER_THREAD: usize = 8;
+
+pub(crate) fn available_threads() -> usize {
+    std::env::var("UZU_CPU_THREADS")
+        .ok()
+        .and_then(|threads| threads.parse::<usize>().ok())
+        .filter(|threads| *threads > 0)
+        .unwrap_or_else(|| std::thread::available_parallelism().map(|threads| threads.get()).unwrap_or(1))
+}
+
+struct Job {
+    run: unsafe fn(*const (), Range<usize>),
+    data: *const (),
+    chunk: usize,
+    chunks: usize,
+    units: usize,
+    next: AtomicUsize,
+}
+
+unsafe impl Send for Job {}
+unsafe impl Sync for Job {}
+
+impl Job {
+    unsafe fn run_claimed(&self) {
+        loop {
+            let index = self.next.fetch_add(1, Ordering::Relaxed);
+            if index >= self.chunks {
+                return;
+            }
+            let start = index * self.chunk;
+            unsafe { (self.run)(self.data, start..(start + self.chunk).min(self.units)) };
+        }
+    }
+}
+
+#[derive(Default)]
+struct State {
+    job: Option<&'static Job>,
+    generation: u64,
+    active: usize,
+    panicked: bool,
+    stop: bool,
+}
+
+#[derive(Default)]
+struct Shared {
+    state: Mutex<State>,
+    wake: Condvar,
+    idle: Condvar,
+}
+
+pub(crate) struct Pool {
+    shared: Arc<Shared>,
+    workers: Vec<JoinHandle<()>>,
+}
+
+/// Retracts the job and drains workers even if the submitter unwinds, so the job never
+/// outlives the closure it points at.
+struct Retract<'a>(&'a Shared);
+
+impl Drop for Retract<'_> {
+    fn drop(&mut self) {
+        let mut state = self.0.state.lock().unwrap_or_else(|error| error.into_inner());
+        state.job = None;
+        while state.active > 0 {
+            state = self.0.idle.wait(state).unwrap_or_else(|error| error.into_inner());
+        }
+    }
+}
+
+impl Pool {
+    pub(crate) fn new(threads: usize) -> Self {
+        let shared = Arc::new(Shared::default());
+        let workers = (1..threads)
+            .map(|_| {
+                let shared = shared.clone();
+                std::thread::spawn(move || worker(&shared))
+            })
+            .collect();
+
+        Self {
+            shared,
+            workers,
+        }
+    }
+
+    pub(crate) fn for_each_chunk<F>(
+        &self,
+        units: usize,
+        work: usize,
+        compute: F,
+    ) where
+        F: Fn(Range<usize>) + Sync,
+    {
+        let threads = (self.workers.len() + 1).min(units).min((work / MIN_WORK_PER_THREAD).max(1));
+        if threads <= 1 {
+            compute(0..units);
+            return;
+        }
+
+        unsafe fn call<F: Fn(Range<usize>)>(
+            data: *const (),
+            range: Range<usize>,
+        ) {
+            unsafe { (*(data as *const F))(range) }
+        }
+
+        let chunk = units.div_ceil(threads * CHUNKS_PER_THREAD).max(1);
+        let job = Job {
+            run: call::<F>,
+            data: (&raw const compute) as *const (),
+            chunk,
+            chunks: units.div_ceil(chunk),
+            units,
+            next: AtomicUsize::new(0),
+        };
+
+        // SAFETY: `Retract` below clears the job and waits for every worker that took it,
+        // on the normal path and while unwinding, so workers never see it after this call.
+        let published: &'static Job = unsafe { std::mem::transmute::<&Job, &'static Job>(&job) };
+
+        {
+            let mut state = self.shared.state.lock().unwrap();
+            state.job = Some(published);
+            state.generation = state.generation.wrapping_add(1);
+        }
+        for _ in 1..threads {
+            self.shared.wake.notify_one();
+        }
+
+        {
+            let _retract = Retract(&self.shared);
+            unsafe { job.run_claimed() };
+        }
+
+        let mut state = self.shared.state.lock().unwrap();
+        if std::mem::take(&mut state.panicked) {
+            drop(state);
+            panic!("cpu kernel panicked on a pool worker");
+        }
+    }
+}
+
+impl Drop for Pool {
+    fn drop(&mut self) {
+        {
+            let mut state = self.shared.state.lock().unwrap_or_else(|error| error.into_inner());
+            state.stop = true;
+        }
+        self.shared.wake.notify_all();
+        for worker in self.workers.drain(..) {
+            let _ = worker.join();
+        }
+    }
+}
+
+fn worker(shared: &Shared) {
+    let mut seen = 0u64;
+    loop {
+        let job = {
+            let mut state = shared.state.lock().unwrap_or_else(|error| error.into_inner());
+            loop {
+                if state.stop {
+                    return;
+                }
+                match state.job {
+                    Some(job) if state.generation != seen => {
+                        seen = state.generation;
+                        state.active += 1;
+                        break job;
+                    },
+                    _ => {
+                        state = shared.wake.wait(state).unwrap_or_else(|error| error.into_inner());
+                    },
+                }
+            }
+        };
+
+        let outcome = catch_unwind(AssertUnwindSafe(|| unsafe { job.run_claimed() }));
+
+        let mut state = shared.state.lock().unwrap_or_else(|error| error.into_inner());
+        state.active -= 1;
+        state.panicked |= outcome.is_err();
+        if state.active == 0 {
+            shared.idle.notify_all();
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "../../../tests/unit/backends/cpu/parallel_test.rs"]
+mod tests;

--- a/crates/backend-uzu/src/backends/metal/backend.rs
+++ b/crates/backend-uzu/src/backends/metal/backend.rs
@@ -16,6 +16,7 @@ impl Backend for Metal {
     type Error = MetalError;
 
     const NAME: &'static str = "metal";
+    const NEEDS_BARRIERS: bool = false;
     const MIN_ALLOCATION_ALIGNMENT: usize = 4;
     const MAX_ALLOCATION_ALIGNMENT: usize = 64;
     const ALLOCATION_GRANULARITY: usize = 8 * 1024 * 1024;

--- a/crates/backend-uzu/src/backends/metal/command_buffer.rs
+++ b/crates/backend-uzu/src/backends/metal/command_buffer.rs
@@ -21,6 +21,9 @@ use crate::backends::{
 
 static DEBUG_ENCODER_LABELS: LazyLock<bool> = LazyLock::new(|| std::env::var("UZU_METAL_DEBUG_ENCODER_LABELS").is_ok());
 
+static DEBUG_GROUPS: LazyLock<bool> =
+    LazyLock::new(|| *DEBUG_ENCODER_LABELS || std::env::var("METAL_CAPTURE_ENABLED").is_ok());
+
 pub struct MetalCommandBuffer;
 
 impl CommandBuffer for MetalCommandBuffer {
@@ -203,6 +206,10 @@ impl CommandBufferEncoding for MetalCommandBufferEncoding {
         &mut self,
         name: &str,
     ) {
+        if !*DEBUG_GROUPS {
+            return;
+        }
+
         if *DEBUG_ENCODER_LABELS {
             self.ensure_none();
         }
@@ -220,6 +227,10 @@ impl CommandBufferEncoding for MetalCommandBufferEncoding {
     }
 
     fn pop_debug_group(&mut self) {
+        if !*DEBUG_GROUPS {
+            return;
+        }
+
         if *DEBUG_ENCODER_LABELS {
             self.ensure_none();
         }

--- a/crates/backend-uzu/src/backends/metal/context.rs
+++ b/crates/backend-uzu/src/backends/metal/context.rs
@@ -43,6 +43,7 @@ pub struct MetalContext {
     pipeline_cache: Mutex<HashMap<String, Retained<ProtocolObject<dyn MTLComputePipelineState>>>>,
     sparse_heap_pool: Mutex<MetalSparseHeapPool>,
     device_tier: DeviceTier,
+    supports_mxu: bool,
     weak_self: Weak<MetalContext>,
     #[cfg(test)]
     timeline_shared_event: Retained<ProtocolObject<dyn MTLSharedEvent>>,
@@ -50,7 +51,7 @@ pub struct MetalContext {
 
 impl MetalContext {
     pub fn supports_mxu(&self) -> bool {
-        self.device.supports_mxu()
+        self.supports_mxu
     }
 
     pub(crate) fn device_tier(&self) -> DeviceTier {
@@ -156,6 +157,7 @@ impl Context for MetalContext {
 
         let gpu_core_count = device.gpu_core_count();
         let device_tier = device_tier_for_device(gpu_core_count, device.as_ref());
+        let supports_mxu = device.supports_mxu();
         let page_size = MTLSparsePageSize::KB256;
         let heap_capacity = Metal::ALLOCATION_GRANULARITY;
         let sparse_pool = MetalSparseHeapPool::new(page_size, heap_capacity);
@@ -175,6 +177,7 @@ impl Context for MetalContext {
             pipeline_cache: Mutex::new(HashMap::new()),
             sparse_heap_pool: Mutex::new(sparse_pool),
             device_tier,
+            supports_mxu,
             weak_self: weak_self.clone(),
             #[cfg(test)]
             timeline_shared_event,
@@ -269,7 +272,7 @@ impl Context for MetalContext {
         if self.device.supports_placement_sparse_resources() {
             capabilities |= DeviceCapabilities::SPARSE_BUFFERS;
         }
-        if self.device.supports_mxu() {
+        if self.supports_mxu {
             capabilities |= DeviceCapabilities::NATIVE_INT8_MATMUL;
         }
         capabilities

--- a/crates/backend-uzu/src/encodable_block/transformer_layer.rs
+++ b/crates/backend-uzu/src/encodable_block/transformer_layer.rs
@@ -37,6 +37,7 @@ pub enum TransformerLayerError<B: Backend> {
 
 pub struct TransformerLayer<B: Backend> {
     pub layer_index: u32,
+    debug_label: Box<str>,
     pub pre_mixer_norm: Option<Normalization<B>>,
     pub kv_source_layer_index: Option<u32>,
     pub mixer: Box<dyn Mixer<B>>,
@@ -180,6 +181,7 @@ impl<B: Backend> TransformerLayer<B> {
 
         Ok(Self {
             layer_index,
+            debug_label: format!("transformer layer {layer_index}").into_boxed_str(),
             pre_mixer_norm,
             kv_source_layer_index: layer_config.kv_source_layer_index,
             mixer,
@@ -201,7 +203,7 @@ impl<B: Backend> TransformerLayer<B> {
         state: Option<MaybeMut<dyn MixerState<B>>>,
         encoder: &mut Encoder<B>,
     ) -> Result<Allocation<B>, B::Error> {
-        encoder.push_debug_group(&format!("transformer layer {}", self.layer_index));
+        encoder.push_debug_group(&self.debug_label);
 
         let hidden = if let Some(pre_mixer_norm) = &self.pre_mixer_norm {
             pre_mixer_norm.encode(&input, 0, batch_dim.size(), Some(shortcut), encoder)?

--- a/crates/backend-uzu/src/trie.rs
+++ b/crates/backend-uzu/src/trie.rs
@@ -65,6 +65,7 @@ impl TrieNode {
         Ok(self.next.len() - 1)
     }
 
+    #[cfg(test)]
     pub fn get(
         &self,
         token: u64,
@@ -197,10 +198,7 @@ impl<'a> FlatTrie<'a> {
         any_non_full
     }
 
-    pub fn root(&self) -> Option<&TrieNode> {
-        self.tokens.first().map(|n| n.node)
-    }
-
+    #[cfg(test)]
     pub fn index(
         &self,
         node: &'a TrieNode,
@@ -208,15 +206,31 @@ impl<'a> FlatTrie<'a> {
         self.tokens.iter().position(|n| std::ptr::eq(n.node, node))
     }
 
+    fn child_index(
+        &self,
+        parent: usize,
+        token: u64,
+    ) -> Option<usize> {
+        let subtrie_end = self.tokens[parent].subtrie_range.1;
+        let mut child = parent + 1;
+        while child <= subtrie_end {
+            if self.tokens[child].node.token == token {
+                return Some(child);
+            }
+            child = self.tokens[child].subtrie_range.1 + 1;
+        }
+        None
+    }
+
     pub fn accept(
         &self,
         sampled_tokens: &[u64],
         #[cfg(grammar)] mut grammar: Option<&mut Grammar>,
     ) -> Result<Box<[(usize, u64, u64)]>, TrieAcceptError> {
-        let mut current_token = self.root().unwrap();
+        let mut current_token_index = 0usize;
         let mut accepted = Vec::new();
         loop {
-            let current_token_index = self.index(current_token).unwrap();
+            let current_token = self.tokens[current_token_index].node;
             let current_token_id = sampled_tokens[current_token_index];
 
             accepted.push((current_token_index, current_token.token, current_token_id));
@@ -227,7 +241,7 @@ impl<'a> FlatTrie<'a> {
                 grammar.accept_token(current_token_id)?;
             }
 
-            let Some(next_token) = current_token.get(current_token_id) else {
+            let Some(next_token_index) = self.child_index(current_token_index, current_token_id) else {
                 break;
             };
 
@@ -236,7 +250,7 @@ impl<'a> FlatTrie<'a> {
                 assert!(!grammar.is_terminated(), "Grammar has terminated but llm continued generation");
             }
 
-            current_token = next_token;
+            current_token_index = next_token_index;
         }
 
         Ok(accepted.into_boxed_slice())

--- a/crates/backend-uzu/tests/allocation_budget.rs
+++ b/crates/backend-uzu/tests/allocation_budget.rs
@@ -1,0 +1,110 @@
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    cell::Cell,
+};
+
+use backend_uzu::{
+    backends::common::{AllocationType, Backend, Context, Encoder},
+    data_type::DataType,
+};
+
+#[cfg(backend = "cpu")]
+type TestBackend = backend_uzu::backends::cpu::Cpu;
+#[cfg(all(backend = "metal", not(backend = "cpu")))]
+type TestBackend = backend_uzu::backends::metal::Metal;
+
+struct Counting;
+
+// `const` init: no lazy setup, no destructor, so counting cannot recurse.
+thread_local! {
+    static COUNT: Cell<usize> = const { Cell::new(0) };
+}
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(
+        &self,
+        layout: Layout,
+    ) -> *mut u8 {
+        COUNT.set(COUNT.get() + 1);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(
+        &self,
+        pointer: *mut u8,
+        layout: Layout,
+    ) {
+        unsafe { System.dealloc(pointer, layout) }
+    }
+
+    unsafe fn alloc_zeroed(
+        &self,
+        layout: Layout,
+    ) -> *mut u8 {
+        COUNT.set(COUNT.get() + 1);
+        unsafe { System.alloc_zeroed(layout) }
+    }
+
+    unsafe fn realloc(
+        &self,
+        pointer: *mut u8,
+        layout: Layout,
+        new_size: usize,
+    ) -> *mut u8 {
+        COUNT.set(COUNT.get() + 1);
+        unsafe { System.realloc(pointer, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+fn count(work: impl FnOnce()) -> usize {
+    COUNT.set(0);
+    work();
+    COUNT.get()
+}
+
+/// The two repeat counts are far apart, so a single allocation per dispatch shows up as
+/// hundreds and cannot hide in the fixed-setup noise.
+fn per_dispatch(mut work: impl FnMut(usize)) -> usize {
+    let few = count(|| work(64));
+    let many = count(|| work(1024));
+    many.saturating_sub(few) / 960
+}
+
+#[test]
+fn encode_copy_budget() {
+    let context = <TestBackend as Backend>::Context::new().expect("context");
+    let bytes = 64 * DataType::U32.size_in_bytes();
+    let source = context.create_allocation(bytes, AllocationType::Global).expect("source");
+    let mut destination = context.create_allocation(bytes, AllocationType::Global).expect("destination");
+
+    let allocations = per_dispatch(|repeats| {
+        let mut encoder = Encoder::<TestBackend>::new(&context).expect("encoder");
+        for _ in 0..repeats {
+            encoder.encode_copy(&source, 0..bytes, &mut destination, 0..bytes);
+        }
+        encoder.end_encoding().submit().wait_until_completed().expect("run");
+    });
+
+    println!("encode_copy: {allocations} allocations per dispatch");
+    assert!(allocations <= 4, "encode_copy allocates {allocations} per dispatch");
+}
+
+#[test]
+fn debug_group_budget() {
+    let context = <TestBackend as Backend>::Context::new().expect("context");
+
+    let allocations = per_dispatch(|repeats| {
+        let mut encoder = Encoder::<TestBackend>::new(&context).expect("encoder");
+        for _ in 0..repeats {
+            encoder.push_debug_group("budget probe");
+            encoder.pop_debug_group();
+        }
+        encoder.end_encoding().submit().wait_until_completed().expect("run");
+    });
+
+    println!("debug group: {allocations} allocations per push/pop");
+    assert_eq!(allocations, 0, "a debug group must not allocate");
+}

--- a/crates/backend-uzu/tests/unit/backends/common/allocator/pool_recycling_test.rs
+++ b/crates/backend-uzu/tests/unit/backends/common/allocator/pool_recycling_test.rs
@@ -1,0 +1,81 @@
+use proc_macros::uzu_test;
+
+use super::{RangeAllocationType, RangeAllocator};
+use crate::backends::common::{AllocationType, Backend, Context};
+
+#[cfg(backend = "cpu")]
+type TestBackend = crate::backends::cpu::Cpu;
+#[cfg(all(backend = "metal", not(backend = "cpu")))]
+type TestBackend = crate::backends::metal::Metal;
+
+const POOL_CYCLES: usize = 1024;
+
+#[uzu_test]
+fn pool_numbers_are_recycled() {
+    let context = <TestBackend as Backend>::Context::new().expect("context");
+
+    let mut highest = 0usize;
+    for _ in 0..POOL_CYCLES {
+        let pool = context.create_allocation_pool(false);
+        highest = highest.max(pool.pool_number());
+
+        let allocation = context
+            .create_allocation(
+                4096,
+                AllocationType::Pooled {
+                    pool: &pool,
+                    cpu_available: true,
+                },
+            )
+            .expect("allocation");
+        drop(allocation);
+        drop(pool);
+    }
+
+    assert_eq!(highest, 0, "sequential pools must reuse the same number, got up to {highest}");
+}
+
+#[uzu_test]
+fn nested_pools_stay_dense() {
+    let context = <TestBackend as Backend>::Context::new().expect("context");
+
+    for _ in 0..POOL_CYCLES {
+        let outer = context.create_allocation_pool(false);
+        let inner = context.create_allocation_pool(false);
+        assert!(outer.pool_number() < 2 && inner.pool_number() < 2, "expected numbers 0 and 1");
+        assert_ne!(outer.pool_number(), inner.pool_number(), "live pools must not share a number");
+    }
+}
+
+fn pooled(pool: usize) -> RangeAllocationType {
+    RangeAllocationType::Pooled {
+        pool,
+        can_alias_before: false,
+        can_alias_after: false,
+    }
+}
+
+fn cycle(
+    allocator: &mut RangeAllocator,
+    pool: usize,
+) {
+    let range = allocator.allocate_range_aligned(1024, 64, pooled(pool)).expect("range");
+    allocator.free_range(range, pooled(pool));
+    allocator.free_pool(pool);
+}
+
+/// Shows why the numbers matter: a monotonic counter grows per-pool state without bound.
+#[uzu_test]
+fn range_allocator_state_follows_pool_numbers() {
+    let mut recycled = RangeAllocator::new(0..1 << 20);
+    for _ in 0..POOL_CYCLES {
+        cycle(&mut recycled, 0);
+    }
+    assert_eq!(recycled.pool_slot_count(), 1, "recycled numbers keep per-pool state at one slot");
+
+    let mut growing = RangeAllocator::new(0..1 << 20);
+    for pool in 0..POOL_CYCLES {
+        cycle(&mut growing, pool);
+    }
+    assert_eq!(growing.pool_slot_count(), POOL_CYCLES, "distinct numbers grow per-pool state");
+}

--- a/crates/backend-uzu/tests/unit/backends/cpu/kernel/matmul/parallel_matmul_test.rs
+++ b/crates/backend-uzu/tests/unit/backends/cpu/kernel/matmul/parallel_matmul_test.rs
@@ -1,0 +1,155 @@
+use std::{hint::black_box, time::Instant};
+
+use proc_macros::uzu_test;
+use rand::{RngExt, SeedableRng, rngs::SmallRng};
+
+use crate::{
+    backends::{
+        common::{
+            Backend, Encoder, Kernels,
+            kernel::matmul::{MatmulA, MatmulArguments, MatmulB, MatmulDOps, MatmulKernel},
+        },
+        cpu::Cpu,
+    },
+    data_type::DataType,
+    tests::helpers::{alloc_allocation, alloc_allocation_with_data, allocation_to_vec},
+};
+
+fn random_matrix(
+    elements: usize,
+    seed: u64,
+) -> Vec<f32> {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    (0..elements).map(|_| rng.random_range(-0.5f32..0.5)).collect()
+}
+
+fn run_matmul(
+    threads: usize,
+    m: u32,
+    n: u32,
+    k: u32,
+    a: &[f32],
+    b: &[f32],
+) -> Vec<f32> {
+    let context = <Cpu as Backend>::Context::with_threads(threads);
+    let a_allocation = alloc_allocation_with_data::<Cpu, f32>(&context, a);
+    let b_allocation = alloc_allocation_with_data::<Cpu, f32>(&context, b);
+    let mut d_allocation = alloc_allocation::<Cpu, f32>(&context, (m * n) as usize);
+
+    let mut kernel = <<Cpu as Backend>::Kernels as Kernels>::MatmulKernel::new(
+        &context,
+        DataType::F32,
+        DataType::F32,
+        DataType::F32,
+    )
+    .expect("matmul kernel");
+
+    let mut encoder = Encoder::<Cpu>::new(&context).expect("encoder");
+    kernel
+        .encode(
+            MatmulArguments {
+                a: MatmulA::FullPrecision {
+                    values: &a_allocation,
+                    offset: 0,
+                },
+                b: MatmulB::FullPrecision {
+                    b: &b_allocation,
+                },
+                b_leading_dimension: None,
+                b_transpose: true,
+                d: &mut d_allocation,
+                d_transform: MatmulDOps::none(),
+                gather_indices: None,
+                m,
+                n,
+                k,
+            },
+            &mut encoder,
+        )
+        .expect("encode");
+    encoder.end_encoding().submit().wait_until_completed().expect("run");
+
+    allocation_to_vec::<Cpu, f32>(&d_allocation)
+}
+
+fn reference_matmul(
+    m: usize,
+    n: usize,
+    k: usize,
+    a: &[f32],
+    b: &[f32],
+) -> (Vec<f32>, Vec<f32>) {
+    let mut d = vec![0.0f32; m * n];
+    let mut magnitude = vec![0.0f32; m * n];
+    for row in 0..m {
+        for col in 0..n {
+            let mut accumulator = 0.0f32;
+            let mut absolute = 0.0f32;
+            for inner in 0..k {
+                let term = a[row * k + inner] * b[col * k + inner];
+                accumulator += term;
+                absolute += term.abs();
+            }
+            d[row * n + col] = accumulator;
+            magnitude[row * n + col] = absolute;
+        }
+    }
+    (d, magnitude)
+}
+
+#[uzu_test]
+fn threaded_matmul_is_bit_identical() {
+    for (m, n, k) in [(1u32, 512u32, 256u32), (8, 300, 128), (64, 129, 64), (3, 1024, 512)] {
+        let a = random_matrix((m * k) as usize, 0x9E3779B97F4A7C15 ^ u64::from(n));
+        let b = random_matrix((n * k) as usize, 0xD1B54A32D192ED03 ^ u64::from(k));
+
+        let single = run_matmul(1, m, n, k, &a, &b);
+        let (reference, magnitude) = reference_matmul(m as usize, n as usize, k as usize, &a, &b);
+        for (index, (value, expected)) in single.iter().zip(&reference).enumerate() {
+            let tolerance = 2.0 * k as f32 * f32::EPSILON * magnitude[index];
+            assert!(
+                (value - expected).abs() <= tolerance,
+                "{m}x{n}x{k} element {index}: {value} vs {expected}, tolerance {tolerance}"
+            );
+        }
+
+        for threads in [2usize, 3, 8, 16] {
+            let threaded = run_matmul(threads, m, n, k, &a, &b);
+            assert_eq!(threaded, single, "threads={threads} changed the result ({m}x{n}x{k})");
+        }
+    }
+}
+
+#[uzu_test]
+fn threaded_matmul_handles_ragged_splits() {
+    let (m, n, k) = (2u32, 37u32, 19u32);
+    let a = random_matrix((m * k) as usize, 0x2545F4914F6CDD1D);
+    let b = random_matrix((n * k) as usize, 0x14057B7EF767814F);
+
+    let single = run_matmul(1, m, n, k, &a, &b);
+    for threads in 2..=40usize {
+        assert_eq!(run_matmul(threads, m, n, k, &a, &b), single, "threads={threads}");
+    }
+}
+
+#[uzu_test]
+fn threaded_matmul_speedup() {
+    let (m, n, k) = (1u32, 8192u32, 1024u32);
+    let a = random_matrix((m * k) as usize, 0x3C79AC492BA7B653);
+    let b = random_matrix((n * k) as usize, 0x76E15D3EFEFDCBBF);
+
+    let single_started = Instant::now();
+    let single = run_matmul(1, m, n, k, black_box(&a), black_box(&b));
+    let single_elapsed = single_started.elapsed();
+
+    let threads = std::thread::available_parallelism().map(|threads| threads.get()).unwrap_or(1);
+    let threaded_started = Instant::now();
+    let threaded = run_matmul(threads, m, n, k, black_box(&a), black_box(&b));
+    let threaded_elapsed = threaded_started.elapsed();
+
+    assert_eq!(threaded, single);
+    println!(
+        "cpu matmul {m}x{n}x{k}: 1 thread {single_elapsed:?} -> {threads} threads {threaded_elapsed:?} ({:.2}x)",
+        single_elapsed.as_secs_f64() / threaded_elapsed.as_secs_f64()
+    );
+}

--- a/crates/backend-uzu/tests/unit/backends/cpu/kernel/matmul/quant_matmul_test.rs
+++ b/crates/backend-uzu/tests/unit/backends/cpu/kernel/matmul/quant_matmul_test.rs
@@ -1,0 +1,185 @@
+use std::{hint::black_box, time::Instant};
+
+use half::{bf16, f16};
+use num_traits::Float;
+use proc_macros::uzu_test;
+
+use crate::{
+    array::ArrayElement,
+    backends::common::gpu_types::{QuantizationMethod, QuantizationMode},
+    tests::matmul::quant::{QuantInput, run_quant_cpu},
+};
+
+fn reference_quant_matmul<T: ArrayElement + Float>(input: &QuantInput<T>) -> Vec<T> {
+    let (rows, inner_size, columns) = (input.m as usize, input.k as usize, input.n as usize);
+    let group_size = input.group_size as usize;
+    let bits = match input.mode {
+        QuantizationMode::U4 => 4usize,
+        _ => 8usize,
+    };
+    let groups = inner_size.div_ceil(group_size);
+    let zero_point_stride = if bits == 4 {
+        groups.div_ceil(2)
+    } else {
+        groups
+    };
+    let pack_factor = 32 / bits;
+    let code_mask = (1u32 << bits) - 1;
+    let midpoint = (1u32 << (bits - 1)) as f32;
+    let words = input.weights_for_upload();
+    let prepared = input.prepared_a.as_ref();
+
+    let mut output = Vec::with_capacity(rows * columns);
+    for row in 0..rows {
+        for column in 0..columns {
+            let mut accumulator = 0.0f32;
+            for index in 0..inner_size {
+                let linear = column * inner_size + index;
+                let word = words[linear / pack_factor];
+                let mut code = ((word >> ((linear % pack_factor) * bits)) & code_mask) as u8;
+                if input.signed_codes {
+                    code ^= 1u8 << (bits - 1);
+                }
+
+                let group = index / group_size;
+                let scale = input.scales[column * groups + group].to_f32().unwrap();
+                let bias = if let Some(zero_points) = &input.zero_points {
+                    let zero_point = if bits == 4 {
+                        let byte = zero_points[column * zero_point_stride + (group >> 1)];
+                        if group.is_multiple_of(2) {
+                            (byte & 0x0F) as f32
+                        } else {
+                            ((byte >> 4) & 0x0F) as f32
+                        }
+                    } else {
+                        zero_points[column * zero_point_stride + group] as f32
+                    };
+                    -scale * zero_point
+                } else if let Some(biases) = &input.biases {
+                    biases[column * groups + group].to_f32().unwrap()
+                } else {
+                    -scale * midpoint
+                };
+
+                let activation = match prepared {
+                    Some(prepared) => {
+                        let activation_groups = inner_size / prepared.activation_scale_group_size as usize;
+                        let activation_group = index / prepared.activation_scale_group_size as usize;
+                        f32::from(prepared.values[row * inner_size + index])
+                            * prepared.scales[row * activation_groups + activation_group]
+                    },
+                    None => input.x[row * inner_size + index].to_f32().unwrap(),
+                };
+
+                accumulator += activation * (scale * f32::from(code) + bias);
+            }
+            output.push(T::from(accumulator).unwrap());
+        }
+    }
+    output
+}
+
+const METHODS: [QuantizationMethod; 3] =
+    [QuantizationMethod::ScaleBias, QuantizationMethod::ScaleZeroPoint, QuantizationMethod::ScaleSymmetric];
+
+const SHAPES: [(u32, u32, u32); 6] = [
+    (1, 128, 64),  // decode, every group full
+    (1, 40, 17),   // k = one group of 32 plus a group of 8
+    (3, 96, 33),   // k below a 128-group, exact for 32 and short for 64
+    (8, 256, 128), // prefill-ish batch
+    (2, 160, 9),   // k = 5 groups of 32, odd column count
+    (1, 72, 7),    // short trailing group for every group size
+];
+
+fn check_all<T: ArrayElement + Float + std::fmt::Debug>(label: &str) {
+    let mut seed = 0x9E3779B97F4A7C15u64;
+    for method in METHODS {
+        for bits in [4u32, 8] {
+            for group_size in [32u32, 64, 128] {
+                for (m, k, n) in SHAPES {
+                    seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+                    let input = QuantInput::<T>::new(m, k, n, group_size, bits, method, seed);
+
+                    assert_eq!(
+                        run_quant_cpu(&input),
+                        reference_quant_matmul(&input),
+                        "{label}: method={method:?} bits={bits} group={group_size} shape={m}x{n}x{k}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[uzu_test]
+fn quant_matmul_matches_reference_f32() {
+    check_all::<f32>("f32");
+}
+
+#[uzu_test]
+fn quant_matmul_matches_reference_f16() {
+    check_all::<f16>("f16");
+}
+
+#[uzu_test]
+fn quant_matmul_matches_reference_bf16() {
+    check_all::<bf16>("bf16");
+}
+
+#[uzu_test]
+fn quant_matmul_matches_reference_with_signed_codes() {
+    for bits in [4u32, 8] {
+        for method in METHODS {
+            for (m, k, n) in SHAPES {
+                let input =
+                    QuantInput::<f32>::new(m, k, n, 32, bits, method, 0xD1B54A32D192ED03).with_signed_weight_codes();
+
+                assert_eq!(
+                    run_quant_cpu(&input),
+                    reference_quant_matmul(&input),
+                    "bits={bits} method={method:?} shape={m}x{n}x{k}"
+                );
+            }
+        }
+    }
+}
+
+#[uzu_test]
+fn quant_matmul_matches_reference_with_int8_activations() {
+    for bits in [4u32, 8] {
+        for group_size in [32u32, 64] {
+            let input = QuantInput::<f32>::new(
+                2,
+                256,
+                48,
+                group_size,
+                bits,
+                QuantizationMethod::ScaleSymmetric,
+                0x14057B7EF767814F,
+            )
+            .with_prepared_a(group_size, None);
+
+            assert_eq!(
+                run_quant_cpu(&input),
+                reference_quant_matmul(&input),
+                "int8 activations: bits={bits} group={group_size}"
+            );
+        }
+    }
+}
+
+#[uzu_test]
+fn quant_matmul_decode_speed() {
+    let input = QuantInput::<f32>::new(1, 1024, 8192, 64, 4, QuantizationMethod::ScaleZeroPoint, 0x2545F4914F6CDD1D);
+
+    black_box(run_quant_cpu(&input));
+
+    let iterations = 5;
+    let started = Instant::now();
+    for _ in 0..iterations {
+        black_box(run_quant_cpu(black_box(&input)));
+    }
+    let elapsed = started.elapsed() / iterations;
+
+    println!("cpu quant matmul 1x8192x1024 (4-bit, group 64): {elapsed:?} per call");
+}

--- a/crates/backend-uzu/tests/unit/backends/cpu/kernel/sampling/unified_sampling_test.rs
+++ b/crates/backend-uzu/tests/unit/backends/cpu/kernel/sampling/unified_sampling_test.rs
@@ -1,0 +1,564 @@
+use std::{cmp::Ordering, hint::black_box, time::Instant};
+
+use half::bf16;
+use num_traits::Float;
+use proc_macros::uzu_test;
+use rand::{RngExt, SeedableRng, rngs::SmallRng};
+
+use super::unified_sampling;
+use crate::{
+    array::ArrayElement,
+    encodable_block::sampling::{gumbel_float, revidx},
+};
+
+#[allow(clippy::too_many_arguments)]
+fn reference_unified_sampling<T: ArrayElement + Float>(
+    logits: *const T,
+    output: *mut u32,
+    seeds: Option<*const u64>,
+    bitmask: Option<*const u32>,
+    temperature: Option<f32>,
+    top_k: Option<u32>,
+    top_p: Option<f32>,
+    min_p: Option<f32>,
+    vocab_size: u32,
+    batch_size: u32,
+    is_stochastic: bool,
+    has_bitmask: bool,
+    has_temperature: bool,
+    has_top_k: bool,
+    has_top_p: bool,
+    has_min_p: bool,
+) {
+    for batch_idx in 0..batch_size {
+        let mut logits = unsafe {
+            std::slice::from_raw_parts(logits.wrapping_add((vocab_size * batch_idx) as usize), vocab_size as usize)
+        }
+        .iter()
+        .map(|logit| logit.to_f32().unwrap())
+        .collect::<Vec<f32>>();
+
+        if has_bitmask {
+            let bitmask = unsafe {
+                std::slice::from_raw_parts(
+                    bitmask.unwrap().wrapping_add((vocab_size.div_ceil(u32::BITS) * batch_idx) as usize),
+                    vocab_size.div_ceil(u32::BITS) as usize,
+                )
+            };
+            for (logit_index, logit) in logits.iter_mut().enumerate() {
+                if bitmask[logit_index / (u32::BITS as usize)] & (1 << (logit_index % (u32::BITS as usize))) == 0 {
+                    *logit = f32::NEG_INFINITY;
+                }
+            }
+        }
+
+        if has_temperature {
+            let recip_temperature = 1.0 / temperature.unwrap();
+            for logit in logits.iter_mut() {
+                *logit *= recip_temperature;
+            }
+        }
+
+        if has_top_k || has_top_p || has_min_p {
+            let mut sorted_logits = logits.iter().copied().enumerate().collect::<Vec<_>>();
+            sorted_logits.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal).then(a.0.cmp(&b.0)));
+
+            let logits_max = sorted_logits[0].1;
+            let logits_norm = sorted_logits.iter().map(|logit| (logit.1 - logits_max).exp()).sum::<f32>();
+
+            logits.fill(f32::NEG_INFINITY);
+            let mut top_p_mass = 0.0;
+            for (top_k_num, (index, logit)) in sorted_logits.into_iter().enumerate() {
+                if (has_top_k && top_k_num as u32 >= top_k.unwrap())
+                    || (has_top_p && top_p_mass >= top_p.unwrap())
+                    || (has_min_p && logit < logits_max + min_p.unwrap().ln())
+                {
+                    break;
+                }
+                logits[index] = logit;
+                top_p_mass += (logit - logits_max).exp() / logits_norm;
+            }
+        }
+
+        if is_stochastic {
+            let seed = unsafe { *seeds.unwrap().wrapping_add(batch_idx as usize) };
+            for (logit_index, logit) in logits.iter_mut().enumerate() {
+                *logit += gumbel_float(seed, revidx(logit_index as u32, vocab_size));
+            }
+        }
+
+        let argmax = logits
+            .into_iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(Ordering::Equal).then(b.0.cmp(&a.0)))
+            .unwrap()
+            .0;
+
+        unsafe { *output.wrapping_add(batch_idx as usize) = argmax as u32 }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Shape {
+    Uniform,
+    Peaked,
+    Ties,
+    HalfMasked,
+}
+
+fn make_logits(
+    shape: Shape,
+    vocab: usize,
+    rng: &mut SmallRng,
+) -> Vec<f32> {
+    let mut logits = Vec::with_capacity(vocab);
+    for index in 0..vocab {
+        let value = match shape {
+            Shape::Uniform => rng.random_range(-4.0f32..4.0),
+            Shape::Peaked => {
+                let base = rng.random_range(-12.0f32..-8.0);
+                if index % 997 == 0 {
+                    base + 20.0
+                } else {
+                    base
+                }
+            },
+            Shape::Ties => ((rng.random_range(0u32..7) as f32) - 3.0) * 2.0,
+            Shape::HalfMasked => {
+                if index % 2 == 0 {
+                    f32::NEG_INFINITY
+                } else {
+                    rng.random_range(-4.0f32..4.0)
+                }
+            },
+        };
+        logits.push(value);
+    }
+    logits
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Config {
+    temperature: Option<f32>,
+    top_k: Option<u32>,
+    top_p: Option<f32>,
+    min_p: Option<f32>,
+    stochastic: bool,
+    bitmask: bool,
+}
+
+impl Config {
+    fn sample(rng: &mut SmallRng) -> Self {
+        Self {
+            temperature: match rng.random_range(0u32..3) {
+                0 => None,
+                1 => Some(0.7),
+                _ => Some(1.3),
+            },
+            top_k: match rng.random_range(0u32..5) {
+                0 => None,
+                1 => Some(1),
+                2 => Some(5),
+                3 => Some(40),
+                _ => Some(1000),
+            },
+            top_p: match rng.random_range(0u32..5) {
+                0 => None,
+                1 => Some(0.1),
+                2 => Some(0.5),
+                3 => Some(0.9),
+                _ => Some(0.999),
+            },
+            min_p: match rng.random_range(0u32..4) {
+                0 => None,
+                1 => Some(0.5),
+                2 => Some(0.1),
+                _ => Some(0.01),
+            },
+            stochastic: rng.random_range(0u32..2) == 0,
+            bitmask: rng.random_range(0u32..4) == 0,
+        }
+    }
+}
+
+fn make_bitmask(
+    vocab: usize,
+    rng: &mut SmallRng,
+) -> Vec<u32> {
+    let words = (vocab as u32).div_ceil(u32::BITS) as usize;
+    let mut bitmask = vec![0u32; words];
+    for _ in 0..(vocab / 8).max(1) {
+        let index = rng.random_range(0..vocab);
+        bitmask[index / 32] |= 1 << (index % 32);
+    }
+    bitmask[0] |= 1;
+    bitmask
+}
+
+fn run_both<T: ArrayElement + Float>(
+    logits: &[T],
+    bitmask: Option<&[u32]>,
+    seeds: &[u64],
+    config: Config,
+    vocab: u32,
+    batch: u32,
+) -> (Vec<u32>, Vec<u32>) {
+    let mut actual = vec![u32::MAX; batch as usize];
+    let mut expected = vec![u32::MAX; batch as usize];
+
+    let logits = logits.as_ptr();
+    let seeds = config.stochastic.then_some(seeds.as_ptr());
+    let bitmask_ptr = bitmask.map(|bitmask| bitmask.as_ptr());
+    let has_bitmask = bitmask.is_some();
+    let has_temperature = config.temperature.is_some();
+    let has_top_k = config.top_k.is_some();
+    let has_top_p = config.top_p.is_some();
+    let has_min_p = config.min_p.is_some();
+
+    unified_sampling::<T>(
+        logits,
+        actual.as_mut_ptr(),
+        seeds,
+        bitmask_ptr,
+        config.temperature,
+        config.top_k,
+        config.top_p,
+        config.min_p,
+        vocab,
+        batch,
+        config.stochastic,
+        has_bitmask,
+        has_temperature,
+        has_top_k,
+        has_top_p,
+        has_min_p,
+    );
+    reference_unified_sampling::<T>(
+        logits,
+        expected.as_mut_ptr(),
+        seeds,
+        bitmask_ptr,
+        config.temperature,
+        config.top_k,
+        config.top_p,
+        config.min_p,
+        vocab,
+        batch,
+        config.stochastic,
+        has_bitmask,
+        has_temperature,
+        has_top_k,
+        has_top_p,
+        has_min_p,
+    );
+
+    (actual, expected)
+}
+
+const SHAPES: [Shape; 4] = [Shape::Uniform, Shape::Peaked, Shape::Ties, Shape::HalfMasked];
+
+#[uzu_test]
+fn unified_sampling_matches_reference_f32() {
+    let mut rng = SmallRng::seed_from_u64(0x9E3779B97F4A7C15);
+    let mut cases = 0usize;
+
+    for vocab in [17usize, 129, 1024, 4096] {
+        for shape in SHAPES {
+            for _ in 0..24 {
+                let batch = 1 + rng.random_range(0u32..3);
+                let mut logits = Vec::with_capacity(vocab * batch as usize);
+                for _ in 0..batch {
+                    logits.extend(make_logits(shape, vocab, &mut rng));
+                }
+                let config = Config::sample(&mut rng);
+                let bitmask = config.bitmask.then(|| {
+                    let mut bitmask = Vec::new();
+                    for _ in 0..batch {
+                        bitmask.extend(make_bitmask(vocab, &mut rng));
+                    }
+                    bitmask
+                });
+                let seeds: Vec<u64> = (0..batch).map(|_| rng.random::<u32>() as u64).collect();
+
+                let (actual, expected) = run_both(&logits, bitmask.as_deref(), &seeds, config, vocab as u32, batch);
+                assert_eq!(actual, expected, "vocab={vocab} shape={shape:?} batch={batch} config={config:?}");
+                cases += 1;
+            }
+        }
+    }
+
+    assert!(cases >= 384, "expected a broad sweep, got {cases} cases");
+}
+
+#[uzu_test]
+fn unified_sampling_matches_reference_bf16() {
+    let mut rng = SmallRng::seed_from_u64(0xD1B54A32D192ED03);
+
+    for vocab in [64usize, 512, 2048] {
+        for shape in SHAPES {
+            for _ in 0..12 {
+                let logits: Vec<bf16> = make_logits(shape, vocab, &mut rng).into_iter().map(bf16::from_f32).collect();
+                let config = Config::sample(&mut rng);
+                let bitmask = config.bitmask.then(|| make_bitmask(vocab, &mut rng));
+                let seeds = vec![rng.random::<u32>() as u64];
+
+                let (actual, expected) = run_both(&logits, bitmask.as_deref(), &seeds, config, vocab as u32, 1);
+                assert_eq!(actual, expected, "vocab={vocab} shape={shape:?} config={config:?}");
+            }
+        }
+    }
+}
+
+#[uzu_test]
+fn unified_sampling_matches_reference_full_vocab() {
+    let vocab = 151_936usize;
+    let mut rng = SmallRng::seed_from_u64(0x2545F4914F6CDD1D);
+    let logits = make_logits(Shape::Peaked, vocab, &mut rng);
+
+    for config in [
+        Config {
+            temperature: Some(0.7),
+            top_k: Some(40),
+            top_p: Some(0.95),
+            min_p: None,
+            stochastic: true,
+            bitmask: false,
+        },
+        Config {
+            temperature: None,
+            top_k: None,
+            top_p: Some(0.9),
+            min_p: None,
+            stochastic: true,
+            bitmask: false,
+        },
+        Config {
+            temperature: Some(1.0),
+            top_k: None,
+            top_p: None,
+            min_p: Some(0.05),
+            stochastic: false,
+            bitmask: false,
+        },
+        Config {
+            temperature: None,
+            top_k: Some(1),
+            top_p: None,
+            min_p: None,
+            stochastic: true,
+            bitmask: false,
+        },
+        Config {
+            temperature: None,
+            top_k: None,
+            top_p: None,
+            min_p: None,
+            stochastic: false,
+            bitmask: false,
+        },
+    ] {
+        let seeds = vec![0xABCD_EF01_2345_6789u64];
+        let (actual, expected) = run_both(&logits, None, &seeds, config, vocab as u32, 1);
+        assert_eq!(actual, expected, "config={config:?}");
+    }
+}
+
+#[uzu_test]
+fn unified_sampling_support_set_matches_reference() {
+    let vocab = 2048usize;
+    let mut rng = SmallRng::seed_from_u64(0x14057B7EF767814F);
+
+    for shape in SHAPES {
+        let logits = make_logits(shape, vocab, &mut rng);
+        for config in [
+            Config {
+                temperature: None,
+                top_k: Some(16),
+                top_p: None,
+                min_p: None,
+                stochastic: true,
+                bitmask: false,
+            },
+            Config {
+                temperature: None,
+                top_k: None,
+                top_p: Some(0.9),
+                min_p: None,
+                stochastic: true,
+                bitmask: false,
+            },
+            Config {
+                temperature: Some(0.8),
+                top_k: Some(64),
+                top_p: Some(0.99),
+                min_p: Some(0.02),
+                stochastic: true,
+                bitmask: false,
+            },
+        ] {
+            let mut actual_support = std::collections::BTreeSet::new();
+            let mut expected_support = std::collections::BTreeSet::new();
+            for seed in 0..512u64 {
+                let seeds = vec![seed.wrapping_mul(0x9E3779B97F4A7C15)];
+                let (actual, expected) = run_both(&logits, None, &seeds, config, vocab as u32, 1);
+                actual_support.insert(actual[0]);
+                expected_support.insert(expected[0]);
+            }
+            assert_eq!(actual_support, expected_support, "shape={shape:?} config={config:?}");
+            assert!(actual_support.len() > 1, "degenerate support for shape={shape:?} config={config:?}");
+        }
+    }
+}
+
+#[uzu_test]
+fn unified_sampling_edge_cases_match_reference() {
+    let greedy = Config {
+        temperature: None,
+        top_k: None,
+        top_p: None,
+        min_p: None,
+        stochastic: false,
+        bitmask: false,
+    };
+
+    let all_masked = vec![f32::NEG_INFINITY; 64];
+    for config in [
+        greedy,
+        Config {
+            top_k: Some(4),
+            ..greedy
+        },
+        Config {
+            top_p: Some(0.9),
+            ..greedy
+        },
+        Config {
+            min_p: Some(0.1),
+            ..greedy
+        },
+    ] {
+        let (actual, expected) = run_both(&all_masked, None, &[7], config, 64, 1);
+        assert_eq!(actual, expected, "all -inf, config={config:?}");
+    }
+
+    let single = vec![1.5f32];
+    let (actual, expected) = run_both(&single, None, &[3], greedy, 1, 1);
+    assert_eq!(actual, expected);
+
+    let flat = vec![2.0f32; 128];
+    for config in [
+        greedy,
+        Config {
+            top_k: Some(3),
+            ..greedy
+        },
+        Config {
+            top_p: Some(0.5),
+            ..greedy
+        },
+    ] {
+        let (actual, expected) = run_both(&flat, None, &[11], config, 128, 1);
+        assert_eq!(actual, expected, "flat, config={config:?}");
+        assert_eq!(actual[0], 0, "flat argmax must be the lowest index");
+    }
+
+    let mut rng = SmallRng::seed_from_u64(0x76E15D3EFEFDCBBF);
+    let logits = make_logits(Shape::Peaked, 300, &mut rng);
+    for config in [
+        Config {
+            top_k: Some(4096),
+            ..greedy
+        },
+        Config {
+            min_p: Some(1.0),
+            ..greedy
+        },
+        Config {
+            top_p: Some(0.0),
+            ..greedy
+        },
+        Config {
+            top_k: Some(1),
+            top_p: Some(0.999),
+            min_p: Some(0.001),
+            ..greedy
+        },
+    ] {
+        let (actual, expected) = run_both(&logits, None, &[5], config, 300, 1);
+        assert_eq!(actual, expected, "config={config:?}");
+    }
+}
+
+#[uzu_test]
+fn unified_sampling_speedup_over_reference() {
+    let vocab = 151_936usize;
+    let mut rng = SmallRng::seed_from_u64(0x3C79AC492BA7B653);
+    let logits = make_logits(Shape::Peaked, vocab, &mut rng);
+    let config = Config {
+        temperature: Some(0.7),
+        top_k: Some(40),
+        top_p: Some(0.95),
+        min_p: None,
+        stochastic: true,
+        bitmask: false,
+    };
+    let seeds = vec![0x1234_5678_9ABC_DEF0u64];
+    let mut output = vec![0u32; 1];
+    let iterations = 20;
+
+    let _ = run_both(&logits, None, &seeds, config, vocab as u32, 1);
+
+    let started = Instant::now();
+    for _ in 0..iterations {
+        unified_sampling::<f32>(
+            black_box(logits.as_ptr()),
+            output.as_mut_ptr(),
+            Some(seeds.as_ptr()),
+            None,
+            config.temperature,
+            config.top_k,
+            config.top_p,
+            config.min_p,
+            vocab as u32,
+            1,
+            true,
+            false,
+            true,
+            true,
+            true,
+            false,
+        );
+    }
+    let optimized = started.elapsed() / iterations;
+
+    let started = Instant::now();
+    for _ in 0..iterations {
+        reference_unified_sampling::<f32>(
+            black_box(logits.as_ptr()),
+            output.as_mut_ptr(),
+            Some(seeds.as_ptr()),
+            None,
+            config.temperature,
+            config.top_k,
+            config.top_p,
+            config.min_p,
+            vocab as u32,
+            1,
+            true,
+            false,
+            true,
+            true,
+            true,
+            false,
+        );
+    }
+    let baseline = started.elapsed() / iterations;
+
+    println!(
+        "unified_sampling vocab={vocab}: baseline {:?} -> optimized {:?} ({:.2}x)",
+        baseline,
+        optimized,
+        baseline.as_secs_f64() / optimized.as_secs_f64()
+    );
+    assert!(optimized < baseline, "rewrite must not be slower: {optimized:?} vs {baseline:?}");
+}

--- a/crates/backend-uzu/tests/unit/backends/cpu/parallel_test.rs
+++ b/crates/backend-uzu/tests/unit/backends/cpu/parallel_test.rs
@@ -1,0 +1,106 @@
+use std::sync::Mutex;
+
+use proc_macros::uzu_test;
+
+use super::Pool;
+
+const LARGE_WORK: usize = 1 << 24;
+
+fn collect_chunks(
+    threads: usize,
+    units: usize,
+    work: usize,
+) -> Vec<std::ops::Range<usize>> {
+    let chunks = Mutex::new(Vec::new());
+    Pool::new(threads).for_each_chunk(units, work, |range| chunks.lock().unwrap().push(range));
+    let mut chunks = chunks.into_inner().unwrap();
+    chunks.sort_by_key(|range| range.start);
+    chunks
+}
+
+#[uzu_test]
+fn chunks_partition_every_unit() {
+    for threads in [1usize, 2, 3, 7, 8, 64] {
+        for units in [1usize, 2, 5, 16, 100, 1024] {
+            let chunks = collect_chunks(threads, units, LARGE_WORK);
+
+            let mut covered = Vec::new();
+            for chunk in &chunks {
+                assert!(chunk.start < chunk.end, "empty chunk for threads={threads} units={units}");
+                covered.extend(chunk.clone());
+            }
+            assert_eq!(
+                covered,
+                (0..units).collect::<Vec<_>>(),
+                "threads={threads} units={units} must be covered once, in order"
+            );
+            assert!(chunks.len() <= units, "threads={threads} units={units}");
+        }
+    }
+}
+
+#[uzu_test]
+fn work_is_split_finer_than_thread_count() {
+    let chunks = collect_chunks(4, 4096, LARGE_WORK);
+    assert!(chunks.len() > 4, "expected finer granularity than one chunk per thread, got {}", chunks.len());
+}
+
+#[uzu_test]
+fn small_work_stays_on_one_thread() {
+    let chunks = collect_chunks(8, 1024, 1024);
+    assert_eq!(chunks.len(), 1);
+    assert_eq!(chunks[0], 0..1024);
+}
+
+#[uzu_test]
+fn single_thread_keeps_one_chunk() {
+    let chunks = collect_chunks(1, 4096, LARGE_WORK);
+    assert_eq!(chunks.len(), 1);
+    assert_eq!(chunks[0], 0..4096);
+}
+
+#[uzu_test]
+fn pool_beats_spawning_per_dispatch() {
+    let threads = std::thread::available_parallelism().map(|threads| threads.get()).unwrap_or(1);
+    let pool = Pool::new(threads);
+    let units = 1024usize;
+    let work = 1 << 24;
+    let iterations = 200;
+    let counter = std::sync::atomic::AtomicUsize::new(0);
+
+    let started = std::time::Instant::now();
+    for _ in 0..iterations {
+        pool.for_each_chunk(units, work, |range| {
+            counter.fetch_add(range.len(), std::sync::atomic::Ordering::Relaxed);
+        });
+    }
+    let pooled = started.elapsed() / iterations;
+
+    let started = std::time::Instant::now();
+    for _ in 0..iterations {
+        let next = std::sync::atomic::AtomicUsize::new(0);
+        let chunk = units.div_ceil(8 * threads);
+        let chunks = units.div_ceil(chunk);
+        std::thread::scope(|scope| {
+            for _ in 0..threads {
+                let next = &next;
+                let counter = &counter;
+                scope.spawn(move || {
+                    loop {
+                        let index = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        if index >= chunks {
+                            break;
+                        }
+                        let start = index * chunk;
+                        let end = (start + chunk).min(units);
+                        counter.fetch_add(end - start, std::sync::atomic::Ordering::Relaxed);
+                    }
+                });
+            }
+        });
+    }
+    let spawned = started.elapsed() / iterations;
+
+    println!("parallel dispatch: spawn {spawned:?} -> pool {pooled:?}");
+    assert_eq!(counter.load(std::sync::atomic::Ordering::Relaxed), 2 * iterations as usize * units);
+}

--- a/crates/backend-uzu/tests/unit/trie_test.rs
+++ b/crates/backend-uzu/tests/unit/trie_test.rs
@@ -177,3 +177,104 @@ fn test_trie_manual_tree() {
 
     verify_tree(&trie_root, &rng)
 }
+
+fn reference_accept(
+    trie_root: &TrieNode,
+    flat_trie: &crate::trie::FlatTrie,
+    sampled_tokens: &[u64],
+) -> Vec<(usize, u64, u64)> {
+    let mut current = trie_root;
+    let mut accepted = Vec::new();
+    loop {
+        let index = flat_trie.index(current).unwrap();
+        let sampled = sampled_tokens[index];
+        accepted.push((index, current.token(), sampled));
+        let Some(next) = current.get(sampled) else {
+            break;
+        };
+        current = next;
+    }
+    accepted
+}
+
+struct TestRng(u64);
+
+impl TestRng {
+    fn next(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+
+    fn below(
+        &mut self,
+        bound: u64,
+    ) -> u64 {
+        self.next() % bound
+    }
+}
+
+fn grow_random_trie(
+    node: &mut TrieNode,
+    depth: usize,
+    rng: &mut TestRng,
+) {
+    if depth == 0 {
+        return;
+    }
+    let children = rng.below(4);
+    for child in 0..children {
+        let mut next = TrieNode::new(child, rng.next());
+        grow_random_trie(&mut next, depth - 1, rng);
+        node.add(next).unwrap();
+    }
+}
+
+#[uzu_test]
+fn test_trie_accept_matches_reference() {
+    let mut rng = TestRng(0x9E3779B97F4A7C15);
+
+    for case in 0..200 {
+        let mut trie_root = TrieNode::new(0, rng.next());
+        grow_random_trie(&mut trie_root, 1 + (case % 5), &mut rng);
+        let flat_trie = trie_root.linearize();
+
+        let sampled_tokens: Vec<u64> = (0..flat_trie.len()).map(|_| rng.below(5)).collect();
+
+        let accepted = flat_trie
+            .accept(
+                &sampled_tokens,
+                #[cfg(grammar)]
+                None,
+            )
+            .unwrap();
+        let expected = reference_accept(&trie_root, &flat_trie, &sampled_tokens);
+
+        assert_eq!(accepted.as_ref(), expected.as_slice(), "case {case}");
+    }
+}
+
+#[uzu_test]
+fn test_trie_accept_full_chain() {
+    let mut trie_root = TrieNode::new(0, 0);
+    let mut node = &mut trie_root;
+    for token in 1..32u64 {
+        node.add(TrieNode::new(token, token)).unwrap();
+        node = &mut node.next[0];
+    }
+    let flat_trie = trie_root.linearize();
+    let sampled_tokens: Vec<u64> = (1..=flat_trie.len() as u64).collect();
+
+    let accepted = flat_trie
+        .accept(
+            &sampled_tokens,
+            #[cfg(grammar)]
+            None,
+        )
+        .unwrap();
+    let expected = reference_accept(&trie_root, &flat_trie, &sampled_tokens);
+
+    assert_eq!(accepted.len(), 32, "the whole chain must be accepted");
+    assert_eq!(accepted.as_ref(), expected.as_slice());
+}

--- a/crates/json-transform/src/execution/string.rs
+++ b/crates/json-transform/src/execution/string.rs
@@ -26,7 +26,7 @@ pub fn execute_regex_replace(
     let Value::String(text) = input else {
         return Ok(Value::Null);
     };
-    let regex = Regex::new(pattern, regex_engine)?;
+    let regex = Regex::cached(pattern, regex_engine)?;
     let replaced = regex.replace_all(&text, template);
     Ok(Value::String(replaced))
 }
@@ -40,7 +40,7 @@ pub fn execute_regex_find_all(
     let Value::String(text) = input else {
         return Ok(Value::Null);
     };
-    let regex = Regex::new(pattern, regex_engine)?;
+    let regex = Regex::cached(pattern, regex_engine)?;
     let matches: Vec<Value> = regex
         .captures_iter(&text)
         .iter()

--- a/crates/json-transform/src/regex/regex.rs
+++ b/crates/json-transform/src/regex/regex.rs
@@ -1,7 +1,18 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, LazyLock, RwLock},
+};
+
 use crate::{
     TransformError,
     regex::{RegexCaptures, RegexEngine},
 };
+
+// Patterns come from schemas, but nothing forces that, so the cache is bounded.
+const CACHE_LIMIT: usize = 256;
+
+static STANDARD: LazyLock<RwLock<HashMap<String, Arc<Regex>>>> = LazyLock::new(Default::default);
+static EXTENDED: LazyLock<RwLock<HashMap<String, Arc<Regex>>>> = LazyLock::new(Default::default);
 
 pub enum Regex {
     Standard(regex::Regex),
@@ -25,6 +36,28 @@ impl Regex {
                 })
             },
         }
+    }
+
+    /// Compiles a pattern once per process instead of once per call.
+    pub fn cached(
+        pattern: &str,
+        engine: &RegexEngine,
+    ) -> Result<Arc<Self>, TransformError> {
+        let cache = match engine {
+            RegexEngine::Standard => &STANDARD,
+            RegexEngine::Extended => &EXTENDED,
+        };
+
+        if let Some(regex) = cache.read().unwrap().get(pattern) {
+            return Ok(regex.clone());
+        }
+
+        let regex = Arc::new(Self::new(pattern, engine)?);
+        let mut cache = cache.write().unwrap();
+        if cache.len() < CACHE_LIMIT {
+            cache.insert(pattern.to_string(), regex.clone());
+        }
+        Ok(regex)
     }
 
     pub fn as_str(&self) -> &str {


### PR DESCRIPTION
Optimizations for the hot path of the CPU backend (linux/windows/x86-mac) plus a few changes to the common code that remove work from each dispatch on both backends.

Sampling. unified_sampling sorted the entire dictionary to take the prefix. Now, partial candidate selection via select_nth_unstable_by with an increase in sampling when a miss occurs on top-p. The order of candidates is defined by a strict complete order (value in descending order, index in ascending order), so the prefix matches the previous one by construction.

A worker pool has been added to CpuContext, and matmul is divided across the output columns. Quantization group constants (scale, zero-point, bias) and data type dispatching have been moved out of the inner loop; 4‑bit codes are read as a single u32 word for eight codes; the activation string is decoded once per dispatch, not per column.

Backend::NEEDS_BARRIERS — both backends have an empty encode_barrier, so tracking hazards and building Vec<Access> in the code generator are no longer performed. Debug groups in Metal do not create String and NSString unless debugging or capturing is enabled. Allocator pool numbers are returned to the free list — previously, the per-pool state grew with the number of pools ever created. FlatTrie::accept uses a flat index instead of a linear search by pointers.

I ran the benchmarks on M1 Max, Qwen3-0.6B-MLX-4bit, and there is a several‑fold speedup. I haven’t tested iOS (metal); the changes in metal/command_buffer.rs, metal/context.rs, and in the code generator have only been verified by reading. We need to run your benchmarks and measure the time on the device.