### PR TITLE
Bound tool-call test generations

### DIFF
--- a/crates/legacy/uzu/tests/tool/calls.rs
+++ b/crates/legacy/uzu/tests/tool/calls.rs
@@ -129,6 +129,8 @@ async fn run_tool_calls_test(
         // the models occasionally skip a tool call, hallucinate that part of the answer, or
         // finish without any text in the final reply.
         let reply_config = ChatReplyConfig {
+            // Bound malformed generations so a missing stop token fails instead of running to the context limit.
+            token_limit: Some(256),
             sampling_policy: SamplingPolicy::Custom {
                 method: SamplingMethod::Greedy {},
             },


### PR DESCRIPTION
Tool-call integration tests currently leave their per-turn generation budget unset. A malformed response that never emits its stop token can therefore decode toward the model context limit and make cargo test appear hung.

This caps each generation at 256 tokens. Correct short tool conversations are unchanged; missing-stop regressions now return Length and fail the existing Stop assertion promptly.

Validation:
- cargo +nightly fmt --check
- cargo +nightly clippy -p uzu --test tool -- -D warnings
- On the reproducing host, calls::qwen3_5_0_8b now reaches the new limit and reports the offending third prompt in 10.96 seconds instead of continuing indefinitely.