### PR TITLE
handle missing pending seed token

### DIFF
--- a/crates/backend-uzu/src/engine/language_model/stream/stream.rs
+++ b/crates/backend-uzu/src/engine/language_model/stream/stream.rs
@@ -343,9 +343,12 @@ impl<'a, B: Backend> LanguageModelStream<'a, B> {
                 output_tokens: output_tokens.unwrap(),
             })
         } else {
+            let Some(seed_token) = model_state.last_output_token.take() else {
+                return Err(LanguageModelStreamError::NoSeedToken);
+            };
             // TODO: this leaks previous LanguageModelStreamOptions
             DecodingState::Seeded {
-                seed_token: model_state.last_output_token.take().unwrap(),
+                seed_token,
             }
         };
 


### PR DESCRIPTION
The current guard in `stream.rs` above

```rust
if model_state.tokens.is_empty() && input.is_empty() {
     return Err(LanguageModelStreamError::NoSeedToken);
};
```

only handles a completely new session state with no previous tokens and no new input.

It does not cover the case where the model state already **contains tokens** but the pending `last_output_token` is None between the streams.


```text
Stream #1, generate() N
→ sets Halted (reaches max context)
→ returns the last token

Stream #1, generate() N+1
→ sees Halted
→ returns None
→ stream ends

Stream #1 goes out of scope
→ NO last_output_token

then:

Stream #2 tries to continue (with empty input)
→ tries to take last_output_token
→ gets None (from previous stream)
→ calls unwrap()
→ panic
```

In `stream.rs`

the code assumes that continuation **with empty input** always has a pending token

```rust
model_state.last_output_token.take().unwrap()
```

But after `Halted` (or Invalid)  that may not be true

```text
last_output_token = None
```

And `LanguageModelStreamError::NoSeedToken` already exists (so we can return that error rather than panic.)
