### PR TITLE
Bound MoE routing to kernel capacity

### DIFF
--- a/crates/backend-uzu/Cargo.toml
+++ b/crates/backend-uzu/Cargo.toml
@@ -61,6 +61,7 @@ shoji.workspace = true
 half.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
 monostate.workspace = true
 thiserror.workspace = true
 tokenizers.workspace = true
@@ -96,6 +97,11 @@ rand_distr.workspace = true
 is_close.workspace = true
 ndarray.workspace = true
 rstest.workspace = true
+blake3.workspace = true
+anyhow.workspace = true
+walkdir.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = { workspace = true, default-features = true }

--- a/crates/backend-uzu/Cargo.toml
+++ b/crates/backend-uzu/Cargo.toml
@@ -102,6 +102,7 @@ anyhow.workspace = true
 walkdir.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+tempfile.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = { workspace = true, default-features = true }

--- a/crates/backend-uzu/build/common/caching.rs
+++ b/crates/backend-uzu/build/common/caching.rs
@@ -1,20 +1,122 @@
 #![cfg(all(feature = "metal", target_os = "macos"))]
 
-use std::{fs, sync::OnceLock};
+use std::{
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+};
 
 use anyhow::Context;
+use walkdir::WalkDir;
 
-static BUILD_SYSTEM_HASH: OnceLock<blake3::Hash> = OnceLock::new();
+pub const METAL_CACHE_SCHEMA: u32 = 2;
 
-pub fn build_system_hash() -> anyhow::Result<&'static blake3::Hash> {
-    if let Some(bsh) = BUILD_SYSTEM_HASH.get() {
-        Ok(bsh)
-    } else {
-        let bsh = blake3::hash(
-            &fs::read(&std::env::current_exe().context("cannot get build system executable")?)
-                .context("cannot read build system executable")?,
-        );
+fn sibling_tmp(path: &Path) -> PathBuf {
+    let name = path.file_name().map(|name| name.to_string_lossy().into_owned()).unwrap_or_else(|| "file".to_string());
+    path.with_file_name(format!(".{name}.tmp-{}", std::process::id()))
+}
 
-        Ok(BUILD_SYSTEM_HASH.get_or_init(|| bsh))
+pub fn write_atomic(
+    path: impl AsRef<Path>,
+    contents: impl AsRef<[u8]>,
+) -> anyhow::Result<()> {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("cannot create {}", parent.display()))?;
     }
+    let tmp = sibling_tmp(path);
+    {
+        let mut file = fs::File::create(&tmp).with_context(|| format!("cannot create {}", tmp.display()))?;
+        file.write_all(contents.as_ref()).with_context(|| format!("cannot write {}", tmp.display()))?;
+        file.sync_all().with_context(|| format!("cannot sync {}", tmp.display()))?;
+    }
+    fs::rename(&tmp, path).with_context(|| format!("cannot rename {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+pub fn copy_atomic(
+    src: impl AsRef<Path>,
+    dest: impl AsRef<Path>,
+) -> anyhow::Result<()> {
+    let dest = dest.as_ref();
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("cannot create {}", parent.display()))?;
+    }
+    let tmp = sibling_tmp(dest);
+    fs::copy(src.as_ref(), &tmp).with_context(|| format!("cannot copy to {}", tmp.display()))?;
+    fs::rename(&tmp, dest).with_context(|| format!("cannot rename {} -> {}", tmp.display(), dest.display()))?;
+    Ok(())
+}
+
+/// Target-local cache materialization without copying large Metal artifacts.
+pub fn hard_link_atomic(
+    src: impl AsRef<Path>,
+    dest: impl AsRef<Path>,
+) -> anyhow::Result<()> {
+    let dest = dest.as_ref();
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("cannot create {}", parent.display()))?;
+    }
+    let tmp = sibling_tmp(dest);
+    if let Err(err) = fs::remove_file(&tmp)
+        && err.kind() != std::io::ErrorKind::NotFound
+    {
+        return Err(err).with_context(|| format!("cannot remove stale {}", tmp.display()));
+    }
+    fs::hard_link(src.as_ref(), &tmp).with_context(|| format!("cannot link to {}", tmp.display()))?;
+    fs::rename(&tmp, dest).with_context(|| format!("cannot rename {} -> {}", tmp.display(), dest.display()))?;
+    Ok(())
+}
+
+/// Removes an output before a compiler can truncate a cache-backed hard link.
+pub fn remove_file_if_exists(path: impl AsRef<Path>) -> anyhow::Result<()> {
+    let path = path.as_ref();
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err).with_context(|| format!("cannot remove {}", path.display())),
+    }
+}
+
+pub fn hash_file(path: impl AsRef<Path>) -> anyhow::Result<blake3::Hash> {
+    let path = path.as_ref();
+    Ok(blake3::hash(&fs::read(path).with_context(|| format!("cannot read {}", path.display()))?))
+}
+
+pub fn hash_paths(paths: impl IntoIterator<Item = impl AsRef<Path>>) -> anyhow::Result<blake3::Hash> {
+    let mut files = Vec::new();
+    for path in paths {
+        let path = path.as_ref();
+        if path.is_dir() {
+            for entry in WalkDir::new(path) {
+                let entry = entry.with_context(|| format!("cannot walk {}", path.display()))?;
+                if entry.file_type().is_file() {
+                    files.push(entry.into_path());
+                }
+            }
+        } else if path.is_file() {
+            files.push(path.to_path_buf());
+        }
+    }
+    files.sort();
+    let mut hasher = blake3::Hasher::new();
+    for file in &files {
+        hasher.update(file.to_string_lossy().as_bytes());
+        hasher.update(b"\0");
+        hasher.update(&fs::read(file).with_context(|| format!("cannot read {}", file.display()))?);
+    }
+    Ok(hasher.finalize())
+}
+
+pub fn cargo_target_dir() -> anyhow::Result<PathBuf> {
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").context("missing OUT_DIR")?);
+    let out_dir = fs::canonicalize(&out_dir).with_context(|| format!("cannot resolve {}", out_dir.display()))?;
+    for ancestor in out_dir.ancestors() {
+        if ancestor.file_name().is_some_and(|name| name == "build")
+            && let Some(target_dir) = ancestor.parent().and_then(Path::parent)
+        {
+            return Ok(target_dir.to_path_buf());
+        }
+    }
+    anyhow::bail!("cannot derive Cargo target dir from {}", out_dir.display())
 }

--- a/crates/backend-uzu/build/common/codegen.rs
+++ b/crates/backend-uzu/build/common/codegen.rs
@@ -1,4 +1,4 @@
-use std::{ffi::OsStr, fs};
+use std::{ffi::OsStr, fs, path::Path};
 
 use anyhow::Context;
 use proc_macro2::TokenStream;
@@ -11,7 +11,11 @@ pub fn write_tokens(
     let file = file.as_ref();
 
     let parsed = syn::parse2(tokens.clone()).with_context(|| format!("cannot parse generated bindings: {}", tokens))?;
-    fs::write(file, prettyplease::unparse(&parsed)).with_context(|| format!("cannot write file {}", file.display()))?;
+    let new_contents = prettyplease::unparse(&parsed);
+    if Path::new(file).exists() && fs::read(file).is_ok_and(|old_contents| old_contents == new_contents.as_bytes()) {
+        return Ok(());
+    }
+    fs::write(file, new_contents).with_context(|| format!("cannot write file {}", file.display()))?;
 
     Ok(())
 }

--- a/crates/backend-uzu/build/common/envs.rs
+++ b/crates/backend-uzu/build/common/envs.rs
@@ -6,7 +6,10 @@ static BUILD_CLEAN: OnceLock<bool> = OnceLock::new();
 
 fn env_flag(name: &str) -> bool {
     println!("cargo::rerun-if-env-changed={name}");
-    std::env::var(name).is_ok()
+    match std::env::var(name) {
+        Ok(value) => matches!(value.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"),
+        Err(_) => false,
+    }
 }
 
 pub fn build_debug() -> bool {

--- a/crates/backend-uzu/build/common/logging.rs
+++ b/crates/backend-uzu/build/common/logging.rs
@@ -14,9 +14,22 @@ pub fn _debug_log(args: std::fmt::Arguments) {
     }
 }
 
+pub fn _build_warning(args: std::fmt::Arguments) {
+    if envs::build_debug() {
+        println!("cargo::warning=(metal-build) [{}ms] {}", elapsed_ms(), args);
+    }
+}
+
 #[macro_export]
 macro_rules! debug_log {
     ($($arg:tt)*) => {{
         $crate::common::logging::_debug_log(format_args!($($arg)*));
+    }};
+}
+
+#[macro_export]
+macro_rules! build_warning {
+    ($($arg:tt)*) => {{
+        $crate::common::logging::_build_warning(format_args!($($arg)*));
     }};
 }

--- a/crates/backend-uzu/build/main.rs
+++ b/crates/backend-uzu/build/main.rs
@@ -1,4 +1,4 @@
-use std::{env, fs, path::PathBuf, process::ExitCode};
+use std::{env, fs, path::PathBuf, process::ExitCode, time::Instant};
 
 use anyhow::Context;
 use futures::future::try_join_all;
@@ -11,9 +11,17 @@ mod cpu;
 #[cfg(all(feature = "metal", target_os = "macos"))]
 mod metal;
 
+fn emit_rerun_directives() {
+    for path in
+        ["build", "src/backends/common/gpu_types", "src/backends/cpu/kernel", "src/backends/metal/kernel", "Cargo.toml"]
+    {
+        println!("cargo::rerun-if-changed={path}");
+    }
+}
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<ExitCode> {
-    println!("cargo::rerun-if-changed=.");
+    emit_rerun_directives();
     if envs::build_always() {
         println!("cargo::rerun-if-changed=/var/empty/hack_nonexistent_file_to_always_rerun");
     }
@@ -50,8 +58,9 @@ async fn main() -> anyhow::Result<ExitCode> {
         debug_log!("cleaned caches");
     }
 
+    let gpu_types_started = Instant::now();
     let gpu_types = GpuTypes::scan().context("Failed to scan gpu types")?;
-    debug_log!("gpu_types scan done");
+    debug_log!("gpu_types scan done in {}ms", gpu_types_started.elapsed().as_millis());
 
     let enum_paths = EnumPaths::from_gpu_types(&gpu_types).context("Failed to build enum path map")?;
 

--- a/crates/backend-uzu/build/metal/artifact_cache.rs
+++ b/crates/backend-uzu/build/metal/artifact_cache.rs
@@ -1,0 +1,49 @@
+use std::{collections::HashMap, fs};
+
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+
+pub use super::cache_protocol::{SharedArtifactCache, air_key, dependencies_match, index_key, metallib_key, zstd_key};
+use super::{ast::MetalKernelInfo, cache_protocol::Stage};
+use crate::common::{caching, identifiers::KernelName, kernel::Kernel};
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct SourceIndex {
+    pub schema: u32,
+    pub source_hash: [u8; blake3::OUT_LEN],
+    pub compile_schema_hash: [u8; blake3::OUT_LEN],
+    pub analyzer_hash: [u8; blake3::OUT_LEN],
+    pub gpu_types_hash: [u8; blake3::OUT_LEN],
+    pub dependency_hashes: HashMap<Box<str>, [u8; blake3::OUT_LEN]>,
+    pub footer: String,
+    pub kernel_infos: Vec<MetalKernelInfo>,
+    pub specialize_indices: HashMap<KernelName, usize>,
+    pub public_kernels: Box<[Kernel]>,
+}
+
+pub fn load_source_index(
+    cache: &SharedArtifactCache,
+    key: &blake3::Hash,
+) -> anyhow::Result<Option<SourceIndex>> {
+    let Some(path) = cache.lookup(Stage::Index, key)? else {
+        return Ok(None);
+    };
+    let bytes = fs::read(&path.path).with_context(|| format!("cannot read {}", path.path.display()))?;
+    let Ok(index) = serde_json::from_slice::<SourceIndex>(&bytes) else {
+        return Ok(None);
+    };
+    if index.schema != caching::METAL_CACHE_SCHEMA {
+        return Ok(None);
+    }
+    Ok(Some(index))
+}
+
+pub fn store_source_index(
+    cache: &SharedArtifactCache,
+    key: &blake3::Hash,
+    index: &SourceIndex,
+) -> anyhow::Result<()> {
+    let bytes = serde_json::to_vec_pretty(index).context("cannot serialize source index")?;
+    cache.store_bytes(Stage::Index, key, bytes)?;
+    Ok(())
+}

--- a/crates/backend-uzu/build/metal/ast.rs
+++ b/crates/backend-uzu/build/metal/ast.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, bail};
 use quote::quote;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::common::{
     expr_rewrite::rewrite_paths_with,
@@ -121,25 +121,25 @@ fn annotation_from_ast_node(annotation_node: MetalAstNode) -> anyhow::Result<Box
         .collect()
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum MetalBufferAccess {
     Read,
     ReadWrite,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MetalConstantType {
     Scalar,
     Array(Option<Box<str>>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MetalGroupsType {
     Direct(Box<str>),
     Indirect,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MetalArgumentType {
     Buffer(MetalBufferAccess),
     Constant((Box<str>, MetalConstantType)),
@@ -151,7 +151,7 @@ pub enum MetalArgumentType {
     ThreadContext,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MetalArgument {
     pub name: ArgumentName,
     pub c_type: Box<str>,
@@ -394,13 +394,13 @@ fn parse_argument_type(
     bail!("cannot parse c type: {}", c_type);
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MetalTemplateParameterType {
     Type,
     Value(Box<str>),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MetalTemplateParameter {
     pub name: Box<str>,
     pub ty: MetalTemplateParameterType,
@@ -419,7 +419,7 @@ impl MetalTemplateParameter {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MetalKernelInfo {
     pub public: bool,
     pub name: KernelName,

--- a/crates/backend-uzu/build/metal/cache_protocol.rs
+++ b/crates/backend-uzu/build/metal/cache_protocol.rs
@@ -1,0 +1,321 @@
+use std::{
+    collections::HashMap,
+    fs,
+    io::ErrorKind,
+    path::{Path, PathBuf},
+    process::Stdio,
+    time::{Duration, Instant},
+};
+
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+
+#[cfg(test)]
+use super::caching;
+#[cfg(not(test))]
+use crate::common::caching;
+
+pub const ZSTD_CODEC_ID: &str = "zstd-encode_all";
+pub const STAGE_LOCK_TIMEOUT: Duration = Duration::from_secs(20 * 60);
+const LOCK_OWNER_GRACE: Duration = Duration::from_secs(2);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Stage {
+    Air,
+    Metallib,
+    Zstd,
+    Index,
+}
+
+impl Stage {
+    pub fn dir_name(self) -> &'static str {
+        match self {
+            Self::Air => "air",
+            Self::Metallib => "metallib",
+            Self::Zstd => "zstd",
+            Self::Index => "index",
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct StageManifest {
+    schema: u32,
+    kind: String,
+    hash: [u8; blake3::OUT_LEN],
+    len: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct SharedArtifactCache {
+    root: PathBuf,
+}
+
+pub struct StageLock {
+    path: PathBuf,
+}
+
+/// Immutable stage output after manifest and content verification.
+pub struct CachedArtifact {
+    pub path: PathBuf,
+    pub hash: [u8; blake3::OUT_LEN],
+}
+
+impl Drop for StageLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+impl SharedArtifactCache {
+    pub fn new() -> anyhow::Result<Self> {
+        Self::at(caching::cargo_target_dir()?.join("uzu-metal-cache").join(format!("v{}", caching::METAL_CACHE_SCHEMA)))
+    }
+
+    pub fn at(root: impl Into<PathBuf>) -> anyhow::Result<Self> {
+        let root = root.into();
+        fs::create_dir_all(&root).with_context(|| format!("cannot create {}", root.display()))?;
+        Ok(Self {
+            root,
+        })
+    }
+
+    pub fn stage_dir(
+        &self,
+        stage: Stage,
+        key: &blake3::Hash,
+    ) -> PathBuf {
+        self.root.join(stage.dir_name()).join(key.to_hex().as_str())
+    }
+
+    pub async fn lock(
+        &self,
+        stage: Stage,
+        key: &blake3::Hash,
+    ) -> anyhow::Result<StageLock> {
+        self.lock_with_timeout(stage, key, STAGE_LOCK_TIMEOUT).await
+    }
+
+    pub async fn lock_with_timeout(
+        &self,
+        stage: Stage,
+        key: &blake3::Hash,
+        timeout: Duration,
+    ) -> anyhow::Result<StageLock> {
+        let dir = self.stage_dir(stage, key);
+        fs::create_dir_all(&dir).with_context(|| format!("cannot create {}", dir.display()))?;
+        let lock_path = dir.join(".lock");
+        let deadline = Instant::now() + timeout;
+        let mut sleep = Duration::from_millis(20);
+        loop {
+            match fs::create_dir(&lock_path) {
+                Ok(()) => {
+                    let owner_path = lock_path.join("pid");
+                    let owner = fs::write(&owner_path, std::process::id().to_string());
+                    if let Err(err) = owner {
+                        let _ = fs::remove_dir_all(&lock_path);
+                        return Err(err).with_context(|| format!("cannot write {}", owner_path.display()));
+                    }
+                    return Ok(StageLock {
+                        path: lock_path,
+                    });
+                },
+                Err(err) if err.kind() == ErrorKind::AlreadyExists => {
+                    if lock_holder_dead(&lock_path) {
+                        let _ = fs::remove_dir_all(&lock_path);
+                        continue;
+                    }
+                    if Instant::now() >= deadline {
+                        anyhow::bail!("timed out waiting for metal cache lock {}", lock_path.display());
+                    }
+                    tokio::time::sleep(sleep).await;
+                    sleep = (sleep * 2).min(Duration::from_millis(250));
+                },
+                Err(err) => {
+                    return Err(err).with_context(|| format!("cannot lock {}", lock_path.display()));
+                },
+            }
+        }
+    }
+
+    pub fn lookup(
+        &self,
+        stage: Stage,
+        key: &blake3::Hash,
+    ) -> anyhow::Result<Option<CachedArtifact>> {
+        let dir = self.stage_dir(stage, key);
+        let manifest_path = dir.join("manifest.json");
+        let artifact = dir.join("artifact");
+        let Ok(bytes) = fs::read(&manifest_path) else {
+            return Ok(None);
+        };
+        let Ok(manifest) = serde_json::from_slice::<StageManifest>(&bytes) else {
+            return Ok(None);
+        };
+        if manifest.schema != caching::METAL_CACHE_SCHEMA || manifest.kind != stage.dir_name() {
+            return Ok(None);
+        }
+        let Ok(meta) = fs::metadata(&artifact) else {
+            return Ok(None);
+        };
+        if meta.len() != manifest.len {
+            return Ok(None);
+        }
+        if caching::hash_file(&artifact)?.as_bytes() != &manifest.hash {
+            return Ok(None);
+        }
+        Ok(Some(CachedArtifact {
+            path: artifact,
+            hash: manifest.hash,
+        }))
+    }
+
+    pub fn store(
+        &self,
+        stage: Stage,
+        key: &blake3::Hash,
+        src: impl AsRef<Path>,
+    ) -> anyhow::Result<[u8; blake3::OUT_LEN]> {
+        let dir = self.stage_dir(stage, key);
+        fs::create_dir_all(&dir).with_context(|| format!("cannot create {}", dir.display()))?;
+        let artifact = dir.join("artifact");
+        caching::copy_atomic(src.as_ref(), &artifact)?;
+        self.commit_manifest(stage, &artifact)
+    }
+
+    pub fn store_bytes(
+        &self,
+        stage: Stage,
+        key: &blake3::Hash,
+        bytes: impl AsRef<[u8]>,
+    ) -> anyhow::Result<[u8; blake3::OUT_LEN]> {
+        let dir = self.stage_dir(stage, key);
+        fs::create_dir_all(&dir).with_context(|| format!("cannot create {}", dir.display()))?;
+        let artifact = dir.join("artifact");
+        caching::write_atomic(&artifact, bytes)?;
+        self.commit_manifest(stage, &artifact)
+    }
+
+    fn commit_manifest(
+        &self,
+        stage: Stage,
+        artifact: &Path,
+    ) -> anyhow::Result<[u8; blake3::OUT_LEN]> {
+        let hash = caching::hash_file(artifact)?;
+        let len = fs::metadata(artifact).with_context(|| format!("cannot stat {}", artifact.display()))?.len();
+        let manifest = StageManifest {
+            schema: caching::METAL_CACHE_SCHEMA,
+            kind: stage.dir_name().to_string(),
+            hash: *hash.as_bytes(),
+            len,
+        };
+        caching::write_atomic(
+            artifact.with_file_name("manifest.json"),
+            serde_json::to_vec_pretty(&manifest).context("cannot serialize stage manifest")?,
+        )?;
+        Ok(*hash.as_bytes())
+    }
+}
+
+pub fn air_key(
+    source_path_relative: &str,
+    dependency_hashes: &HashMap<Box<str>, [u8; blake3::OUT_LEN]>,
+    footer: &str,
+    compile_schema_hash: &blake3::Hash,
+    toolchain_hash: &blake3::Hash,
+) -> blake3::Hash {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"uzu-metal-air-v2");
+    hasher.update(&caching::METAL_CACHE_SCHEMA.to_le_bytes());
+    hasher.update(source_path_relative.as_bytes());
+    hasher.update(b"\0");
+    update_sorted_deps(&mut hasher, dependency_hashes);
+    hasher.update(footer.as_bytes());
+    hasher.update(compile_schema_hash.as_bytes());
+    hasher.update(toolchain_hash.as_bytes());
+    hasher.finalize()
+}
+
+pub fn metallib_key(
+    air_hash: &blake3::Hash,
+    linker_hash: &blake3::Hash,
+) -> blake3::Hash {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"uzu-metal-metallib-v2");
+    hasher.update(&caching::METAL_CACHE_SCHEMA.to_le_bytes());
+    hasher.update(air_hash.as_bytes());
+    hasher.update(linker_hash.as_bytes());
+    hasher.finalize()
+}
+
+pub fn zstd_key(
+    metallib_hash: &blake3::Hash,
+    zstd_level: i32,
+) -> blake3::Hash {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"uzu-metal-zstd-v2");
+    hasher.update(&caching::METAL_CACHE_SCHEMA.to_le_bytes());
+    hasher.update(metallib_hash.as_bytes());
+    hasher.update(ZSTD_CODEC_ID.as_bytes());
+    hasher.update(&zstd_level.to_le_bytes());
+    hasher.finalize()
+}
+
+pub fn index_key(
+    source_path_relative: &str,
+    source_hash: &blake3::Hash,
+    compile_schema_hash: &blake3::Hash,
+    analyzer_hash: &blake3::Hash,
+    gpu_types_hash: &blake3::Hash,
+) -> blake3::Hash {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"uzu-metal-index-v2");
+    hasher.update(&caching::METAL_CACHE_SCHEMA.to_le_bytes());
+    hasher.update(source_path_relative.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(source_hash.as_bytes());
+    hasher.update(compile_schema_hash.as_bytes());
+    hasher.update(analyzer_hash.as_bytes());
+    hasher.update(gpu_types_hash.as_bytes());
+    hasher.finalize()
+}
+
+pub fn dependencies_match(stored: &HashMap<Box<str>, [u8; blake3::OUT_LEN]>) -> bool {
+    stored.iter().all(|(path, hash)| fs::read(path.as_ref()).is_ok_and(|bytes| blake3::hash(&bytes).as_bytes() == hash))
+}
+
+fn update_sorted_deps(
+    hasher: &mut blake3::Hasher,
+    dependency_hashes: &HashMap<Box<str>, [u8; blake3::OUT_LEN]>,
+) {
+    let mut deps: Vec<_> = dependency_hashes.iter().collect();
+    deps.sort_by(|a, b| a.0.cmp(b.0));
+    for (path, hash) in deps {
+        hasher.update(path.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(hash);
+    }
+}
+
+fn lock_holder_dead(lock_path: &Path) -> bool {
+    let Ok(pid) = fs::read_to_string(lock_path.join("pid")) else {
+        let age = fs::metadata(lock_path)
+            .and_then(|metadata| metadata.modified())
+            .ok()
+            .and_then(|modified| std::time::SystemTime::now().duration_since(modified).ok());
+        return age.is_some_and(|age| age >= LOCK_OWNER_GRACE);
+    };
+    let Ok(pid) = pid.trim().parse::<u32>() else {
+        return true;
+    };
+    process_exists(pid).is_ok_and(|exists| !exists)
+}
+
+fn process_exists(pid: u32) -> std::io::Result<bool> {
+    let status = std::process::Command::new("/bin/kill")
+        .args(["-0", &pid.to_string()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()?;
+    Ok(status.success())
+}

--- a/crates/backend-uzu/build/metal/compiler.rs
+++ b/crates/backend-uzu/build/metal/compiler.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashMap, env, fs, path::PathBuf};
+use std::{
+    collections::HashMap,
+    env, fmt, fs,
+    path::{Path, PathBuf},
+    time::Instant,
+};
 
 use anyhow::Context;
 use async_trait::async_trait;
@@ -7,22 +12,132 @@ use quote::{format_ident, quote};
 use serde::{Deserialize, Serialize};
 use walkdir::WalkDir;
 
-use super::{ast::MetalKernelInfo, bindgen::bindgen_global, toolchain::MetalToolchain, wrapper::wrappers};
+use super::{
+    artifact_cache::{self, SharedArtifactCache, SourceIndex},
+    ast::MetalKernelInfo,
+    bindgen::bindgen_global,
+    cache_protocol::Stage,
+    toolchain::MetalToolchain,
+    wrapper::{SpecializeBaseIndices, wrappers},
+};
 use crate::{
+    build_warning,
     common::{
-        caching, codegen::write_tokens, compiler::Compiler, enum_paths::EnumPaths, gpu_types::GpuTypes,
+        caching, codegen::write_tokens, compiler::Compiler, enum_paths::EnumPaths, envs, gpu_types::GpuTypes,
         identifiers::KernelPath, kernel::Kernel,
     },
     debug_log,
     metal::gpu_types::gpu_type_gen,
 };
 
-#[derive(Serialize, Deserialize)]
+/// Distribution compression level retained from the original release build.
+const METAL_ZSTD_LEVEL: i32 = 22;
+
+#[derive(Serialize, Deserialize, Clone)]
 struct Cached {
-    buildsystem_hash: [u8; blake3::OUT_LEN],
+    schema: u32,
+    compile_schema_hash: [u8; blake3::OUT_LEN],
+    toolchain_hash: [u8; blake3::OUT_LEN],
     dependency_hashes: HashMap<Box<str>, [u8; blake3::OUT_LEN]>,
+    artifact_hash: [u8; blake3::OUT_LEN],
+    binding_hash: [u8; blake3::OUT_LEN],
+    zstd_level: i32,
+    compressed: bool,
     public_kernels: Box<[Kernel]>,
     has_kernels: bool,
+}
+
+enum LocalCache {
+    Hit(Cached),
+    Rebind(MissReason),
+    Miss(MissReason),
+}
+
+#[derive(Clone)]
+enum MissReason {
+    MissingMetadata,
+    Schema,
+    CompileSchema,
+    MissingBinding,
+    Dependency(Box<str>),
+    Toolchain,
+    Compression,
+    MissingArtifact,
+    CorruptArtifact,
+}
+
+impl fmt::Display for MissReason {
+    fn fmt(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        match self {
+            Self::MissingMetadata => write!(f, "missing metadata"),
+            Self::Schema => write!(f, "build-system/schema change"),
+            Self::CompileSchema => write!(f, "compile schema change"),
+            Self::MissingBinding => write!(f, "missing or stale bindings"),
+            Self::Dependency(path) => write!(f, "named dependency change: {path}"),
+            Self::Toolchain => write!(f, "compiler/SDK/flags change"),
+            Self::Compression => write!(f, "compression settings change"),
+            Self::MissingArtifact => write!(f, "missing artifact"),
+            Self::CorruptArtifact => write!(f, "corrupt artifact"),
+        }
+    }
+}
+
+struct StageClock {
+    stages: Vec<(String, u128)>,
+    mark: Instant,
+    started: Instant,
+}
+
+impl StageClock {
+    fn new() -> Self {
+        let now = Instant::now();
+        Self {
+            stages: Vec::new(),
+            mark: now,
+            started: now,
+        }
+    }
+
+    fn lap(
+        &mut self,
+        name: &str,
+    ) {
+        let now = Instant::now();
+        self.stages.push((name.to_string(), now.duration_since(self.mark).as_millis()));
+        self.mark = now;
+    }
+
+    fn total_ms(&self) -> u128 {
+        self.started.elapsed().as_millis()
+    }
+}
+
+struct CompiledSource {
+    kernel_path: KernelPath,
+    public_kernels: Box<[Kernel]>,
+    has_kernels: bool,
+    source: String,
+    cache_hit: bool,
+    miss_reason: Option<String>,
+    total_ms: u128,
+    stages: Vec<(String, u128)>,
+}
+
+struct Analysis {
+    kernel_infos: Vec<MetalKernelInfo>,
+    specialize_indices: SpecializeBaseIndices,
+    public_kernels: Box<[Kernel]>,
+    dependency_hashes: HashMap<Box<str>, [u8; blake3::OUT_LEN]>,
+    footer: String,
+    from_index: bool,
+}
+
+struct EnsuredArtifact {
+    origin: &'static str,
+    hash: [u8; blake3::OUT_LEN],
 }
 
 #[derive(Debug)]
@@ -31,14 +146,21 @@ pub struct MetalCompiler {
     gpu_types_directory: PathBuf,
     output_directory: PathBuf,
     metallib_compressed: bool,
+    zstd_level: i32,
     toolchain: MetalToolchain,
+    toolchain_hash: blake3::Hash,
+    analyzer_hash: blake3::Hash,
+    linker_hash: blake3::Hash,
+    compile_schema_hash: blake3::Hash,
+    gpu_types_hash: blake3::Hash,
+    shared_cache: SharedArtifactCache,
+    bypass_shared_cache: bool,
 }
 
 impl MetalCompiler {
     pub fn new() -> anyhow::Result<Self> {
-        let source_directory = PathBuf::from(env::var("CARGO_MANIFEST_DIR").context("missing CARGO_MANIFEST_DIR")?)
-            .join("src/backends/metal/kernel");
-
+        let manifest_directory = PathBuf::from(env::var("CARGO_MANIFEST_DIR").context("missing CARGO_MANIFEST_DIR")?);
+        let source_directory = manifest_directory.join("src/backends/metal/kernel");
         let gpu_types_directory = source_directory.join("generated");
 
         let output_directory = PathBuf::from(env::var("OUT_DIR").context("missing OUT_DIR")?).join("metal");
@@ -50,15 +172,457 @@ impl MetalCompiler {
             _ => true,                // treat everything else (3,s,z) as release build where size matters
         };
 
+        let zstd_level = METAL_ZSTD_LEVEL;
+
         let toolchain = MetalToolchain::from_env_with_include_dir(Some(gpu_types_directory.clone()))
             .context("cannot create toolchain")?;
+        let toolchain_hash = toolchain.identity_hash().context("cannot hash metal toolchain")?;
+        let analyzer_hash = toolchain.analyzer_identity_hash().context("cannot hash metal analyzer")?;
+        let linker_hash = toolchain.linker_identity_hash().context("cannot hash metal linker")?;
+
+        // Build-source and dependency changes are rare compared with host runtime edits. Hashing the
+        // conservative generator boundary keeps cache hits correct without tying them to Cargo's build-script binary.
+        let workspace_directory =
+            manifest_directory.parent().and_then(Path::parent).context("backend-uzu is not inside the workspace")?;
+        let compile_schema_hash = caching::hash_paths([
+            manifest_directory.join("build"),
+            manifest_directory.join("Cargo.toml"),
+            workspace_directory.join("Cargo.lock"),
+        ])
+        .context("cannot hash compile schema")?;
+        let gpu_types_hash = caching::hash_paths([manifest_directory.join("src/backends/common/gpu_types")])
+            .context("cannot hash gpu types")?;
 
         Ok(Self {
             source_directory,
             gpu_types_directory,
             output_directory,
             metallib_compressed,
+            zstd_level,
             toolchain,
+            toolchain_hash,
+            analyzer_hash,
+            linker_hash,
+            compile_schema_hash,
+            gpu_types_hash,
+            shared_cache: SharedArtifactCache::new()?,
+            // BUILD_CLEAN keeps its upstream meaning: force regeneration, then refresh the shared cache.
+            bypass_shared_cache: envs::build_clean(),
+        })
+    }
+
+    fn check_local_cache(
+        &self,
+        cached_file: &Path,
+        artifact_file: &Path,
+        bindgen_file: &Path,
+    ) -> LocalCache {
+        let Ok(bytes) = fs::read(cached_file) else {
+            return LocalCache::Miss(MissReason::MissingMetadata);
+        };
+        let Ok(cached) = serde_json::from_slice::<Cached>(&bytes) else {
+            return LocalCache::Miss(MissReason::Schema);
+        };
+        if cached.schema != caching::METAL_CACHE_SCHEMA {
+            return LocalCache::Miss(MissReason::Schema);
+        }
+        if &cached.compile_schema_hash != self.compile_schema_hash.as_bytes() {
+            return LocalCache::Miss(MissReason::CompileSchema);
+        }
+        if &cached.toolchain_hash != self.toolchain_hash.as_bytes() {
+            return LocalCache::Miss(MissReason::Toolchain);
+        }
+        for (path, hash) in &cached.dependency_hashes {
+            match fs::read(path.as_ref()) {
+                Ok(contents) if blake3::hash(&contents).as_bytes() == hash => {},
+                _ => return LocalCache::Miss(MissReason::Dependency(path.clone())),
+            }
+        }
+        if cached.compressed != self.metallib_compressed || cached.zstd_level != self.effective_zstd_level() {
+            return LocalCache::Miss(MissReason::Compression);
+        }
+        if cached.has_kernels {
+            let Ok(artifact) = fs::read(artifact_file) else {
+                return LocalCache::Miss(MissReason::MissingArtifact);
+            };
+            if blake3::hash(&artifact).as_bytes() != &cached.artifact_hash {
+                return LocalCache::Miss(MissReason::CorruptArtifact);
+            }
+            match fs::read(bindgen_file) {
+                Ok(binding) if blake3::hash(&binding).as_bytes() == &cached.binding_hash => {},
+                _ => return LocalCache::Rebind(MissReason::MissingBinding),
+            }
+        }
+        LocalCache::Hit(cached)
+    }
+
+    fn effective_zstd_level(&self) -> i32 {
+        if self.metallib_compressed {
+            self.zstd_level
+        } else {
+            0
+        }
+    }
+
+    fn write_local_cache(
+        &self,
+        cached_file: &Path,
+        dependency_hashes: HashMap<Box<str>, [u8; blake3::OUT_LEN]>,
+        artifact_hash: [u8; blake3::OUT_LEN],
+        binding_hash: [u8; blake3::OUT_LEN],
+        public_kernels: Box<[Kernel]>,
+        has_kernels: bool,
+    ) -> anyhow::Result<()> {
+        let cached = Cached {
+            schema: caching::METAL_CACHE_SCHEMA,
+            compile_schema_hash: *self.compile_schema_hash.as_bytes(),
+            toolchain_hash: *self.toolchain_hash.as_bytes(),
+            dependency_hashes,
+            artifact_hash,
+            binding_hash,
+            zstd_level: self.effective_zstd_level(),
+            compressed: self.metallib_compressed,
+            public_kernels,
+            has_kernels,
+        };
+        caching::write_atomic(cached_file, serde_json::to_vec_pretty(&cached).context("cannot serialize cache")?)
+            .context("cannot write cache file")
+    }
+
+    fn write_bindings(
+        &self,
+        source_path_relative_str: &str,
+        kernel_infos: &[MetalKernelInfo],
+        specialize_indices: &SpecializeBaseIndices,
+        enum_paths: &EnumPaths,
+        metallib_maybe_compressed_file: &Path,
+        bindgen_file: &Path,
+    ) -> anyhow::Result<[u8; blake3::OUT_LEN]> {
+        let library_const =
+            format_ident!("MTLB_{}", blake3::hash(source_path_relative_str.as_bytes()).to_hex().to_uppercase());
+        let metallib_maybe_compressed_file_str =
+            metallib_maybe_compressed_file.to_str().context("metallib path is not utf-8")?;
+
+        let bindings = kernel_infos
+            .iter()
+            .map(|kernel| {
+                super::bindgen::bindgen(
+                    kernel,
+                    specialize_indices,
+                    enum_paths,
+                    &library_const,
+                    self.metallib_compressed,
+                )
+                .with_context(|| format!("cannot generate bindings for {}", kernel.name))
+                .map(|(tokens, _associated_type)| tokens)
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        let tokens = quote! {
+            const #library_const: &[u8] = include_bytes!(#metallib_maybe_compressed_file_str);
+
+            #(#bindings)*
+        };
+
+        write_tokens(tokens, bindgen_file).context("cannot write bindings")?;
+        Ok(*caching::hash_file(bindgen_file)?.as_bytes())
+    }
+
+    async fn compress_metallib(
+        &self,
+        metallib_file: PathBuf,
+        compressed_file: PathBuf,
+    ) -> anyhow::Result<()> {
+        let zstd_level = self.zstd_level;
+        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+            let metallib_source = fs::read(&metallib_file)?;
+            let metallib_compressed = zstd::encode_all(metallib_source.as_slice(), zstd_level)?;
+            caching::write_atomic(&compressed_file, metallib_compressed)?;
+            Ok(())
+        })
+        .await??;
+        Ok(())
+    }
+
+    async fn compile_air(
+        &self,
+        source_path: &Path,
+        source_path_relative_str: &str,
+        footer: &str,
+        object_file: &Path,
+    ) -> anyhow::Result<()> {
+        let compile_output = self
+            .toolchain
+            .compile(source_path, footer, object_file)
+            .await
+            .with_context(|| format!("cannot compile {source_path_relative_str}"))?;
+
+        if let Some(warnings) = &compile_output {
+            for line in warnings.lines() {
+                println!("cargo::warning={line}");
+            }
+        }
+        Ok(())
+    }
+
+    async fn link_metallib(
+        &self,
+        source_path_relative_str: &str,
+        object_file: &Path,
+        metallib_file: &Path,
+    ) -> anyhow::Result<()> {
+        let link_output = self
+            .toolchain
+            .link(object_file, metallib_file)
+            .await
+            .with_context(|| format!("cannot link {source_path_relative_str}"))?;
+
+        if let Some(warnings) = &link_output {
+            for line in warnings.lines() {
+                println!("cargo::warning={line}");
+            }
+        }
+        Ok(())
+    }
+
+    async fn resolve_analysis(
+        &self,
+        source_path: &Path,
+        source_path_relative_str: &str,
+        enum_paths: &EnumPaths,
+        clock: &mut StageClock,
+    ) -> anyhow::Result<Analysis> {
+        let source_hash = caching::hash_file(source_path)?;
+        let index_key = artifact_cache::index_key(
+            source_path_relative_str,
+            &source_hash,
+            &self.compile_schema_hash,
+            &self.analyzer_hash,
+            &self.gpu_types_hash,
+        );
+
+        if !self.bypass_shared_cache
+            && let Some(index) = artifact_cache::load_source_index(&self.shared_cache, &index_key)?
+            && index.compile_schema_hash == *self.compile_schema_hash.as_bytes()
+            && index.analyzer_hash == *self.analyzer_hash.as_bytes()
+            && index.gpu_types_hash == *self.gpu_types_hash.as_bytes()
+            && index.source_hash == *source_hash.as_bytes()
+            && artifact_cache::dependencies_match(&index.dependency_hashes)
+        {
+            clock.lap("index");
+            return Ok(Analysis {
+                kernel_infos: index.kernel_infos,
+                specialize_indices: index.specialize_indices,
+                public_kernels: index.public_kernels,
+                dependency_hashes: index.dependency_hashes,
+                footer: index.footer,
+                from_index: true,
+            });
+        }
+
+        let _lock = self.shared_cache.lock(Stage::Index, &index_key).await?;
+        if !self.bypass_shared_cache
+            && let Some(index) = artifact_cache::load_source_index(&self.shared_cache, &index_key)?
+            && index.compile_schema_hash == *self.compile_schema_hash.as_bytes()
+            && index.analyzer_hash == *self.analyzer_hash.as_bytes()
+            && index.gpu_types_hash == *self.gpu_types_hash.as_bytes()
+            && index.source_hash == *source_hash.as_bytes()
+            && artifact_cache::dependencies_match(&index.dependency_hashes)
+        {
+            clock.lap("index");
+            return Ok(Analysis {
+                kernel_infos: index.kernel_infos,
+                specialize_indices: index.specialize_indices,
+                public_kernels: index.public_kernels,
+                dependency_hashes: index.dependency_hashes,
+                footer: index.footer,
+                from_index: true,
+            });
+        }
+
+        let (metal_kernel_infos, dependencies) = self
+            .toolchain
+            .analyze(source_path)
+            .await
+            .with_context(|| format!("cannot analyze {source_path_relative_str}"))?;
+        let kernel_infos: Vec<MetalKernelInfo> = metal_kernel_infos.collect();
+        clock.lap("analyze");
+
+        let dependency_hashes = dependencies
+            .map(|path| {
+                Ok((
+                    path.clone(),
+                    blake3::hash(&fs::read(path.as_ref()).with_context(|| format!("cannot read {path}"))?).into(),
+                ))
+            })
+            .collect::<anyhow::Result<HashMap<Box<str>, [u8; blake3::OUT_LEN]>>>()
+            .context("cannot hash dependencies")?;
+
+        let (footer, specialize_indices) = if kernel_infos.is_empty() {
+            (String::new(), SpecializeBaseIndices::new())
+        } else {
+            let (wrapper_strs, specialize_indices) =
+                wrappers(&kernel_infos, enum_paths).context("cannot generate kernel wrappers")?;
+            let mut footer = String::new();
+            for wrapper in wrapper_strs.iter() {
+                footer.push_str(wrapper);
+            }
+            clock.lap("wrappers");
+            (footer, specialize_indices)
+        };
+
+        let public_kernels: Box<[Kernel]> = kernel_infos.iter().filter_map(|kernel| kernel.to_kernel()).collect();
+        let index = SourceIndex {
+            schema: caching::METAL_CACHE_SCHEMA,
+            source_hash: *source_hash.as_bytes(),
+            compile_schema_hash: *self.compile_schema_hash.as_bytes(),
+            analyzer_hash: *self.analyzer_hash.as_bytes(),
+            gpu_types_hash: *self.gpu_types_hash.as_bytes(),
+            dependency_hashes: dependency_hashes.clone(),
+            footer: footer.clone(),
+            kernel_infos: kernel_infos.clone(),
+            specialize_indices: specialize_indices.clone(),
+            public_kernels: public_kernels.clone(),
+        };
+        artifact_cache::store_source_index(&self.shared_cache, &index_key, &index)?;
+        clock.lap("index_store");
+
+        Ok(Analysis {
+            kernel_infos,
+            specialize_indices,
+            public_kernels,
+            dependency_hashes,
+            footer,
+            from_index: false,
+        })
+    }
+
+    async fn ensure_air(
+        &self,
+        source_path: &Path,
+        source_path_relative_str: &str,
+        analysis: &Analysis,
+        object_file: &Path,
+        clock: &mut StageClock,
+    ) -> anyhow::Result<EnsuredArtifact> {
+        let key = artifact_cache::air_key(
+            source_path_relative_str,
+            &analysis.dependency_hashes,
+            &analysis.footer,
+            &self.compile_schema_hash,
+            &self.toolchain_hash,
+        );
+        if !self.bypass_shared_cache
+            && let Some(artifact) = self.shared_cache.lookup(Stage::Air, &key)?
+        {
+            caching::hard_link_atomic(&artifact.path, object_file)?;
+            clock.lap("shared_air");
+            return Ok(EnsuredArtifact {
+                origin: "shared_air",
+                hash: artifact.hash,
+            });
+        }
+        let _lock = self.shared_cache.lock(Stage::Air, &key).await?;
+        if !self.bypass_shared_cache
+            && let Some(artifact) = self.shared_cache.lookup(Stage::Air, &key)?
+        {
+            caching::hard_link_atomic(&artifact.path, object_file)?;
+            clock.lap("shared_air");
+            return Ok(EnsuredArtifact {
+                origin: "shared_air",
+                hash: artifact.hash,
+            });
+        }
+        caching::remove_file_if_exists(object_file)?;
+        self.compile_air(source_path, source_path_relative_str, &analysis.footer, object_file).await?;
+        clock.lap("compile");
+        let hash = self.shared_cache.store(Stage::Air, &key, object_file)?;
+        clock.lap("air_store");
+        Ok(EnsuredArtifact {
+            origin: "compile",
+            hash,
+        })
+    }
+
+    async fn ensure_metallib(
+        &self,
+        source_path_relative_str: &str,
+        air_hash: [u8; blake3::OUT_LEN],
+        object_file: &Path,
+        metallib_file: &Path,
+        clock: &mut StageClock,
+    ) -> anyhow::Result<EnsuredArtifact> {
+        let air_hash = blake3::Hash::from_bytes(air_hash);
+        let key = artifact_cache::metallib_key(&air_hash, &self.linker_hash);
+        if !self.bypass_shared_cache
+            && let Some(artifact) = self.shared_cache.lookup(Stage::Metallib, &key)?
+        {
+            caching::hard_link_atomic(&artifact.path, metallib_file)?;
+            clock.lap("shared_metallib");
+            return Ok(EnsuredArtifact {
+                origin: "shared_metallib",
+                hash: artifact.hash,
+            });
+        }
+        let _lock = self.shared_cache.lock(Stage::Metallib, &key).await?;
+        if !self.bypass_shared_cache
+            && let Some(artifact) = self.shared_cache.lookup(Stage::Metallib, &key)?
+        {
+            caching::hard_link_atomic(&artifact.path, metallib_file)?;
+            clock.lap("shared_metallib");
+            return Ok(EnsuredArtifact {
+                origin: "shared_metallib",
+                hash: artifact.hash,
+            });
+        }
+        caching::remove_file_if_exists(metallib_file)?;
+        self.link_metallib(source_path_relative_str, object_file, metallib_file).await?;
+        clock.lap("link");
+        let hash = self.shared_cache.store(Stage::Metallib, &key, metallib_file)?;
+        clock.lap("metallib_store");
+        Ok(EnsuredArtifact {
+            origin: "link",
+            hash,
+        })
+    }
+
+    async fn ensure_zstd(
+        &self,
+        metallib_hash: [u8; blake3::OUT_LEN],
+        metallib_file: &Path,
+        compressed_file: &Path,
+        clock: &mut StageClock,
+    ) -> anyhow::Result<EnsuredArtifact> {
+        let metallib_hash = blake3::Hash::from_bytes(metallib_hash);
+        let key = artifact_cache::zstd_key(&metallib_hash, self.zstd_level);
+        if !self.bypass_shared_cache
+            && let Some(artifact) = self.shared_cache.lookup(Stage::Zstd, &key)?
+        {
+            caching::hard_link_atomic(&artifact.path, compressed_file)?;
+            clock.lap("shared_zstd");
+            return Ok(EnsuredArtifact {
+                origin: "shared_zstd",
+                hash: artifact.hash,
+            });
+        }
+        let _lock = self.shared_cache.lock(Stage::Zstd, &key).await?;
+        if !self.bypass_shared_cache
+            && let Some(artifact) = self.shared_cache.lookup(Stage::Zstd, &key)?
+        {
+            caching::hard_link_atomic(&artifact.path, compressed_file)?;
+            clock.lap("shared_zstd");
+            return Ok(EnsuredArtifact {
+                origin: "shared_zstd",
+                hash: artifact.hash,
+            });
+        }
+        self.compress_metallib(metallib_file.to_path_buf(), compressed_file.to_path_buf()).await?;
+        clock.lap("compress");
+        let hash = self.shared_cache.store(Stage::Zstd, &key, compressed_file)?;
+        clock.lap("zstd_store");
+        Ok(EnsuredArtifact {
+            origin: "compress",
+            hash,
         })
     }
 
@@ -66,7 +630,8 @@ impl MetalCompiler {
         &self,
         source_path: PathBuf,
         enum_paths: &EnumPaths,
-    ) -> anyhow::Result<(KernelPath, Box<[Kernel]>, bool)> {
+    ) -> anyhow::Result<CompiledSource> {
+        let mut clock = StageClock::new();
         let source_path_relative =
             source_path.strip_prefix(&self.source_directory).context("source is not in src_dir")?;
         let source_path_relative_str = source_path_relative.to_str().context("source path is not utf-8")?;
@@ -92,127 +657,128 @@ impl MetalCompiler {
         let bindgen_file = output_base_path.with_extension("rs");
         let cached_file = output_base_path.with_extension("cached");
 
-        let buildsystem_hash = caching::build_system_hash().context("cannot get build system hash")?.as_bytes();
+        let local = self.check_local_cache(&cached_file, &metallib_maybe_compressed_file, &bindgen_file);
+        clock.lap("local_cache");
 
-        if let Ok(cached_contents) = fs::read(&cached_file)
-            && let Ok(cached) = serde_json::from_slice::<Cached>(&cached_contents)
-            && &cached.buildsystem_hash == buildsystem_hash
-            && cached.dependency_hashes.iter().all(|(path, hash)| {
-                fs::read(path.as_ref()).map(|contents| blake3::hash(&contents).as_bytes() == hash).unwrap_or(false)
-            })
-        {
+        if let LocalCache::Hit(cached) = local {
             debug_log!("compile cached: {source_path_relative_str}");
-            return Ok((kernel_path, cached.public_kernels, cached.has_kernels));
+            return Ok(CompiledSource {
+                kernel_path,
+                public_kernels: cached.public_kernels,
+                has_kernels: cached.has_kernels,
+                source: source_path_relative_str.to_string(),
+                cache_hit: true,
+                miss_reason: None,
+                total_ms: clock.total_ms(),
+                stages: clock.stages,
+            });
         }
 
-        let (metal_kernel_infos, dependencies) = self
-            .toolchain
-            .analyze(&source_path)
-            .await
-            .with_context(|| format!("cannot analyze {source_path_relative_str}"))?;
-
-        let kernel_infos: Vec<MetalKernelInfo> = metal_kernel_infos.collect();
-
-        let dependency_hashes = dependencies
-            .map(|path| {
-                Ok((
-                    path.clone(),
-                    blake3::hash(&fs::read(path.as_ref()).with_context(|| format!("cannot read {path}"))?).into(),
-                ))
-            })
-            .collect::<anyhow::Result<HashMap<Box<str>, [u8; blake3::OUT_LEN]>>>()
-            .context("cannot hash dependencies")?;
-
-        if !kernel_infos.is_empty() {
-            let (wrapper_strs, specialize_indices) =
-                wrappers(&kernel_infos, enum_paths).context("cannot generate kernel wrappers")?;
-
-            let mut footer = String::new();
-            for wrapper in wrapper_strs.iter() {
-                footer.push_str(wrapper);
-            }
-
-            let compile_output = self
-                .toolchain
-                .compile(&source_path, &footer, &object_file)
-                .await
-                .with_context(|| format!("cannot compile {source_path_relative_str}"))?;
-
-            if let Some(warnings) = &compile_output {
-                for line in warnings.lines() {
-                    println!("cargo::warning={line}");
-                }
-            }
-
-            let link_output = self
-                .toolchain
-                .link(&object_file, &metallib_file)
-                .await
-                .with_context(|| format!("cannot link {source_path_relative_str}"))?;
-
-            if let Some(warnings) = &link_output {
-                for line in warnings.lines() {
-                    println!("cargo::warning={line}");
-                }
-            }
-
-            if self.metallib_compressed {
-                let metallib_file = metallib_file.clone();
-                let metallib_compressed_file = metallib_maybe_compressed_file.clone();
-
-                tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-                    let metallib_source = fs::read(&metallib_file)?;
-                    let metallib_compressed = zstd::encode_all(metallib_source.as_slice(), 22)?;
-                    fs::write(&metallib_compressed_file, &metallib_compressed)?;
-                    Ok(())
-                })
-                .await??;
-            };
-
-            let library_const =
-                format_ident!("MTLB_{}", blake3::hash(source_path_relative_str.as_bytes()).to_hex().to_uppercase());
-            let metallib_maybe_compressed_file_str =
-                metallib_maybe_compressed_file.to_str().context("metallib path is not utf-8")?;
-
-            let bindings = kernel_infos
-                .iter()
-                .map(|kernel| {
-                    super::bindgen::bindgen(
-                        kernel,
-                        &specialize_indices,
-                        enum_paths,
-                        &library_const,
-                        self.metallib_compressed,
-                    )
-                    .with_context(|| format!("cannot generate bindings for {}", kernel.name))
-                    .map(|(tokens, _associated_type)| tokens)
-                })
-                .collect::<anyhow::Result<Vec<_>>>()?;
-
-            let tokens = quote! {
-                const #library_const: &[u8] = include_bytes!(#metallib_maybe_compressed_file_str);
-
-                #(#bindings)*
-            };
-
-            write_tokens(tokens, &bindgen_file).context("cannot write bindings")?;
-        }
-
-        let public_kernels: Box<[Kernel]> = kernel_infos.iter().filter_map(|kernel| kernel.to_kernel()).collect();
-        let has_kernels = !kernel_infos.is_empty();
-
-        let cached = Cached {
-            buildsystem_hash: *buildsystem_hash,
-            dependency_hashes,
-            public_kernels: public_kernels.clone(),
-            has_kernels,
+        let miss_reason = match &local {
+            LocalCache::Hit(_) => unreachable!(),
+            LocalCache::Rebind(reason) | LocalCache::Miss(reason) => reason.clone(),
         };
-        fs::write(&cached_file, serde_json::to_vec_pretty(&cached).context("cannot serialize cache")?)
-            .context("cannot write cache file")?;
 
-        debug_log!("compile end: {source_path_relative_str}");
+        let analysis = self.resolve_analysis(&source_path, source_path_relative_str, enum_paths, &mut clock).await?;
 
-        Ok((kernel_path, public_kernels, has_kernels))
+        if analysis.kernel_infos.is_empty() {
+            self.write_local_cache(
+                &cached_file,
+                analysis.dependency_hashes,
+                [0; blake3::OUT_LEN],
+                [0; blake3::OUT_LEN],
+                Box::new([]),
+                false,
+            )?;
+            clock.lap("cache_store");
+            return Ok(CompiledSource {
+                kernel_path,
+                public_kernels: Box::new([]),
+                has_kernels: false,
+                source: source_path_relative_str.to_string(),
+                cache_hit: analysis.from_index,
+                miss_reason: Some(miss_reason.to_string()),
+                total_ms: clock.total_ms(),
+                stages: clock.stages,
+            });
+        }
+
+        if let LocalCache::Rebind(_) = local {
+            let binding_hash = self.write_bindings(
+                source_path_relative_str,
+                &analysis.kernel_infos,
+                &analysis.specialize_indices,
+                enum_paths,
+                &metallib_maybe_compressed_file,
+                &bindgen_file,
+            )?;
+            let artifact_hash = *caching::hash_file(&metallib_maybe_compressed_file)?.as_bytes();
+            self.write_local_cache(
+                &cached_file,
+                analysis.dependency_hashes,
+                artifact_hash,
+                binding_hash,
+                analysis.public_kernels.clone(),
+                true,
+            )?;
+            clock.lap("bindgen");
+            return Ok(CompiledSource {
+                kernel_path,
+                public_kernels: analysis.public_kernels,
+                has_kernels: true,
+                source: source_path_relative_str.to_string(),
+                cache_hit: false,
+                miss_reason: Some(miss_reason.to_string()),
+                total_ms: clock.total_ms(),
+                stages: clock.stages,
+            });
+        }
+
+        let air = self.ensure_air(&source_path, source_path_relative_str, &analysis, &object_file, &mut clock).await?;
+        let metallib =
+            self.ensure_metallib(source_path_relative_str, air.hash, &object_file, &metallib_file, &mut clock).await?;
+        let artifact = if self.metallib_compressed {
+            self.ensure_zstd(metallib.hash, &metallib_file, &metallib_maybe_compressed_file, &mut clock).await?
+        } else {
+            metallib
+        };
+        let produced_from = if artifact.origin.starts_with("shared_") && !air.origin.starts_with("shared_") {
+            air.origin
+        } else {
+            artifact.origin
+        };
+
+        let binding_hash = self.write_bindings(
+            source_path_relative_str,
+            &analysis.kernel_infos,
+            &analysis.specialize_indices,
+            enum_paths,
+            &metallib_maybe_compressed_file,
+            &bindgen_file,
+        )?;
+        clock.lap("bindgen");
+
+        self.write_local_cache(
+            &cached_file,
+            analysis.dependency_hashes,
+            artifact.hash,
+            binding_hash,
+            analysis.public_kernels.clone(),
+            true,
+        )?;
+
+        debug_log!("compile end: {source_path_relative_str} via {produced_from}");
+
+        Ok(CompiledSource {
+            kernel_path,
+            public_kernels: analysis.public_kernels,
+            has_kernels: true,
+            source: source_path_relative_str.to_string(),
+            cache_hit: produced_from.starts_with("shared_"),
+            miss_reason: Some(format!("{miss_reason}; recovered via {produced_from}")),
+            total_ms: clock.total_ms(),
+            stages: clock.stages,
+        })
     }
 }
 
@@ -223,7 +789,9 @@ impl Compiler for MetalCompiler {
         gpu_types: &GpuTypes,
         enum_paths: &EnumPaths,
     ) -> anyhow::Result<HashMap<KernelPath, Box<[Kernel]>>> {
+        let gpu_types_started = Instant::now();
         gpu_type_gen(&self.gpu_types_directory, gpu_types).await.context("cannot generate shared gpu types")?;
+        build_warning!("gpu-type generation {}ms", gpu_types_started.elapsed().as_millis());
 
         let metal_sources: Vec<PathBuf> = WalkDir::new(&self.source_directory)
             .into_iter()
@@ -233,8 +801,9 @@ impl Compiler for MetalCompiler {
             .collect();
 
         let num_concurrent_compiles = std::thread::available_parallelism().map(|x| x.get()).unwrap_or(4) * 2;
+        build_warning!("compiling {} metal sources, concurrency {num_concurrent_compiles}", metal_sources.len());
 
-        let compiled: Vec<(KernelPath, Box<[Kernel]>, bool)> = stream::iter(metal_sources)
+        let compiled: Vec<CompiledSource> = stream::iter(metal_sources)
             .map(|path| async move {
                 self.compile(path.clone(), enum_paths)
                     .await
@@ -244,11 +813,37 @@ impl Compiler for MetalCompiler {
             .try_collect()
             .await?;
 
+        let hits = compiled.iter().filter(|source| source.cache_hit).count();
+        let misses = compiled.len() - hits;
+        let slowest = compiled.iter().max_by_key(|source| source.total_ms);
+        build_warning!(
+            "metal summary: {hits} hit, {misses} miss, {} sources; slowest {} ({}ms)",
+            compiled.len(),
+            slowest.map(|source| source.source.as_str()).unwrap_or("-"),
+            slowest.map(|source| source.total_ms).unwrap_or(0)
+        );
+        for source in &compiled {
+            if source.cache_hit {
+                debug_log!("metal hit {}: {}ms {:?}", source.source, source.total_ms, source.stages);
+            } else {
+                build_warning!(
+                    "metal miss {}: {} ({}ms) {:?}",
+                    source.source,
+                    source.miss_reason.as_deref().unwrap_or("unknown"),
+                    source.total_ms,
+                    source.stages
+                );
+            }
+        }
+
         let mut kernels_bindgen = compiled
             .iter()
-            .filter(|(_path, _kernels, has_kernels)| *has_kernels)
-            .map(|(path, kernels, _has_kernels)| {
-                (self.output_directory.join(path.join("/")).with_extension("rs"), kernels.as_ref())
+            .filter(|source| source.has_kernels)
+            .map(|source| {
+                (
+                    self.output_directory.join(source.kernel_path.join("/")).with_extension("rs"),
+                    source.public_kernels.as_ref(),
+                )
             })
             .collect::<Vec<(PathBuf, &[Kernel])>>();
         kernels_bindgen.sort_by(|(a_path, _a_kernels), (b_path, _b_kernels)| a_path.cmp(b_path));
@@ -256,6 +851,6 @@ impl Compiler for MetalCompiler {
         let tokens = bindgen_global(&kernels_bindgen).context("cannot generate bindings")?;
         write_tokens(tokens, self.output_directory.with_extension("rs")).context("cannot write bindings")?;
 
-        Ok(compiled.into_iter().map(|(path, kernels, _has_kernels)| (path, kernels)).collect())
+        Ok(compiled.into_iter().map(|source| (source.kernel_path, source.public_kernels)).collect())
     }
 }

--- a/crates/backend-uzu/build/metal/mod.rs
+++ b/crates/backend-uzu/build/metal/mod.rs
@@ -1,5 +1,7 @@
+mod artifact_cache;
 mod ast;
 mod bindgen;
+mod cache_protocol;
 mod compiler;
 mod enum_path_rewrite;
 mod gpu_types;

--- a/crates/backend-uzu/build/metal/toolchain.rs
+++ b/crates/backend-uzu/build/metal/toolchain.rs
@@ -4,6 +4,7 @@ use std::{
     fs,
     path::{Path, PathBuf},
     process::Stdio,
+    sync::OnceLock,
 };
 
 use anyhow::{Context, bail};
@@ -129,6 +130,69 @@ impl MetalToolchain {
             extra_options,
             include_dirs,
         })
+    }
+
+    pub fn identity_hash(&self) -> anyhow::Result<blake3::Hash> {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(self.sdk.to_str().as_bytes());
+        hasher.update(b"\0");
+        hasher.update(self.std.to_str().as_bytes());
+        hasher.update(b"\0");
+        hasher.update(self.std.min_os().as_bytes());
+        hasher.update(b"\0");
+        for flag in self.opt_flags.iter() {
+            hasher.update(flag.to_string_lossy().as_bytes());
+            hasher.update(b"\0");
+        }
+        for option in self.extra_options.iter() {
+            hasher.update(option.to_string_lossy().as_bytes());
+            hasher.update(b"\0");
+        }
+        hasher.update(self.compiler_version()?.as_bytes());
+        Ok(hasher.finalize())
+    }
+
+    /// Metal frontend identity used to cache AST and dependency analysis.
+    pub fn analyzer_identity_hash(&self) -> anyhow::Result<blake3::Hash> {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"metal-analyzer\0");
+        hasher.update(self.sdk.to_str().as_bytes());
+        hasher.update(b"\0");
+        hasher.update(self.std.to_str().as_bytes());
+        hasher.update(b"\0");
+        hasher.update(self.std.min_os().as_bytes());
+        hasher.update(b"\0");
+        for option in self.extra_options.iter() {
+            hasher.update(option.to_string_lossy().as_bytes());
+            hasher.update(b"\0");
+        }
+        hasher.update(self.compiler_version()?.as_bytes());
+        Ok(hasher.finalize())
+    }
+
+    pub fn linker_identity_hash(&self) -> anyhow::Result<blake3::Hash> {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"metallib\0");
+        hasher.update(self.sdk.to_str().as_bytes());
+        hasher.update(b"\0");
+        hasher.update(self.compiler_version()?.as_bytes());
+        Ok(hasher.finalize())
+    }
+
+    fn compiler_version(&self) -> anyhow::Result<&'static str> {
+        static VERSION: OnceLock<String> = OnceLock::new();
+        if let Some(version) = VERSION.get() {
+            return Ok(version.as_str());
+        }
+        let output = std::process::Command::new("xcrun")
+            .args(["-sdk", self.sdk.to_str(), "metal", "--version"])
+            .output()
+            .context("cannot execute metal --version")?;
+        if !output.status.success() {
+            anyhow::bail!("metal --version failed: {}", String::from_utf8_lossy(&output.stderr));
+        }
+        let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        Ok(VERSION.get_or_init(|| version).as_str())
     }
 
     fn xcrun(&self) -> Command {

--- a/crates/backend-uzu/src/encodable_block/mlp/moe/mod.rs
+++ b/crates/backend-uzu/src/encodable_block/mlp/moe/mod.rs
@@ -63,9 +63,9 @@ pub enum MoeBlockError<B: Backend> {
     ParameterLoaderError(#[from] ParameterLoaderError<B>),
     #[error("MoE requires model_dim % 4 == 0")]
     InvalidModelDim,
-    #[error("MoE num_routed_experts must be <= 512")]
+    #[error("MoE num_routed_experts must be > 0 and <= 512")]
     InvalidRoutedExpertCount,
-    #[error("MoE num_active_routed_experts must be > 0 and <= 128")]
+    #[error("MoE num_active_routed_experts must be > 0, <= 128, and <= num_routed_experts")]
     InvalidActiveExpertCount,
     #[error("MoE shared experts are not supported")]
     UnsupportedSharedExperts,
@@ -90,11 +90,14 @@ impl<B: Backend> MoeBlock<B> {
         if !model_dim.is_multiple_of(4) {
             return Err(MoeBlockError::InvalidModelDim);
         }
-        if moe_config.num_active_routed_experts == 0 || moe_config.num_active_routed_experts > 128 {
-            return Err(MoeBlockError::InvalidActiveExpertCount);
-        }
-        if moe_config.num_routed_experts > 512 {
+        if moe_config.num_routed_experts == 0 || moe_config.num_routed_experts > 512 {
             return Err(MoeBlockError::InvalidRoutedExpertCount);
+        }
+        if moe_config.num_active_routed_experts == 0
+            || moe_config.num_active_routed_experts > 128
+            || moe_config.num_active_routed_experts > moe_config.num_routed_experts
+        {
+            return Err(MoeBlockError::InvalidActiveExpertCount);
         }
         if moe_config.num_shared_experts != 0 {
             return Err(MoeBlockError::UnsupportedSharedExperts);

--- a/crates/backend-uzu/tests/metal_artifact_cache.rs
+++ b/crates/backend-uzu/tests/metal_artifact_cache.rs
@@ -1,0 +1,173 @@
+#![cfg(all(feature = "metal", target_os = "macos"))]
+#![allow(dead_code)]
+
+use std::{
+    collections::HashMap,
+    fs,
+    path::PathBuf,
+    sync::atomic::{AtomicU64, Ordering},
+    time::{Duration, Instant},
+};
+
+#[path = "../build/common/caching.rs"]
+mod caching;
+
+#[path = "../build/metal/cache_protocol.rs"]
+mod cache_protocol;
+
+use cache_protocol::{SharedArtifactCache, Stage, air_key, index_key, metallib_key, zstd_key};
+
+static SCRATCH_SEQ: AtomicU64 = AtomicU64::new(0);
+
+fn scratch() -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "uzu-metal-cache-test-{}-{}",
+        std::process::id(),
+        SCRATCH_SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn sample_deps() -> HashMap<Box<str>, [u8; blake3::OUT_LEN]> {
+    let mut deps = HashMap::new();
+    deps.insert("a.metal".into(), *blake3::hash(b"a").as_bytes());
+    deps.insert("b.h".into(), *blake3::hash(b"b").as_bytes());
+    deps
+}
+
+#[test]
+fn air_key_ignores_zstd_level() {
+    let compile = blake3::hash(b"compile");
+    let toolchain = blake3::hash(b"toolchain");
+    let deps = sample_deps();
+    let air = air_key("gemm/kernel.metal", &deps, "footer", &compile, &toolchain);
+    let again = air_key("gemm/kernel.metal", &deps, "footer", &compile, &toolchain);
+    assert_eq!(air, again);
+
+    let other_footer = air_key("gemm/kernel.metal", &deps, "footer2", &compile, &toolchain);
+    assert_ne!(air, other_footer);
+}
+
+#[test]
+fn zstd_key_changes_with_level_not_air() {
+    let air_hash = blake3::hash(b"air-bytes");
+    let linker = blake3::hash(b"linker");
+    let metallib = metallib_key(&air_hash, &linker);
+    let z20 = zstd_key(&metallib, 20);
+    let z22 = zstd_key(&metallib, 22);
+    assert_ne!(z20, z22);
+    assert_eq!(metallib, metallib_key(&air_hash, &linker));
+}
+
+#[test]
+fn index_key_tracks_source_and_schemas() {
+    let source = blake3::hash(b"source");
+    let compile = blake3::hash(b"compile");
+    let analyzer = blake3::hash(b"analyzer");
+    let gpu = blake3::hash(b"gpu");
+    let a = index_key("gemm/kernel.metal", &source, &compile, &analyzer, &gpu);
+    let b = index_key("gemm/kernel.metal", &blake3::hash(b"source2"), &compile, &analyzer, &gpu);
+    let c = index_key("gemm/kernel.metal", &source, &blake3::hash(b"compile2"), &analyzer, &gpu);
+    let d = index_key("gemm/kernel.metal", &source, &compile, &blake3::hash(b"analyzer2"), &gpu);
+    assert_ne!(a, b);
+    assert_ne!(a, c);
+    assert_ne!(a, d);
+}
+
+#[test]
+fn store_lookup_roundtrip() {
+    let cache = SharedArtifactCache::at(scratch()).unwrap();
+    let key = blake3::hash(b"roundtrip");
+    cache.store_bytes(Stage::Air, &key, b"air-bytes").unwrap();
+    let artifact = cache.lookup(Stage::Air, &key).unwrap().expect("artifact");
+    assert_eq!(artifact.hash, *blake3::hash(b"air-bytes").as_bytes());
+    assert_eq!(fs::read(artifact.path).unwrap(), b"air-bytes");
+}
+
+#[test]
+fn lookup_rejects_missing_manifest() {
+    let cache = SharedArtifactCache::at(scratch()).unwrap();
+    let key = blake3::hash(b"no-manifest");
+    let dir = cache.stage_dir(Stage::Air, &key);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("artifact"), b"air-bytes").unwrap();
+    assert!(cache.lookup(Stage::Air, &key).unwrap().is_none());
+}
+
+#[test]
+fn lookup_rejects_corrupt_artifact() {
+    let cache = SharedArtifactCache::at(scratch()).unwrap();
+    let key = blake3::hash(b"corrupt");
+    cache.store_bytes(Stage::Metallib, &key, b"good").unwrap();
+    let artifact = cache.stage_dir(Stage::Metallib, &key).join("artifact");
+    fs::write(artifact, b"tampered").unwrap();
+    assert!(cache.lookup(Stage::Metallib, &key).unwrap().is_none());
+}
+
+#[test]
+fn lookup_rejects_wrong_stage_kind() {
+    let cache = SharedArtifactCache::at(scratch()).unwrap();
+    let key = blake3::hash(b"kind");
+    cache.store_bytes(Stage::Air, &key, b"air").unwrap();
+    let manifest = cache.stage_dir(Stage::Air, &key).join("manifest.json");
+    let bytes = fs::read(&manifest).unwrap();
+    let mut value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    value["kind"] = serde_json::Value::String("zstd".into());
+    fs::write(manifest, serde_json::to_vec(&value).unwrap()).unwrap();
+    assert!(cache.lookup(Stage::Air, &key).unwrap().is_none());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn lock_serializes_producers() {
+    let root = scratch();
+    let cache = SharedArtifactCache::at(&root).unwrap();
+    let key = blake3::hash(b"lock");
+    let held = cache.lock_with_timeout(Stage::Zstd, &key, Duration::from_secs(5)).await.unwrap();
+    let started = Instant::now();
+    let waiter = {
+        let cache = SharedArtifactCache::at(&root).unwrap();
+        tokio::spawn(async move {
+            let _lock = cache.lock_with_timeout(Stage::Zstd, &key, Duration::from_secs(5)).await.unwrap();
+            started.elapsed()
+        })
+    };
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    drop(held);
+    let waited = waiter.await.unwrap();
+    assert!(waited >= Duration::from_millis(100), "waiter elapsed {waited:?}");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn concurrent_miss_reuses_first_store() {
+    let root = scratch();
+    let key = blake3::hash(b"race");
+    let producer = {
+        let cache = SharedArtifactCache::at(&root).unwrap();
+        tokio::spawn(async move {
+            let _lock = cache.lock_with_timeout(Stage::Air, &key, Duration::from_secs(5)).await.unwrap();
+            if cache.lookup(Stage::Air, &key).unwrap().is_none() {
+                tokio::time::sleep(Duration::from_millis(120)).await;
+                cache.store_bytes(Stage::Air, &key, b"first").unwrap();
+            }
+        })
+    };
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    let cache = SharedArtifactCache::at(&root).unwrap();
+    let _lock = cache.lock_with_timeout(Stage::Air, &key, Duration::from_secs(5)).await.unwrap();
+    let artifact = cache.lookup(Stage::Air, &key).unwrap().expect("second producer must see first store");
+    assert_eq!(fs::read(artifact.path).unwrap(), b"first");
+    drop(_lock);
+    producer.await.unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn malformed_lock_owner_is_reclaimed() {
+    let cache = SharedArtifactCache::at(scratch()).unwrap();
+    let key = blake3::hash(b"malformed-owner");
+    let lock_dir = cache.stage_dir(Stage::Air, &key).join(".lock");
+    fs::create_dir_all(&lock_dir).unwrap();
+    fs::write(lock_dir.join("pid"), "not-a-pid").unwrap();
+
+    let _lock = cache.lock_with_timeout(Stage::Air, &key, Duration::from_secs(1)).await.unwrap();
+}

--- a/crates/backend-uzu/tests/unit/encodable_block/moe/mod.rs
+++ b/crates/backend-uzu/tests/unit/encodable_block/moe/mod.rs
@@ -5,6 +5,7 @@ use super::{
 };
 
 mod moe_block_e2e_test;
+mod moe_block_validation_test;
 mod moe_experts_perf_test;
 mod moe_experts_test;
 mod moe_perf_test;

--- a/crates/backend-uzu/tests/unit/encodable_block/moe/moe_block_validation_test.rs
+++ b/crates/backend-uzu/tests/unit/encodable_block/moe/moe_block_validation_test.rs
@@ -1,0 +1,88 @@
+use std::io::Write;
+
+use proc_macros::uzu_test;
+use serde_json::{Value, json};
+use tempfile::NamedTempFile;
+
+use super::super::{MoeBlock, MoeBlockError};
+use crate::{
+    backends::{
+        common::{Backend, Context},
+        cpu::Cpu,
+    },
+    config::mlp::mixture_of_experts::MixtureOfExpertsConfig,
+    data_type::DataType,
+    parameters::ParameterLoader,
+};
+
+fn config(
+    routed_experts: u32,
+    active_experts: u32,
+) -> MixtureOfExpertsConfig {
+    serde_json::from_value(json!({
+        "type": "MixtureOfExpertsConfig",
+        "expert_config": {
+            "type": "DenseMLPConfig",
+            "linear_config": {},
+            "activation": { "type": "SiLU", "alpha": 1.0 },
+            "has_up_biases": true,
+            "has_down_biases": true,
+            "gate_clipping": null,
+            "up_clipping": null
+        },
+        "router_config": {},
+        "routing_function": { "type": "SoftmaxRouting" },
+        "num_routed_experts": routed_experts,
+        "num_active_routed_experts": active_experts,
+        "router_has_biases": true,
+        "num_shared_experts": 0,
+        "expert_hidden_dim": 32,
+        "gate_config": null
+    }))
+    .expect("valid test configuration")
+}
+
+fn empty_parameter_file() -> NamedTempFile {
+    let mut header = serde_json::to_vec(&Value::Object(Default::default())).expect("serialize parameter header");
+    header.extend(std::iter::repeat_n(b' ', (8 - header.len() % 8) % 8));
+
+    let mut file = NamedTempFile::new().expect("create parameter file");
+    file.write_all(&(header.len() as u64).to_le_bytes()).expect("write header length");
+    file.write_all(&header).expect("write header");
+    file
+}
+
+fn constructor_error(
+    routed_experts: u32,
+    active_experts: u32,
+) -> MoeBlockError<Cpu> {
+    let context = <Cpu as Backend>::Context::new().expect("create CPU context");
+    let file = empty_parameter_file();
+    let loader =
+        ParameterLoader::<Cpu>::new_random(file.as_file(), context.as_ref(), 0).expect("load empty parameter file");
+
+    match MoeBlock::<Cpu>::new(
+        context.as_ref(),
+        &config(routed_experts, active_experts),
+        16,
+        DataType::BF16,
+        &loader.tree(),
+    ) {
+        Ok(_) => panic!("invalid expert counts were accepted"),
+        Err(error) => error,
+    }
+}
+
+#[uzu_test]
+fn rejects_invalid_routed_expert_counts() {
+    for routed_experts in [0, 513] {
+        assert!(matches!(constructor_error(routed_experts, 1), MoeBlockError::InvalidRoutedExpertCount));
+    }
+}
+
+#[uzu_test]
+fn rejects_invalid_active_expert_counts() {
+    for (routed_experts, active_experts) in [(1, 0), (1, 2), (512, 129)] {
+        assert!(matches!(constructor_error(routed_experts, active_experts), MoeBlockError::InvalidActiveExpertCount));
+    }
+}


### PR DESCRIPTION
MoE routing uses fixed threadgroup storage for expert logits, TopK selection, and model input caching. This change centralizes those limits across Rust and Metal and rejects configurations that exceed them before parameter loading or dispatch.

It also validates nonzero expert dimensions, checked hidden-width expansion, and route-count arithmetic without changing the existing MoE execution pipeline.