### PR TITLE
fix grammar leak across streams

### DIFF
--- a/crates/backend-uzu/src/engine/language_model/grammar/config.rs
+++ b/crates/backend-uzu/src/engine/language_model/grammar/config.rs
@@ -1,6 +1,6 @@
 use schemars::JsonSchema;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum GrammarConfig {
     JsonSchema {
         schema: String,

--- a/crates/backend-uzu/src/engine/language_model/grammar/mod.rs
+++ b/crates/backend-uzu/src/engine/language_model/grammar/mod.rs
@@ -19,6 +19,7 @@ pub struct Grammar {
     vocab_size: usize,
     matcher: GrammarMatcher,
     engagement_state: GrammarEngagementState,
+    config: GrammarConfig,
 }
 
 #[derive(Debug, Error)]
@@ -85,6 +86,7 @@ impl Grammar {
             vocab_size,
             matcher,
             engagement_state,
+            config: config.clone(),
         })
     }
 }
@@ -148,6 +150,10 @@ impl Grammar {
         if num_grammar_tokens > 0 {
             self.matcher.rollback(num_grammar_tokens as i32);
         }
+    }
+
+    pub fn config(&self) -> &GrammarConfig {
+        &self.config
     }
 
     pub fn is_terminated(&self) -> bool {

--- a/crates/backend-uzu/src/engine/language_model/state.rs
+++ b/crates/backend-uzu/src/engine/language_model/state.rs
@@ -1,18 +1,28 @@
 use thiserror::Error;
 
+#[cfg(grammar)]
+use crate::engine::language_model::grammar::GrammarConfig;
 use crate::{
     backends::common::Backend,
     encodable_block::{dflash::DFlashState, sampling::PRng, transformer::TransformerState},
     engine::language_model::LanguageModel,
 };
 
+pub(super) struct PendingOutput {
+    pub(super) token: u64,
+    #[cfg(grammar)]
+    pub(super) grammar: Option<GrammarConfig>,
+}
+
 pub struct LanguageModelState<B: Backend> {
     pub(super) tokens: Vec<u64>,
-    pub(super) last_output_token: Option<u64>, // TODO: this leaks previous LanguageModelStreamOptions
+    pub(super) last_output: Option<PendingOutput>,
     pub(super) prng: PRng,
     pub(super) transformer_state: TransformerState<B>,
     pub(super) speculator_state: Option<DFlashState<B>>,
     pub(super) max_context_length: Option<u32>,
+    #[cfg(grammar)]
+    pub(super) grammar_start: usize,
 }
 
 impl<B: Backend> LanguageModelState<B> {
@@ -33,7 +43,7 @@ impl<B: Backend> LanguageModel<B> {
         max_context_length: Option<u32>,
     ) -> Result<LanguageModelState<B>, LanguageModelCreateEmptyStateError<B>> {
         let tokens = Vec::new();
-        let last_output_token = None;
+        let last_output = None;
 
         let prng = PRng::new(rand::random());
 
@@ -52,8 +62,10 @@ impl<B: Backend> LanguageModel<B> {
             .map_err(LanguageModelCreateEmptyStateError::Backend)?;
 
         Ok(LanguageModelState {
+            #[cfg(grammar)]
+            grammar_start: tokens.len(),
             tokens,
-            last_output_token,
+            last_output,
             prng,
             transformer_state,
             speculator_state,

--- a/crates/backend-uzu/src/engine/language_model/stream/mod.rs
+++ b/crates/backend-uzu/src/engine/language_model/stream/mod.rs
@@ -35,6 +35,8 @@ pub enum LanguageModelStreamError<B: Backend> {
     Speculator(#[from] DFlashTreeError<B>),
     #[error("No seed token (both state and input are empty)")]
     NoSeedToken,
+    #[error("Incompatible pending output (sampled under a different grammar)")]
+    IncompatiblePendingOutput,
     #[error("Context overflow")]
     ContextOverflow,
 }

--- a/crates/backend-uzu/src/engine/language_model/stream/stream.rs
+++ b/crates/backend-uzu/src/engine/language_model/stream/stream.rs
@@ -20,7 +20,7 @@ use crate::{
         capture::CaptureSpan,
         language_model::{
             LanguageModel,
-            state::LanguageModelState,
+            state::{LanguageModelState, PendingOutput},
             stream::{LanguageModelStreamError, LanguageModelStreamOptions},
         },
     },
@@ -188,7 +188,11 @@ impl<'a, B: Backend> LanguageModelStream<'a, B> {
         let mut metrics = TokenStreamMetrics::default();
 
         let decoding_state = if !input.is_empty() {
-            model_state.last_output_token.take();
+            model_state.last_output.take();
+            #[cfg(grammar)]
+            {
+                model_state.grammar_start = model_state.tokens.len() + input.len();
+            }
 
             // NOTE: this is required for attention correctness (hardcoded suffix 1024). This is really bad design, attention should be rewritten to allow on-demand suffix length
             let max_batch_size = 1024;
@@ -343,9 +347,20 @@ impl<'a, B: Backend> LanguageModelStream<'a, B> {
                 output_tokens: output_tokens.unwrap(),
             })
         } else {
-            // TODO: this leaks previous LanguageModelStreamOptions
+            let pending = model_state.last_output.take().unwrap();
+            #[cfg(grammar)]
+            match (&pending.grammar, options.grammar.as_ref().map(Grammar::config)) {
+                (old, Some(new)) if old.as_ref() == Some(new) => {
+                    let grammar = options.grammar.as_mut().unwrap();
+                    for &token in &model_state.tokens[model_state.grammar_start..] {
+                        grammar.accept_token(token)?;
+                    }
+                },
+                (_, Some(_)) => return Err(LanguageModelStreamError::IncompatiblePendingOutput),
+                (_, None) => {},
+            }
             DecodingState::Seeded {
-                seed_token: model_state.last_output_token.take().unwrap(),
+                seed_token: pending.token,
             }
         };
 
@@ -796,7 +811,7 @@ impl<'a, B: Backend> Iterator for LanguageModelStream<'a, B> {
 
 impl<'a, B: Backend> Drop for LanguageModelStream<'a, B> {
     fn drop(&mut self) {
-        let last_output_token = match replace(&mut self.decoding_state, DecodingState::Invalid) {
+        let last_output = match replace(&mut self.decoding_state, DecodingState::Invalid) {
             DecodingState::Seeded {
                 seed_token,
             } => Some(seed_token),
@@ -868,6 +883,10 @@ impl<'a, B: Backend> Drop for LanguageModelStream<'a, B> {
             DecodingState::Invalid => None, // TODO: proper error handling
         };
 
-        self.model_state.last_output_token = last_output_token;
+        self.model_state.last_output = last_output.map(|token| PendingOutput {
+            token,
+            #[cfg(grammar)]
+            grammar: self.options.grammar.as_ref().map(|grammar| grammar.config().clone()),
+        });
     }
 }


### PR DESCRIPTION
This PR tries to fix:

```rust
  // TODO: this leaks previous LanguageModelStreamOptions
  ```
  
The current issue is that a pending `output token` in `stream.rs` can cross a stream boundary even when the new stream uses a different grammar.

```text
Stream #1
grammar = text / None
→ pending token = "history"

Stream #2
grammar = JSON
→ inherits "history" - very first token is printed with the Stream #1 grammar 
→ then continues under JSON grammar

Result:
history{"name":"Bob"} - WRONG
```

A stream with a grammar should only return output that matches that grammar.

`history{"name":"Bob"}` is invalid JSON because the first token was sampled using the **previous stream**'s grammar config. (the first token was cooked using the old grammar)

Now: 

```text
same grammar config
→ replay committed tokens into the new Grammar matcher
→ continue

input is empty
→ pending output exists?
   compare grammars

or maybe new stream has no grammar
→ continue normally
```

Sampling method differences are intentionally not treated as incompatible here. this PR only addresses grammar correctness.
