### PR TITLE
Fix QuantInput packed-weight allocation overflow

### DIFF
--- a/crates/uzu-engine/unit/common/matmul/quant.rs
+++ b/crates/uzu-engine/unit/common/matmul/quant.rs
@@ -67,7 +67,8 @@ impl<T: ArrayElement + Float> QuantInput<T> {
         let num_groups_k = k.div_ceil(group_size);
         let mut rng = SmallRng::seed_from_u64(seed);
 
-        let w_packed: Vec<u32> = (0..(n * k * bits / 32) as usize).map(|_| rng.random_range(0..u32::MAX)).collect();
+        let w_packed: Vec<u32> =
+            (0..(n as usize * k as usize * bits as usize / 32)).map(|_| rng.random_range(0..u32::MAX)).collect();
         let scales: Vec<T> =
             (0..(n * num_groups_k) as usize).map(|_| T::from(rng.random_range(0.01f32..0.3f32)).unwrap()).collect();
         let x: Vec<T> = (0..(m * k) as usize).map(|_| T::from(rng.random_range(-0.3f32..0.3f32)).unwrap()).collect();


### PR DESCRIPTION
Widen n * k * bits to usize before computing the packed length: at lm_head scale (248320x5120, 4-bit = 5.09e9 bits) the u32 product wraps and silently truncates the weight buffer to 99 MB of the expected 636 MB.