### PR TITLE
repetition_penalty bounds fix

### DIFF
--- a/crates/backend-uzu/src/backends/cpu/kernel/sampling/repetition_penalty.rs
+++ b/crates/backend-uzu/src/backends/cpu/kernel/sampling/repetition_penalty.rs
@@ -25,6 +25,9 @@ pub fn repetition_penalty<T: ArrayElement + Float + NumCast>(
         token_id: usize,
         repetition_penalty: f32,
     ) {
+        if token_id >= vocab_size {
+            return;
+        }
         let offset = sample_index * vocab_size + token_id;
         let logit = unsafe { (*original_logits.add(offset)).to_f32().unwrap() };
         let penalized = if logit > 0.0 {

--- a/crates/backend-uzu/src/backends/metal/kernel/sampling/repetition_penalty.metal
+++ b/crates/backend-uzu/src/backends/metal/kernel/sampling/repetition_penalty.metal
@@ -40,6 +40,10 @@ PUBLIC KERNEL(RepetitionPenalty)(
     token_id = token_ids[source_index - ring.ring_length];
   }
 
+  if (token_id >= vocab_size) {
+    return;
+  }
+
   const uint32_t logit_offset = sample_index * vocab_size + token_id;
   const float logit = static_cast<float>(original_logits[logit_offset]);
   const float penalized = logit > 0.0 ? logit / repetition_penalty : logit * repetition_penalty;

--- a/crates/backend-uzu/tests/unit/backends/common/kernel/mod.rs
+++ b/crates/backend-uzu/tests/unit/backends/common/kernel/mod.rs
@@ -12,6 +12,7 @@ mod normalization_test;
 mod pooling;
 mod qkv_norm_test;
 mod radix_top_k_small_test;
+mod repetition_penalty_test;
 mod short_conv;
 mod ssm;
 mod tensor_add_bias_test;

--- a/crates/backend-uzu/tests/unit/backends/common/kernel/repetition_penalty_test.rs
+++ b/crates/backend-uzu/tests/unit/backends/common/kernel/repetition_penalty_test.rs
@@ -1,0 +1,122 @@
+use std::fmt::Display;
+
+use num_traits::Float;
+use proc_macros::uzu_test;
+
+use crate::{
+    array::ArrayElement,
+    backends::{
+        common::{Backend, Context, Encoder, Kernels, kernel::RepetitionPenaltyKernel},
+        cpu::Cpu,
+    },
+    tests::{
+        assert::assert_eq_float,
+        helpers::{alloc_allocation_with_data, allocation_to_vec, for_each_non_cpu_backend},
+    },
+};
+
+struct Input<T: ArrayElement + Float> {
+    logits: Box<[T]>,
+    context_ring: Box<[u32]>,
+    token_ids: Box<[u32]>,
+    repetition_penalty: f32,
+    suffix_repetition_length: u32,
+    vocab_size: u32,
+    sampling_start: u32,
+    sampling_length: u32,
+}
+
+fn get_output<T: ArrayElement + Float, B: Backend>(input: &Input<T>) -> Vec<T> {
+    let context = B::Context::new().expect("Failed to create Context");
+    let kernel = <<B as Backend>::Kernels as Kernels>::RepetitionPenaltyKernel::new(&context, T::data_type())
+        .expect("Failed to create RepetitionPenaltyKernel");
+
+    let original_logits = alloc_allocation_with_data::<B, T>(&context, &input.logits);
+    let mut copy = alloc_allocation_with_data::<B, T>(&context, &input.logits);
+    let context_ring = alloc_allocation_with_data::<B, u32>(&context, &input.context_ring);
+    let token_ids = alloc_allocation_with_data::<B, u32>(&context, &input.token_ids);
+
+    let mut encoder = Encoder::new(context.as_ref()).expect("Failed to create encoder");
+    kernel.encode(
+        &original_logits,
+        &mut copy,
+        &context_ring,
+        &token_ids,
+        input.repetition_penalty,
+        input.suffix_repetition_length,
+        input.vocab_size,
+        input.sampling_start,
+        input.sampling_length,
+        &mut encoder,
+    );
+    encoder.end_encoding().submit().wait_until_completed().expect("Failed to wait command buffer");
+
+    allocation_to_vec(&copy)
+}
+
+fn ascending_logits<T: ArrayElement + Float>(len: usize) -> Box<[T]> {
+    (0..len).map(|index| T::from(1.0 + index as f32).unwrap()).collect()
+}
+
+fn context_ring(
+    ring_offset: u32,
+    ring_length: u32,
+    slots: &[u32],
+) -> Box<[u32]> {
+    [&[ring_offset, ring_length], slots].concat().into_boxed_slice()
+}
+
+fn penalized<T: ArrayElement + Float>(
+    logit: T,
+    repetition_penalty: f32,
+) -> T {
+    T::from(logit.to_f32().unwrap() / repetition_penalty).unwrap()
+}
+
+fn check<T: ArrayElement + Float + Display>(
+    input: &Input<T>,
+    expected: &[T],
+) {
+    assert_eq_float::<T>(expected, &get_output::<T, Cpu>(input), 1e-5, "RepetitionPenalty failed with backend=Cpu");
+    for_each_non_cpu_backend!(|B| {
+        let msg = format!("RepetitionPenalty failed with backend={}", std::any::type_name::<B>());
+        assert_eq_float::<T>(expected, &get_output::<T, B>(input), 1e-5, &msg);
+    });
+}
+
+#[uzu_test]
+fn test_out_of_vocab() {
+    let logits = ascending_logits::<f32>(8);
+    let expected = logits.to_vec();
+    let input = Input {
+        logits,
+        context_ring: context_ring(0, 0, &[0; 8]),
+        token_ids: vec![3_000_000].into_boxed_slice(),
+        repetition_penalty: 2.0,
+        suffix_repetition_length: 8,
+        vocab_size: 8,
+        sampling_start: 0,
+        sampling_length: 1,
+    };
+    check(&input, &expected);
+}
+
+#[uzu_test]
+fn test_boundary() {
+    let (vocab_size, penalty) = (4u32, 2.0f32);
+    let logits = ascending_logits::<f32>((vocab_size * 2) as usize);
+    let valid_offset = vocab_size as usize + 2;
+    let mut expected = logits.to_vec();
+    expected[valid_offset] = penalized(expected[valid_offset], penalty);
+    let input = Input {
+        logits,
+        context_ring: context_ring(0, 0, &[0; 4]),
+        token_ids: vec![vocab_size, 2].into_boxed_slice(),
+        repetition_penalty: penalty,
+        suffix_repetition_length: 1,
+        vocab_size,
+        sampling_start: 0,
+        sampling_length: 2,
+    };
+    check(&input, &expected);
+}


### PR DESCRIPTION
Repetition penalty kernel used the token id directly as a store offset
without checking it against `vocab_size`

A too-large token_id from a model bundle could cause an out-of-bounds write or a crash.