### PR TITLE
Qmm / M Align Tile

### DIFF
--- a/crates/backend-uzu/src/backends/metal/kernel/matmul/gemm/kernel.rs
+++ b/crates/backend-uzu/src/backends/metal/kernel/matmul/gemm/kernel.rs
@@ -21,6 +21,7 @@ use crate::{
         metal::{
             Metal,
             context::MetalContext,
+            device_profile::DeviceProfile,
             error::MetalError,
             kernel::{GemmMetalKernel, GemmSplitKReduceMetalKernel, TensorAddBiasMetalKernel},
         },
@@ -109,8 +110,9 @@ impl GemmKernel {
         &self,
         shape: MatmulShape,
         supports_mxu: bool,
+        profile: DeviceProfile,
     ) -> GemmProblem {
-        GemmProblem::new(shape, self.weights_data_type, self.output_data_type, supports_mxu)
+        GemmProblem::new(shape, self.weights_data_type, self.output_data_type, supports_mxu, profile)
     }
 
     #[cfg(test)]
@@ -120,7 +122,7 @@ impl GemmKernel {
         engine: GemmEngine,
         context: &MetalContext,
     ) -> Result<GemmPlan, MetalError> {
-        self.problem(*shape, context.supports_mxu())
+        self.problem(*shape, context.supports_mxu(), context.device_profile())
             .select_plan_for_engine(engine)
             .map_err(|error| MetalError::KernelDispatchFailed(Box::new(error)))
     }
@@ -144,7 +146,7 @@ impl GemmKernel {
         encoder: &mut Encoder<Metal>,
     ) -> Result<(), MetalError> {
         let shape = MatmulShape::from_arguments(&arguments);
-        self.problem(shape, encoder.context().supports_mxu())
+        self.problem(shape, encoder.context().supports_mxu(), encoder.context().device_profile())
             .validate_engine(plan.engine)
             .map_err(|error| MetalError::KernelDispatchFailed(Box::new(error)))?;
 

--- a/crates/backend-uzu/src/backends/metal/kernel/matmul/gemm/policy.rs
+++ b/crates/backend-uzu/src/backends/metal/kernel/matmul/gemm/policy.rs
@@ -4,7 +4,10 @@
 //! features to choices. Eligibility, fallbacks, and legality stay in
 //! `selection.rs`.
 
-use crate::backends::common::gpu_types::gemm::GemmTiling;
+use crate::backends::{
+    common::gpu_types::gemm::GemmTiling,
+    metal::device_profile::{DeviceGeneration, DeviceProfile},
+};
 
 pub(super) const MXU_DEFAULT_TILE: GemmTiling = GemmTiling::Tile64x64x256_Simdgroups2x2;
 
@@ -20,6 +23,7 @@ const MXU_M_BUCKET_MAXES: [u32; 4] = [16, 63, 255, 511];
 const MXU_N_BUCKET_MAXES: [u32; 2] = [63, 127];
 
 const SIMDGROUP_QUANT_SMALL_M_MAX: u32 = 32;
+const SIMDGROUP_QUANT_NARROW_BLOCK_M: u32 = 8;
 const SIMDGROUP_QUANT_LARGE_M_MIN: u32 = 64;
 const SIMDGROUP_QUANT_WIDE_N_MIN: u32 = 6144;
 
@@ -95,15 +99,29 @@ pub(super) fn simdgroup_fp_tile(
     }
 }
 
+/// A partial trailing M block costs a second pass over the weights. Older GPUs are bound by that;
+/// Apple9 and newer would rather keep the narrow tile's parallelism.
+fn prefers_wide_partial_m_tile(profile: DeviceProfile) -> bool {
+    matches!(profile.generation(), DeviceGeneration::Legacy | DeviceGeneration::Apple8)
+}
+
 pub(super) fn simdgroup_quant_tile(
     m: u32,
     n: u32,
     group_size: u32,
+    profile: DeviceProfile,
 ) -> GemmTiling {
     if group_size < 32 {
         GemmTiling::Tile64x64x16_Simdgroups2x2
     } else if m < SIMDGROUP_QUANT_SMALL_M_MAX {
-        GemmTiling::Tile8x32x32_Simdgroups1x1
+        if !prefers_wide_partial_m_tile(profile)
+            || m <= SIMDGROUP_QUANT_NARROW_BLOCK_M
+            || m.is_multiple_of(SIMDGROUP_QUANT_NARROW_BLOCK_M)
+        {
+            GemmTiling::Tile8x32x32_Simdgroups1x1
+        } else {
+            GemmTiling::Tile32x32x32_Simdgroups2x2
+        }
     } else if m >= SIMDGROUP_QUANT_LARGE_M_MIN && n >= SIMDGROUP_QUANT_WIDE_N_MIN && n.is_multiple_of(64) {
         GemmTiling::Tile64x64x32_Simdgroups2x2
     } else {

--- a/crates/backend-uzu/src/backends/metal/kernel/matmul/gemm/selection.rs
+++ b/crates/backend-uzu/src/backends/metal/kernel/matmul/gemm/selection.rs
@@ -2,9 +2,12 @@ use thiserror::Error;
 
 use super::{GemmEngine, GemmPlan, policy};
 use crate::{
-    backends::common::{
-        gpu_types::gemm::{GemmBPrologueKind, GemmTiling},
-        kernel::{activation_transform::ACTIVATION_SCALE_GROUP_SIZE, matmul::MatmulShape},
+    backends::{
+        common::{
+            gpu_types::gemm::{GemmBPrologueKind, GemmTiling},
+            kernel::{activation_transform::ACTIVATION_SCALE_GROUP_SIZE, matmul::MatmulShape},
+        },
+        metal::device_profile::DeviceProfile,
     },
     data_type::DataType,
 };
@@ -15,6 +18,7 @@ pub struct GemmProblem {
     weights_data_type: DataType,
     output_data_type: DataType,
     supports_mxu: bool,
+    profile: DeviceProfile,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Error)]
@@ -31,12 +35,14 @@ impl GemmProblem {
         weights_data_type: DataType,
         output_data_type: DataType,
         supports_mxu: bool,
+        profile: DeviceProfile,
     ) -> Self {
         Self {
             shape,
             weights_data_type,
             output_data_type,
             supports_mxu,
+            profile,
         }
     }
 
@@ -46,7 +52,7 @@ impl GemmProblem {
         } else {
             GemmEngine::Simdgroup
         };
-        self.finish_plan(engine, select_tiling(self.shape, engine))
+        self.finish_plan(engine, select_tiling(self.shape, engine, self.profile))
     }
 
     #[cfg(test)]
@@ -55,7 +61,7 @@ impl GemmProblem {
         engine: GemmEngine,
     ) -> Result<GemmPlan, GemmPlanError> {
         self.validate_engine(engine)?;
-        Ok(self.finish_plan(engine, select_tiling(self.shape, engine)))
+        Ok(self.finish_plan(engine, select_tiling(self.shape, engine, self.profile)))
     }
 
     pub(super) fn validate_engine(
@@ -160,10 +166,11 @@ fn mxu_is_eligible(shape: MatmulShape) -> bool {
 fn select_tiling(
     shape: MatmulShape,
     engine: GemmEngine,
+    profile: DeviceProfile,
 ) -> GemmTiling {
     match engine {
         GemmEngine::Simdgroup if shape.is_quant() => {
-            policy::simdgroup_quant_tile(shape.m, shape.n, shape.b_group_size.unwrap_or(0))
+            policy::simdgroup_quant_tile(shape.m, shape.n, shape.b_group_size.unwrap_or(0), profile)
         },
         GemmEngine::Simdgroup => policy::simdgroup_fp_tile(shape.m, shape.n, shape.k),
         GemmEngine::Mxu if !shape.a_full_precision || shape.is_quant() => select_mxu_quant_tiling(shape),

--- a/crates/backend-uzu/src/backends/metal/kernel/matmul/mod.rs
+++ b/crates/backend-uzu/src/backends/metal/kernel/matmul/mod.rs
@@ -76,7 +76,13 @@ impl MatmulMetalKernel {
             self.output_data_type,
             context.device_profile(),
         );
-        let problem = GemmProblem::new(*shape, self.weights_data_type, self.output_data_type, context.supports_mxu());
+        let problem = GemmProblem::new(
+            *shape,
+            self.weights_data_type,
+            self.output_data_type,
+            context.supports_mxu(),
+            context.device_profile(),
+        );
         let plan = problem.select_plan();
         match gemv {
             None => MatmulDispatch::Gemm(plan),

--- a/crates/backend-uzu/src/tests/matmul/shape.rs
+++ b/crates/backend-uzu/src/tests/matmul/shape.rs
@@ -58,7 +58,8 @@ pub fn bench_quant_gemm_shapes(bits: u32) -> impl Iterator<Item = Shape> {
     } else {
         256
     };
-    let ms = &[4u32, 5, 6, 7, 8, 16, 32, 48, 64];
+    // The tile policy only differs for m that is not a multiple of 8, so keep 4..16 contiguous.
+    let ms = &[4u32, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 32, 48, 64];
     BENCH_NK
         .iter()
         .filter(move |&&(n, k)| n % 32 == 0 && k % block_size == 0)

--- a/crates/backend-uzu/tests/unit/backends/metal/kernel/matmul/gemm/selection_test.rs
+++ b/crates/backend-uzu/tests/unit/backends/metal/kernel/matmul/gemm/selection_test.rs
@@ -3,8 +3,14 @@ use proc_macros::uzu_test;
 use super::{super::specialization::GemmSpecialization, *};
 use crate::backends::{
     common::gpu_types::gemm::{GemmAPrologueKind, GemmAlignment, GemmDTransform},
-    metal::kernel::matmul::MatmulMetalKernel,
+    metal::{
+        device_profile::{DeviceGeneration, DeviceProfile},
+        kernel::matmul::MatmulMetalKernel,
+    },
 };
+
+const LEGACY_PROFILE: DeviceProfile = DeviceProfile::new(8, DeviceGeneration::Legacy);
+const APPLE9_PROFILE: DeviceProfile = DeviceProfile::new(10, DeviceGeneration::Apple9);
 
 fn shape(
     m: u32,
@@ -39,7 +45,7 @@ fn problem(
     shape: MatmulShape,
     output_data_type: DataType,
 ) -> GemmProblem {
-    GemmProblem::new(shape, DataType::BF16, output_data_type, true)
+    GemmProblem::new(shape, DataType::BF16, output_data_type, true, LEGACY_PROFILE)
 }
 
 fn plan(split_k: u32) -> GemmPlan {
@@ -78,11 +84,24 @@ fn policy_boundaries_are_preserved() {
 
     for (m, n, group_size, expected) in [
         (16, 4096, 31, Tile64x64x16_Simdgroups2x2),
-        (31, 4096, 32, Tile8x32x32_Simdgroups1x1),
+        // Full M blocks keep the narrow tile.
+        (4, 4096, 32, Tile8x32x32_Simdgroups1x1),
+        (8, 4096, 32, Tile8x32x32_Simdgroups1x1),
+        (16, 4096, 32, Tile8x32x32_Simdgroups1x1),
+        (24, 4096, 32, Tile8x32x32_Simdgroups1x1),
+        // A partial trailing block takes the wide tile.
+        (9, 4096, 32, Tile32x32x32_Simdgroups2x2),
+        (15, 4096, 32, Tile32x32x32_Simdgroups2x2),
+        (31, 4096, 32, Tile32x32x32_Simdgroups2x2),
         (64, 6143, 32, Tile32x32x32_Simdgroups2x2),
         (64, 6144, 32, Tile64x64x32_Simdgroups2x2),
     ] {
-        assert_eq!(policy::simdgroup_quant_tile(m, n, group_size), expected);
+        assert_eq!(policy::simdgroup_quant_tile(m, n, group_size, LEGACY_PROFILE), expected);
+    }
+
+    // Apple9 and newer keep the narrow tile regardless.
+    for m in [9, 15, 31] {
+        assert_eq!(policy::simdgroup_quant_tile(m, 4096, 32, APPLE9_PROFILE), Tile8x32x32_Simdgroups1x1);
     }
 }
 
@@ -110,7 +129,7 @@ fn selection_fallbacks_and_split_k_are_preserved() {
     let mut biased = quant(shape(16, 4096, 4096));
     biased.a_full_precision = false;
     biased.d_transform = GemmDTransform::BIAS;
-    assert_eq!(GemmProblem::new(biased, DataType::BF16, DataType::F32, true).select_plan().split_k, 1);
+    assert_eq!(GemmProblem::new(biased, DataType::BF16, DataType::F32, true, LEGACY_PROFILE).select_plan().split_k, 1);
 
     let mut zero = quant(shape(0, 1, 1));
     zero.b_prologue = GemmBPrologueKind::ScaleZeroPointDequant;
@@ -122,7 +141,8 @@ fn selection_fallbacks_and_split_k_are_preserved() {
 fn forced_engine_errors_are_preserved() {
     let huge = shape(u32::MAX, u32::MAX, u32::MAX);
     assert_eq!(
-        GemmProblem::new(huge, DataType::BF16, DataType::BF16, false).select_plan_for_engine(GemmEngine::Mxu),
+        GemmProblem::new(huge, DataType::BF16, DataType::BF16, false, LEGACY_PROFILE)
+            .select_plan_for_engine(GemmEngine::Mxu),
         Err(GemmPlanError::MxuUnavailable)
     );
 
@@ -167,7 +187,7 @@ fn gemv_gemm_route_boundaries_are_preserved() {
         (shape(3, 4096, 8192), DataType::BF16, false),
         (shape(5, 4096, 8192), DataType::BF16, false),
     ] {
-        let plan = GemmProblem::new(shape, data_type, data_type, true).select_plan();
+        let plan = GemmProblem::new(shape, data_type, data_type, true, LEGACY_PROFILE).select_plan();
         assert_eq!(MatmulMetalKernel::prefer_gemm_over_gemv(shape, plan, data_type, data_type, data_type), prefer_gemm);
     }
     let mut gathered = shape(4, 4096, 8192);


### PR DESCRIPTION
Use a 32-row tile instead of 8-row to eliminate trailing blocks.

In main branch:

1. [**Small batches pick the 8-row tile**](https://github.com/trymirai/uzu/blob/4d93248a02f3927a6ee3679ef9fd01fa8890f04e/crates/backend-uzu/src/backends/metal/kernel/matmul/gemm/policy.rs#L105)
2. [**That tile's M block is 8 rows**](https://github.com/trymirai/uzu/blob/4d93248a02f3927a6ee3679ef9fd01fa8890f04e/crates/backend-uzu/src/backends/common/gpu_types/gemm.rs#L54)
3. [**One threadgroup per M block**](https://github.com/trymirai/uzu/blob/4d93248a02f3927a6ee3679ef9fd01fa8890f04e/crates/backend-uzu/src/backends/metal/kernel/matmul/gemm/kernel.rs#L370)

So `m=8 → 1`, `m=9 → 2` which is doubling.

[**Every one of those threadgroups reads the same weights**](https://github.com/trymirai/uzu/blob/4d93248a02f3927a6ee3679ef9fd01fa8890f04e/crates/backend-uzu/src/backends/metal/kernel/matmul/gemm/common/schedules/staged.h#L36)

Benches vs main

## m1

| shape | M | before | after |
|---|---:|---:|---:|
| K2048 N2048 | 9 | 1.36 ms | 1.46 ms |
|  | 10 | 1.37 ms | 1.48 ms |
|  | 11 | 1.36 ms | 1.41 ms |
|  | 12 | 1.39 ms | 1.40 ms |
|  | 13 | 1.36 ms | 1.28 ms |
|  | 14 | 1.39 ms | 1.34 ms |
|  | 15 | 1.40 ms | 1.55 ms |
| K4096 N2048 | 9 | 2.63 ms | 1.69 ms |
|  | 10 | 2.64 ms | 2.13 ms |
|  | 11 | 2.67 ms | 1.50 ms |
|  | 12 | 2.58 ms | 1.60 ms |
|  | 13 | 2.47 ms | 1.37 ms |
|  | 14 | 2.44 ms | 1.41 ms |
|  | 15 | 2.38 ms | 1.29 ms |
| K4096 N4096 | 9 | 5.16 ms | 2.22 ms |
|  | 10 | 5.09 ms | 2.18 ms |
|  | 11 | 4.10 ms | 3.78 ms |
|  | 12 | 5.90 ms | 2.84 ms |
|  | 13 | 5.81 ms | 2.77 ms |
|  | 14 | 5.87 ms | 2.51 ms |
|  | 15 | 5.74 ms | 2.65 ms |
| K4096 N14336 | 9 | 17.57 ms | 8.74 ms |
|  | 10 | 9.51 ms | 8.98 ms |
|  | 11 | 17.61 ms | 8.22 ms |
|  | 12 | 15.91 ms | 8.51 ms |
|  | 13 | 17.05 ms | 4.92 ms |
|  | 14 | 17.29 ms | 7.85 ms |
|  | 15 | 16.99 ms | 7.80 ms |
| K14336 N4096 | 9 | 16.92 ms | 9.37 ms |
|  | 10 | 16.69 ms | 8.55 ms |
|  | 11 | 17.43 ms | 8.91 ms |
|  | 12 | 16.95 ms | 4.75 ms |
|  | 13 | 17.13 ms | 7.94 ms |
|  | 14 | 17.28 ms | 7.84 ms |
|  | 15 | 15.68 ms | 7.76 ms |
| K14336 N14336 | 9 | 47.77 ms | 25.66 ms |
|  | 10 | 48.21 ms | 22.80 ms |
|  | 11 | 48.10 ms | 22.33 ms |
|  | 12 | 47.82 ms | 21.19 ms |
|  | 13 | 47.51 ms | 21.18 ms |
|  | 14 | 48.65 ms | 20.70 ms |
|  | 15 | 47.58 ms | 21.12 ms |

## m2

| shape | M | before | after |
|---|---:|---:|---:|
| K2048 N2048 | 9 | 0.93 ms | 0.51 ms |
|  | 10 | 0.93 ms | 0.49 ms |
|  | 11 | 0.75 ms | 0.55 ms |
|  | 12 | 0.83 ms | 0.48 ms |
|  | 13 | 0.84 ms | 0.54 ms |
|  | 14 | 0.74 ms | 0.34 ms |
|  | 15 | 0.73 ms | 0.46 ms |
| K4096 N2048 | 9 | 1.56 ms | 1.80 ms |
|  | 10 | 1.61 ms | 1.83 ms |
|  | 11 | 1.46 ms | 1.78 ms |
|  | 12 | 1.53 ms | 1.84 ms |
|  | 13 | 1.70 ms | 1.67 ms |
|  | 14 | 1.00 ms | 1.48 ms |
|  | 15 | 2.11 ms | 1.62 ms |
| K4096 N4096 | 9 | 5.73 ms | 2.59 ms |
|  | 10 | 5.64 ms | 2.54 ms |
|  | 11 | 5.58 ms | 2.62 ms |
|  | 12 | 5.57 ms | 2.52 ms |
|  | 13 | 5.76 ms | 2.56 ms |
|  | 14 | 5.62 ms | 2.66 ms |
|  | 15 | 5.59 ms | 2.60 ms |
| K4096 N14336 | 9 | 11.29 ms | 5.99 ms |
|  | 10 | 13.13 ms | 6.10 ms |
|  | 11 | 13.70 ms | 5.65 ms |
|  | 12 | 13.63 ms | 5.95 ms |
|  | 13 | 13.68 ms | 6.12 ms |
|  | 14 | 14.01 ms | 5.72 ms |
|  | 15 | 13.82 ms | 5.79 ms |
| K14336 N4096 | 9 | 14.10 ms | 6.74 ms |
|  | 10 | 14.49 ms | 4.45 ms |
|  | 11 | 14.13 ms | 5.44 ms |
|  | 12 | 12.72 ms | 5.58 ms |
|  | 13 | 10.84 ms | 5.52 ms |
|  | 14 | 10.90 ms | 5.70 ms |
|  | 15 | 11.02 ms | 5.35 ms |
| K14336 N14336 | 9 | 50.75 ms | 20.29 ms |
|  | 10 | 47.50 ms | 19.61 ms |
|  | 11 | 48.43 ms | 20.46 ms |
|  | 12 | 49.74 ms | 19.28 ms |
|  | 13 | 49.74 ms | 20.04 ms |
|  | 14 | 51.50 ms | 20.12 ms |
|  | 15 | 33.84 ms | 20.03 ms |

## m2-pro

| shape | M | before | after |
|---|---:|---:|---:|
| K2048 N2048 | 9 | 0.38 ms | 0.32 ms |
|  | 10 | 0.38 ms | 0.27 ms |
|  | 11 | 0.38 ms | 0.34 ms |
|  | 12 | 0.38 ms | 0.34 ms |
|  | 13 | 0.38 ms | 0.08 ms |
|  | 14 | 0.38 ms | 0.33 ms |
|  | 15 | 0.38 ms | 0.30 ms |
| K4096 N2048 | 9 | 0.77 ms | 0.25 ms |
|  | 10 | 0.77 ms | 0.25 ms |
|  | 11 | 0.77 ms | 0.25 ms |
|  | 12 | 0.77 ms | 0.25 ms |
|  | 13 | 0.77 ms | 0.25 ms |
|  | 14 | 0.77 ms | 0.25 ms |
|  | 15 | 0.78 ms | 0.25 ms |
| K4096 N4096 | 9 | 1.53 ms | 0.48 ms |
|  | 10 | 1.54 ms | 0.48 ms |
|  | 11 | 1.54 ms | 0.48 ms |
|  | 12 | 1.54 ms | 0.48 ms |
|  | 13 | 1.54 ms | 0.48 ms |
|  | 14 | 1.54 ms | 0.48 ms |
|  | 15 | 1.54 ms | 0.48 ms |
| K4096 N14336 | 9 | 4.69 ms | 1.55 ms |
|  | 10 | 5.27 ms | 1.55 ms |
|  | 11 | 5.29 ms | 1.55 ms |
|  | 12 | 5.12 ms | 1.55 ms |
|  | 13 | 4.74 ms | 1.55 ms |
|  | 14 | 5.24 ms | 1.55 ms |
|  | 15 | 5.24 ms | 1.55 ms |
| K14336 N4096 | 9 | 5.62 ms | 1.64 ms |
|  | 10 | 5.63 ms | 1.64 ms |
|  | 11 | 5.63 ms | 1.64 ms |
|  | 12 | 5.64 ms | 1.64 ms |
|  | 13 | 5.64 ms | 1.64 ms |
|  | 14 | 5.64 ms | 1.64 ms |
|  | 15 | 5.65 ms | 1.64 ms |
| K14336 N14336 | 9 | 17.66 ms | 5.53 ms |
|  | 10 | 19.12 ms | 5.52 ms |
|  | 11 | 18.50 ms | 5.52 ms |
|  | 12 | 17.80 ms | 5.52 ms |
|  | 13 | 19.67 ms | 5.53 ms |
|  | 14 | 19.34 ms | 5.53 ms |
|  | 15 | 19.50 ms | 5.53 ms |


Cryterion raw results

[bench-m-align.zip](https://github.com/user-attachments/files/31228113/bench-m-align.zip)
