### PR TITLE
Add dense Metal GEMV and GEMM for MXFP4

### DIFF
--- a/crates/uzu-engine/Cargo.toml
+++ b/crates/uzu-engine/Cargo.toml
@@ -84,6 +84,7 @@ xgrammar = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 
 [dev-dependencies]
+tempfile.workspace = true
 test-tag.workspace = true
 proptest.workspace = true
 criterion.workspace = true

--- a/crates/uzu-engine/src/backends/common/buffer/arg.rs
+++ b/crates/uzu-engine/src/backends/common/buffer/arg.rs
@@ -19,6 +19,12 @@ impl<'a, B: Backend> BufferArg<'a, B> for &'a dyn Buffer<Backend = B> {
     }
 }
 
+impl<'a, B: Backend> BufferArg<'a, B> for (&'a dyn Buffer<Backend = B>, usize, usize) {
+    fn into_parts(self) -> (&'a dyn Buffer<Backend = B>, usize, usize) {
+        self
+    }
+}
+
 impl<'a, B: Backend, T: BufferArg<'a, B>> BufferArg<'a, B> for (T, usize) {
     fn into_parts(self) -> (&'a dyn Buffer<Backend = B>, usize, usize) {
         let (buffer, offset, length) = self.0.into_parts();

--- a/crates/uzu-engine/src/backends/common/gpu_types/matmul.rs
+++ b/crates/uzu-engine/src/backends/common/gpu_types/matmul.rs
@@ -13,4 +13,5 @@ pub struct GemmParams {
     pub aligned_inner_iterations: u32,
     pub use_morton: bool,
     pub ab_scale: f32,
+    pub soft_cap: f32,
 }

--- a/crates/uzu-engine/src/backends/common/kernel/matmul/error.rs
+++ b/crates/uzu-engine/src/backends/common/kernel/matmul/error.rs
@@ -1,11 +1,7 @@
 use thiserror::Error;
 
 use crate::{
-    backends::common::{
-        Backend,
-        gpu_types::gemm::GemmDTransform,
-        microfloat::{MicrofloatError, MicrofloatFormat},
-    },
+    backends::common::{Backend, gpu_types::gemm::GemmDTransform, microfloat::MicrofloatError},
     data_type::DataType,
 };
 
@@ -28,8 +24,6 @@ pub enum MatmulError<B: Backend> {
     InvalidMicrofloatStorage,
     #[error(transparent)]
     InvalidMicrofloat(#[from] MicrofloatError),
-    #[error("Unsupported microfloat weight format: {0:?}")]
-    UnsupportedMicrofloat(MicrofloatFormat),
     #[error("Incompatible A operand for {path}: {reason}")]
     IncompatibleA {
         path: &'static str,

--- a/crates/uzu-engine/src/backends/common/kernel/matmul/error.rs
+++ b/crates/uzu-engine/src/backends/common/kernel/matmul/error.rs
@@ -1,7 +1,11 @@
 use thiserror::Error;
 
 use crate::{
-    backends::common::{Backend, gpu_types::gemm::GemmDTransform},
+    backends::common::{
+        Backend,
+        gpu_types::gemm::GemmDTransform,
+        microfloat::{MicrofloatError, MicrofloatFormat},
+    },
     data_type::DataType,
 };
 
@@ -20,6 +24,12 @@ pub enum MatmulError<B: Backend> {
     UnsupportedLayout {
         path: &'static str,
     },
+    #[error("Microfloat storage does not match the requested matrix")]
+    InvalidMicrofloatStorage,
+    #[error(transparent)]
+    InvalidMicrofloat(#[from] MicrofloatError),
+    #[error("Unsupported microfloat weight format: {0:?}")]
+    UnsupportedMicrofloat(MicrofloatFormat),
     #[error("Incompatible A operand for {path}: {reason}")]
     IncompatibleA {
         path: &'static str,

--- a/crates/uzu-engine/src/backends/common/kernel/matmul/matmul_b.rs
+++ b/crates/uzu-engine/src/backends/common/kernel/matmul/matmul_b.rs
@@ -2,10 +2,17 @@ use crate::{
     backends::common::{
         Allocation, Backend, BufferArg,
         gpu_types::{QuantizationMode, gemm::GemmBPrologueKind},
-        microfloat::MicrofloatMetadata,
+        microfloat::{MicrofloatFormat, MicrofloatMetadata},
     },
     data_type::DataType,
 };
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MatmulBKind {
+    Dense,
+    Integer,
+    Mxfp4,
+}
 
 pub enum MatmulB<'a, B: Backend, TB: BufferArg<'a, B> = &'a Allocation<B>> {
     FullPrecision {
@@ -43,6 +50,29 @@ pub enum MatmulB<'a, B: Backend, TB: BufferArg<'a, B> = &'a Allocation<B>> {
 }
 
 impl<'a, B: Backend, TB: BufferArg<'a, B>> MatmulB<'a, B, TB> {
+    pub fn kind(&self) -> MatmulBKind {
+        match self {
+            Self::FullPrecision {
+                ..
+            } => MatmulBKind::Dense,
+            Self::Microfloat {
+                metadata,
+                ..
+            } => match metadata.encoding.format {
+                MicrofloatFormat::Mxfp4 => MatmulBKind::Mxfp4,
+            },
+            Self::ScaleBiasDequant {
+                ..
+            }
+            | Self::ScaleZeroPointDequant {
+                ..
+            }
+            | Self::ScaleSymmetricDequant {
+                ..
+            } => MatmulBKind::Integer,
+        }
+    }
+
     pub fn b_prologue(&self) -> GemmBPrologueKind {
         match self {
             Self::FullPrecision {

--- a/crates/uzu-engine/src/backends/common/kernel/matmul/matmul_b.rs
+++ b/crates/uzu-engine/src/backends/common/kernel/matmul/matmul_b.rs
@@ -2,6 +2,7 @@ use crate::{
     backends::common::{
         Allocation, Backend, BufferArg,
         gpu_types::{QuantizationMode, gemm::GemmBPrologueKind},
+        microfloat::MicrofloatMetadata,
     },
     data_type::DataType,
 };
@@ -9,6 +10,12 @@ use crate::{
 pub enum MatmulB<'a, B: Backend, TB: BufferArg<'a, B> = &'a Allocation<B>> {
     FullPrecision {
         b: TB,
+    },
+    Microfloat {
+        codes: &'a Allocation<B>,
+        scales: &'a Allocation<B>,
+        outer_scales: &'a Allocation<B>,
+        metadata: MicrofloatMetadata,
     },
     ScaleBiasDequant {
         b: &'a Allocation<B>,
@@ -40,6 +47,9 @@ impl<'a, B: Backend, TB: BufferArg<'a, B>> MatmulB<'a, B, TB> {
         match self {
             Self::FullPrecision {
                 ..
+            }
+            | Self::Microfloat {
+                ..
             } => GemmBPrologueKind::FullPrecision,
             Self::ScaleBiasDequant {
                 ..
@@ -58,6 +68,9 @@ impl<'a, B: Backend, TB: BufferArg<'a, B>> MatmulB<'a, B, TB> {
             Self::FullPrecision {
                 ..
             } => None,
+            Self::Microfloat {
+                ..
+            } => Some(4),
             Self::ScaleBiasDequant {
                 mode,
                 ..
@@ -78,6 +91,10 @@ impl<'a, B: Backend, TB: BufferArg<'a, B>> MatmulB<'a, B, TB> {
             Self::FullPrecision {
                 ..
             } => None,
+            Self::Microfloat {
+                metadata,
+                ..
+            } => Some(metadata.encoding.group_size),
             Self::ScaleBiasDequant {
                 group_size,
                 ..
@@ -96,6 +113,9 @@ impl<'a, B: Backend, TB: BufferArg<'a, B>> MatmulB<'a, B, TB> {
     pub fn signed_codes(&self) -> bool {
         match self {
             Self::FullPrecision {
+                ..
+            }
+            | Self::Microfloat {
                 ..
             } => false,
             Self::ScaleBiasDequant {

--- a/crates/uzu-engine/src/backends/common/kernel/matmul/mod.rs
+++ b/crates/uzu-engine/src/backends/common/kernel/matmul/mod.rs
@@ -11,5 +11,5 @@ pub use d_ops::MatmulDOps;
 pub use error::MatmulError;
 pub use kernel::MatmulKernel;
 pub use matmul_a::MatmulA;
-pub use matmul_b::MatmulB;
+pub use matmul_b::{MatmulB, MatmulBKind};
 pub use routing::{A8ActivationPlan, ActivationFormat, MatmulShape};

--- a/crates/uzu-engine/src/backends/common/kernel/matmul/routing.rs
+++ b/crates/uzu-engine/src/backends/common/kernel/matmul/routing.rs
@@ -1,4 +1,4 @@
-use super::{MatmulA, MatmulArguments};
+use super::{MatmulA, MatmulArguments, MatmulBKind};
 use crate::backends::common::{
     Backend, BufferArg,
     gpu_types::gemm::{GemmBPrologueKind, GemmDTransform},
@@ -23,6 +23,7 @@ pub struct MatmulShape {
     pub k: u32,
     pub b_transpose: bool,
     pub b_leading_dimension: Option<u32>,
+    pub b_kind: MatmulBKind,
     pub b_prologue: GemmBPrologueKind,
     pub b_bits: Option<u32>,
     pub b_group_size: Option<u32>,
@@ -42,6 +43,7 @@ impl MatmulShape {
             k: arguments.k,
             b_transpose: arguments.b_transpose,
             b_leading_dimension: arguments.b_leading_dimension,
+            b_kind: arguments.b.kind(),
             b_prologue: arguments.b.b_prologue(),
             b_bits: arguments.b.bits_per_b(),
             b_group_size: arguments.b.group_size(),

--- a/crates/uzu-engine/src/backends/common/microfloat/encoding.rs
+++ b/crates/uzu-engine/src/backends/common/microfloat/encoding.rs
@@ -1,0 +1,42 @@
+use super::{MicrofloatError, MicrofloatFormat};
+
+/// How packed microfloat bytes are interpreted, separate from matrix dimensions.
+///
+/// With MXFP4 group size 16, every 16 values along the input axis occupy eight
+/// packed code bytes and share one E8M0 scale.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MicrofloatEncoding {
+    pub format: MicrofloatFormat,
+    pub group_size: u32,
+}
+
+impl MicrofloatEncoding {
+    pub fn new(
+        format: MicrofloatFormat,
+        bits: u32,
+        group_size: u32,
+    ) -> Result<Self, MicrofloatError> {
+        if bits != 4 {
+            return Err(MicrofloatError::UnsupportedBits {
+                format,
+                bits,
+            });
+        }
+        let encoding = Self {
+            format,
+            group_size,
+        };
+        encoding.validate()?;
+        Ok(encoding)
+    }
+
+    pub fn validate(self) -> Result<(), MicrofloatError> {
+        if !matches!(self.group_size, 16 | 32) {
+            return Err(MicrofloatError::UnsupportedGroupSize {
+                format: self.format,
+                group_size: self.group_size,
+            });
+        }
+        Ok(())
+    }
+}

--- a/crates/uzu-engine/src/backends/common/microfloat/error.rs
+++ b/crates/uzu-engine/src/backends/common/microfloat/error.rs
@@ -1,0 +1,26 @@
+use thiserror::Error;
+
+use super::MicrofloatFormat;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum MicrofloatError {
+    #[error("unsupported {format:?} bit width: {bits}")]
+    UnsupportedBits {
+        format: MicrofloatFormat,
+        bits: u32,
+    },
+    #[error("unsupported {format:?} group size: {group_size}")]
+    UnsupportedGroupSize {
+        format: MicrofloatFormat,
+        group_size: u32,
+    },
+    #[error("microfloat rows and columns must be nonzero")]
+    EmptyShape,
+    #[error("microfloat columns {columns} are not divisible by group size {group_size}")]
+    MisalignedColumns {
+        columns: u32,
+        group_size: u32,
+    },
+    #[error("microfloat storage size overflows usize")]
+    SizeOverflow,
+}

--- a/crates/uzu-engine/src/backends/common/microfloat/format.rs
+++ b/crates/uzu-engine/src/backends/common/microfloat/format.rs
@@ -1,0 +1,8 @@
+use uzu_engine_macros::uzu_config;
+
+#[derive(Copy, Eq)]
+#[uzu_config]
+#[serde(rename_all = "snake_case")]
+pub enum MicrofloatFormat {
+    Mxfp4,
+}

--- a/crates/uzu-engine/src/backends/common/microfloat/metadata.rs
+++ b/crates/uzu-engine/src/backends/common/microfloat/metadata.rs
@@ -1,0 +1,49 @@
+use super::{MicrofloatEncoding, MicrofloatError};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MicrofloatMetadata {
+    pub encoding: MicrofloatEncoding,
+    pub rows: u32,
+    pub columns: u32,
+}
+
+impl MicrofloatMetadata {
+    pub fn new(
+        encoding: MicrofloatEncoding,
+        rows: u32,
+        columns: u32,
+    ) -> Result<Self, MicrofloatError> {
+        let metadata = Self {
+            encoding,
+            rows,
+            columns,
+        };
+        metadata.storage_sizes()?;
+        Ok(metadata)
+    }
+
+    pub fn code_row_stride(self) -> usize {
+        self.columns as usize / 2
+    }
+
+    pub fn scale_row_stride(self) -> usize {
+        self.columns as usize / self.encoding.group_size as usize
+    }
+
+    /// Validate the encoding and shape, then return code and scale byte counts.
+    pub fn storage_sizes(self) -> Result<(usize, usize), MicrofloatError> {
+        self.encoding.validate()?;
+        if self.rows == 0 || self.columns == 0 {
+            return Err(MicrofloatError::EmptyShape);
+        }
+        if !self.columns.is_multiple_of(self.encoding.group_size) {
+            return Err(MicrofloatError::MisalignedColumns {
+                columns: self.columns,
+                group_size: self.encoding.group_size,
+            });
+        }
+        let codes = (self.rows as usize).checked_mul(self.code_row_stride()).ok_or(MicrofloatError::SizeOverflow)?;
+        let scales = (self.rows as usize).checked_mul(self.scale_row_stride()).ok_or(MicrofloatError::SizeOverflow)?;
+        Ok((codes, scales))
+    }
+}

--- a/crates/uzu-engine/src/backends/common/microfloat/mod.rs
+++ b/crates/uzu-engine/src/backends/common/microfloat/mod.rs
@@ -1,0 +1,9 @@
+mod encoding;
+mod error;
+mod format;
+mod metadata;
+
+pub use encoding::MicrofloatEncoding;
+pub use error::MicrofloatError;
+pub use format::MicrofloatFormat;
+pub use metadata::MicrofloatMetadata;

--- a/crates/uzu-engine/src/backends/common/mod.rs
+++ b/crates/uzu-engine/src/backends/common/mod.rs
@@ -8,6 +8,7 @@ mod encoder;
 pub mod gpu_types;
 mod hazard_tracker;
 pub mod kernel;
+pub mod microfloat;
 
 pub use allocator::{Allocation, AllocationPool, AllocationType, Allocator};
 pub use backend::Backend;

--- a/crates/uzu-engine/src/backends/cpu/kernel/matmul/kernel.rs
+++ b/crates/uzu-engine/src/backends/cpu/kernel/matmul/kernel.rs
@@ -1,4 +1,4 @@
-use super::reference::{WeightData, read_f32, write_f32};
+use super::reference::{WeightData, decode_e2m1, decode_e8m0, read_f32, write_f32};
 use crate::{
     backends::{
         common::{
@@ -58,6 +58,27 @@ impl MatmulKernel for MatmulCpuKernel {
         arguments: MatmulArguments<'a, 'b, 'd, Cpu, TB>,
         encoder: &mut Encoder<Cpu>,
     ) -> Result<(), CpuError> {
+        if let MatmulB::Microfloat {
+            codes,
+            scales,
+            outer_scales,
+            metadata,
+        } = &arguments.b
+        {
+            let (code_bytes, scale_bytes) = metadata.storage_sizes().map_err(MatmulError::InvalidMicrofloat)?;
+            let rows_match = arguments.gather_indices.is_some() || metadata.rows == arguments.n;
+            if !arguments.b_transpose
+                || arguments.b_leading_dimension.is_some()
+                || !rows_match
+                || metadata.columns != arguments.k
+                || codes.size() < code_bytes
+                || scales.size() < scale_bytes
+                || outer_scales.size() < self.weights_data_type.size_in_bytes()
+            {
+                return Err(MatmulError::InvalidMicrofloatStorage.into());
+            }
+        }
+
         let output_scale = arguments.d_transform.ab_scale;
         let accumulate = arguments.d_transform.accumulate;
         let bias_alloc = arguments.d_transform.bias;
@@ -183,6 +204,9 @@ impl MatmulKernel for MatmulCpuKernel {
                 },
                 WeightData::FullPrecision {
                     ..
+                }
+                | WeightData::Microfloat {
+                    ..
                 } => None,
             };
 
@@ -272,6 +296,24 @@ impl MatmulKernel for MatmulCpuKernel {
                                         -scale * midpoint
                                     };
                                     scale * quantized_value + bias_term
+                                },
+                                WeightData::Microfloat {
+                                    codes,
+                                    scales,
+                                    outer_scales,
+                                    metadata,
+                                } => {
+                                    let code_index = b_col * metadata.code_row_stride() + inner / 2;
+                                    let packed = *codes.as_ptr().add(code_index);
+                                    let code = packed >> (4 * (inner % 2));
+                                    let scale_index = b_col * metadata.scale_row_stride()
+                                        + inner / metadata.encoding.group_size as usize;
+                                    let exponent = *scales.as_ptr().add(scale_index);
+                                    let outer_scale = read_f32(outer_scales.as_ptr(), weights_data_type, 0);
+                                    // Avoiding intermediate overflow and underflow before the final f32 rounding.
+                                    (f64::from(decode_e2m1(code))
+                                        * f64::from(decode_e8m0(exponent))
+                                        * f64::from(outer_scale)) as f32
                                 },
                             };
                             accumulator += a_value * b_value;

--- a/crates/uzu-engine/src/backends/cpu/kernel/matmul/reference.rs
+++ b/crates/uzu-engine/src/backends/cpu/kernel/matmul/reference.rs
@@ -2,12 +2,30 @@ use half::{bf16, f16};
 
 use crate::{
     backends::{
-        common::{AsBufferRangeRef, BufferArg, gpu_types::QuantizationMode, kernel::matmul::MatmulB},
+        common::{
+            AsBufferRangeRef, BufferArg, gpu_types::QuantizationMode, kernel::matmul::MatmulB,
+            microfloat::MicrofloatMetadata,
+        },
         cpu::Cpu,
     },
     data_type::DataType,
     utils::pointers::SendPtr,
 };
+
+#[inline]
+pub(super) fn decode_e2m1(code: u8) -> f32 {
+    const VALUES: [f32; 16] = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0];
+    VALUES[usize::from(code & 0x0f)]
+}
+
+#[inline]
+pub(super) fn decode_e8m0(exponent: u8) -> f32 {
+    match exponent {
+        0 => f32::from_bits(0x0040_0000),
+        255 => f32::NAN,
+        exponent => f32::from_bits(u32::from(exponent) << 23),
+    }
+}
 
 pub(super) enum WeightData {
     FullPrecision {
@@ -23,6 +41,12 @@ pub(super) enum WeightData {
         bits: usize,
         group_size: usize,
         signed_codes: bool,
+    },
+    Microfloat {
+        codes: SendPtr<u8>,
+        scales: SendPtr<u8>,
+        outer_scales: SendPtr<u8>,
+        metadata: MicrofloatMetadata,
     },
 }
 
@@ -57,6 +81,17 @@ impl WeightData {
                     leading_dimension,
                     transpose: b_transpose,
                 }
+            },
+            MatmulB::Microfloat {
+                codes,
+                scales,
+                outer_scales,
+                metadata,
+            } => WeightData::Microfloat {
+                codes: alloc_ptr(codes),
+                scales: alloc_ptr(scales),
+                outer_scales: alloc_ptr(outer_scales),
+                metadata,
             },
             MatmulB::ScaleBiasDequant {
                 b: weights,
@@ -141,3 +176,7 @@ pub(super) unsafe fn write_f32(
         }
     }
 }
+
+#[cfg(test)]
+#[path = "../../../../../unit/backends/cpu/kernel/matmul/reference_test.rs"]
+mod tests;

--- a/crates/uzu-engine/src/backends/metal/kernel/activation_transform/activation_transform.metal
+++ b/crates/uzu-engine/src/backends/metal/kernel/activation_transform/activation_transform.metal
@@ -16,7 +16,7 @@ using namespace uzu::activation_transform;
 #define EMITS_GROUP_SUMS (ops == ActivationTransformOp::QuantizeWithGroupSums)
 
 template <typename T>
-VARIANTS(T, float, bfloat)
+VARIANTS(T, float, bfloat, half)
 PUBLIC KERNEL(ActivationTransform)(
     const device T* input OPTIONAL(!in_place),
     device T* fp_out OPTIONAL(!QUANTIZED),

--- a/crates/uzu-engine/src/backends/metal/kernel/generated/matmul.h
+++ b/crates/uzu-engine/src/backends/metal/kernel/generated/matmul.h
@@ -17,5 +17,6 @@ typedef struct {
   uint32_t aligned_inner_iterations;
   bool use_morton;
   float ab_scale;
+  float soft_cap;
 } GemmParams;
 } // namespace uzu::matmul

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/common/microfloat.h
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/common/microfloat.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "defines.h"
+
+namespace uzu {
+namespace gemm {
+
+METAL_FUNC float decode_e2m1(uint code) {
+  constexpr float magnitudes[8] = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f};
+  const uint magnitude_bits = as_type<uint>(magnitudes[code & 0x7u]);
+  const uint sign_bit = (code & 0x8u) << 28u;
+  return as_type<float>(magnitude_bits | sign_bit);
+}
+
+METAL_FUNC float decode_e8m0(uint exponent) {
+  if (exponent == 0u) {
+    return as_type<float>(0x00400000u);
+  }
+  if (exponent == 255u) {
+    return as_type<float>(0x7fc00000u);
+  }
+  return as_type<float>(exponent << 23u);
+}
+
+} // namespace gemm
+} // namespace uzu

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/common/threadgroup_tile.h
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/common/threadgroup_tile.h
@@ -151,15 +151,17 @@ struct ThreadgroupTile {
     });
   }
 
-  METAL_FUNC void apply_bias(const device BT* bias) {
-    const device BT* bias_ptr = bias + simdgroup_col_offset;
+  template <typename BiasElement>
+  METAL_FUNC void apply_bias(const device BiasElement* bias) {
+    const device BiasElement* bias_ptr = bias + simdgroup_col_offset;
     for_each_output([&](ushort, ushort col_offset, ushort k, thread AccumulatorType& v) {
       v += static_cast<AccumulatorType>(bias_ptr[col_offset + k]);
     });
   }
 
-  METAL_FUNC void apply_bias_safe(const device BT* bias, short2 tile_dimensions) {
-    const device BT* bias_ptr = bias + simdgroup_col_offset;
+  template <typename BiasElement>
+  METAL_FUNC void apply_bias_safe(const device BiasElement* bias, short2 tile_dimensions) {
+    const device BiasElement* bias_ptr = bias + simdgroup_col_offset;
     tile_dimensions -= short2(simdgroup_col_offset, simdgroup_row_offset);
     for_each_output([&](ushort row_offset, ushort col_offset, ushort k, thread AccumulatorType& v) {
       if (row_offset < tile_dimensions.y && col_offset + k < tile_dimensions.x)

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/common/microfloat_loader.h
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/common/microfloat_loader.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <metal_stdlib>
+
+#include "../../common/microfloat.h"
+
+using namespace metal;
+
+namespace uzu {
+namespace gemm {
+
+template <
+    typename T,
+    short THREADGROUP_TILE_ROWS,
+    short THREADGROUP_TILE_COLS,
+    short DESTINATION_LEADING_DIMENSION,
+    short THREADGROUP_SIZE,
+    short GROUP_SIZE>
+struct Mxfp4BlockLoader {
+  static_assert(THREADGROUP_TILE_COLS % 2 == 0, "MXFP4 tiles must contain complete packed bytes");
+  static_assert(GROUP_SIZE == 16 || GROUP_SIZE == 32, "MXFP4 groups contain 16 or 32 values");
+  static_assert(THREADGROUP_TILE_COLS == GROUP_SIZE, "MXFP4 staging tiles must span one scale group");
+
+  UZU_CONST short PACK_FACTOR = 2;
+  UZU_CONST short PACKED_COLS = THREADGROUP_TILE_COLS / PACK_FACTOR;
+  UZU_CONST short PACK_COUNT = THREADGROUP_TILE_ROWS * PACKED_COLS;
+  UZU_CONST short READS_PER_THREAD = PACK_COUNT < THREADGROUP_SIZE ? 1 : PACK_COUNT / THREADGROUP_SIZE;
+  UZU_CONST bool TILE_HAS_IDLE_THREADS = PACK_COUNT < THREADGROUP_SIZE;
+  static_assert(
+      PACK_COUNT < THREADGROUP_SIZE || PACK_COUNT % THREADGROUP_SIZE == 0,
+      "MXFP4 tile packs must divide evenly among threads"
+  );
+  static_assert(
+      TILE_HAS_IDLE_THREADS || PACKED_COLS % READS_PER_THREAD == 0,
+      "each MXFP4 thread must remain within one weight row"
+  );
+
+  const short thread_row;
+  const short thread_col;
+  uint k_base;
+
+  threadgroup T* destination;
+  const device uint8_t* codes;
+  const device uint8_t* scales;
+
+  Mxfp4BlockLoader(
+      const device uint8_t* codes_,
+      const device uint8_t* scales_,
+      const size_t code_row_stride_,
+      const size_t scale_row_stride_,
+      const uint k_base_,
+      threadgroup T* destination_,
+      ushort simdgroup_index,
+      ushort simd_lane
+  )
+      : thread_row(READS_PER_THREAD * (simdgroup_index * 32 + simd_lane) / PACKED_COLS),
+        thread_col((READS_PER_THREAD * (simdgroup_index * 32 + simd_lane)) % PACKED_COLS), k_base(k_base_),
+        destination(destination_ + thread_row * DESTINATION_LEADING_DIMENSION + thread_col * PACK_FACTOR),
+        codes(codes_ + size_t(thread_row) * code_row_stride_ + thread_col),
+        scales(scales_ + size_t(thread_row) * scale_row_stride_) {}
+
+  METAL_FUNC void decode_pack(const int pack, const float scale, const int valid_values = PACK_FACTOR) const {
+    const uint packed = codes[pack];
+    destination[pack * PACK_FACTOR] = T(decode_e2m1(packed & 0x0fu) * scale);
+    destination[pack * PACK_FACTOR + 1] = valid_values == PACK_FACTOR ? T(decode_e2m1(packed >> 4u) * scale) : T(0);
+  }
+
+  METAL_FUNC void load_unsafe() const {
+    if constexpr (TILE_HAS_IDLE_THREADS) {
+      if (thread_row >= THREADGROUP_TILE_ROWS) {
+        return;
+      }
+    }
+    const float scale = decode_e8m0(scales[k_base / GROUP_SIZE]);
+    for (int pack = 0; pack < READS_PER_THREAD; ++pack) {
+      decode_pack(pack, scale);
+    }
+  }
+
+  METAL_FUNC void load_safe(short2 source_dimensions) const {
+    if constexpr (TILE_HAS_IDLE_THREADS) {
+      if (thread_row >= THREADGROUP_TILE_ROWS) {
+        return;
+      }
+    }
+    if (thread_row >= source_dimensions.y) {
+      for (int value = 0; value < READS_PER_THREAD * PACK_FACTOR; ++value) {
+        destination[value] = T(0);
+      }
+      return;
+    }
+
+    const float scale = decode_e8m0(scales[k_base / GROUP_SIZE]);
+    const int valid_packs = (source_dimensions.x + PACK_FACTOR - 1) / PACK_FACTOR;
+    for (int pack = 0; pack < READS_PER_THREAD; ++pack) {
+      const int pack_index = thread_col + pack;
+      if (pack_index >= valid_packs) {
+        destination[pack * PACK_FACTOR] = T(0);
+        destination[pack * PACK_FACTOR + 1] = T(0);
+        continue;
+      }
+      const int valid_values = min(int(PACK_FACTOR), int(source_dimensions.x) - pack_index * PACK_FACTOR);
+      decode_pack(pack, scale, valid_values);
+    }
+  }
+
+  METAL_FUNC void next() {
+    codes += PACKED_COLS;
+    k_base += THREADGROUP_TILE_COLS;
+  }
+};
+
+} // namespace gemm
+} // namespace uzu

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/common/operands.h
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/common/operands.h
@@ -41,18 +41,31 @@ struct LeftOperand {
 template <GemmBPrologueKind PROLOGUE, ushort BITS_, ushort GROUP_SIZE_, typename Element>
 struct RightOperand {
   UZU_CONST bool QUANTIZED = PROLOGUE != GemmBPrologueKind::FullPrecision;
-  UZU_CONST ushort BITS = QUANTIZED ? BITS_ : 0;
-  UZU_CONST ushort GROUP_SIZE = QUANTIZED ? GROUP_SIZE_ : 0;
+  UZU_CONST bool MICROFLOAT = !QUANTIZED && BITS_ == 4;
+  UZU_CONST bool DENSE = !QUANTIZED && !MICROFLOAT;
+  UZU_CONST bool PACKED = QUANTIZED || MICROFLOAT;
+  UZU_CONST ushort BITS = PACKED ? BITS_ : 0;
+  UZU_CONST ushort GROUP_SIZE = PACKED ? GROUP_SIZE_ : 0;
   UZU_CONST GemmBPrologueKind SCHEME = PROLOGUE;
   UZU_CONST bool NEEDS_CORRECTION = QUANTIZED && PROLOGUE != GemmBPrologueKind::ScaleSymmetricDequant;
 
-  static_assert(!QUANTIZED || BITS_ == 4 || BITS_ == 8, "quantized integer weights must use 4 or 8 bits");
-  static_assert(!QUANTIZED || PROLOGUE != GemmBPrologueKind::FullPrecision, "quantized weights need a scheme");
+  static_assert(!DENSE || (BITS_ == 0 && GROUP_SIZE_ == 0), "dense weights do not have packing parameters");
+  static_assert(!QUANTIZED || BITS_ == 4 || BITS_ == 8, "integer weights must use 4 or 8 bits");
+  static_assert(!QUANTIZED || PROLOGUE != GemmBPrologueKind::FullPrecision, "integer weights need a scheme");
+  static_assert(
+      !MICROFLOAT || (BITS_ == 4 && (GROUP_SIZE_ == 16 || GROUP_SIZE_ == 32)),
+      "MXFP4 weights require 4-bit codes in groups of 16 or 32"
+  );
+  static_assert(
+      !MICROFLOAT || PROLOGUE == GemmBPrologueKind::FullPrecision,
+      "MXFP4 does not use an integer dequantization prologue"
+  );
 
   using CodeElement = int8_t;
   using ScaleElement = Element;
   using DenseElement = Element;
-  using ElementType = DenseElement;
+  // Widening half staging; E8M0 block scales can exceed half before the outer scale is applied.
+  using ElementType = metal::conditional_t<MICROFLOAT && metal::is_same_v<Element, half>, bfloat, Element>;
   using Format = metal::conditional_t<
       QUANTIZED,
       uzu::matmul::IntegerFormat<BITS_, uzu::matmul::Signedness::Signed>,
@@ -90,6 +103,8 @@ struct RightStorage {
   const device typename Right::ScaleElement* scales;
   const device typename Right::ScaleElement* biases;
   const device uint8_t* zero_points;
+  const device uint8_t* microfloat_scales;
+  const device typename Right::ScaleElement* microfloat_outer_scale;
   bool signed_codes;
 
   METAL_FUNC const device typename Right::ScaleElement* bias() const thread {
@@ -126,27 +141,37 @@ METAL_FUNC RightStorage<Right> pack_right(
     const device Element* scales,
     const device Element* biases,
     const device uint8_t* zero_points,
+    const device uint8_t* microfloat_scales,
+    const device Element* microfloat_outer_scale,
     const bool signed_codes
 ) {
-  if constexpr (!Right::QUANTIZED) {
-    return {dense, nullptr, nullptr, nullptr, nullptr, false};
-  } else {
+  if constexpr (Right::DENSE) {
+    return {dense, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, false};
+  } else if constexpr (Right::QUANTIZED) {
     return {
         nullptr,
         reinterpret_cast<const device uint8_t*>(dense),
         scales,
         Right::SCHEME == GemmBPrologueKind::ScaleBiasDequant ? biases : nullptr,
         Right::SCHEME == GemmBPrologueKind::ScaleZeroPointDequant ? zero_points : nullptr,
+        nullptr,
+        nullptr,
         signed_codes
+    };
+  } else {
+    static_assert(Right::MICROFLOAT, "unsupported packed weight format");
+    return {
+        nullptr,
+        reinterpret_cast<const device uint8_t*>(dense),
+        nullptr,
+        nullptr,
+        nullptr,
+        microfloat_scales,
+        microfloat_outer_scale,
+        false
     };
   }
 }
-
-template <GemmAPrologueKind PROLOGUE, typename Element, ushort ACTIVATION_GROUP_SIZE>
-using LeftOperandFor = LeftOperand<PROLOGUE, Element, ACTIVATION_GROUP_SIZE>;
-
-template <GemmBPrologueKind PROLOGUE, ushort BITS, ushort GROUP_SIZE, typename Element>
-using RightOperandFor = RightOperand<PROLOGUE, BITS, GROUP_SIZE, Element>;
 
 } // namespace operands
 } // namespace gemm

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/common/schedules/staged.h
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/common/schedules/staged.h
@@ -7,6 +7,7 @@
 #include "../../../common/fragment.h"
 #include "../../../common/mxu_gemm_loop.h"
 #include "../gemm_alignment.h"
+#include "../microfloat_loader.h"
 #include "../operands.h"
 #include "../quant_scale_bias.h"
 #include "../quant_scale_zero_point.h"
@@ -19,7 +20,41 @@ namespace gemm {
 namespace schedules {
 
 template <typename Core, typename RightOperand>
-static METAL_FUNC auto make_staged_loader(
+static METAL_FUNC auto make_mxfp4_loader(
+    const typename Core::RightStorage right,
+    const constant uzu::matmul::GemmParams* params,
+    const size_t block_col,
+    const uint k_offset,
+    threadgroup typename Core::RightElementType* staging,
+    const thread ThreadContext& thread_context
+) {
+  static_assert(RightOperand::MICROFLOAT, "MXFP4 loader requires MXFP4 weights");
+  using Element = typename Core::RightElementType;
+  const size_t code_row_stride = size_t(params->K) / 2;
+  const size_t scale_row_stride = size_t(params->K) / RightOperand::GROUP_SIZE;
+  const device uint8_t* codes = right.codes + block_col * code_row_stride + size_t(k_offset) / 2;
+  const device uint8_t* scales = right.microfloat_scales + block_col * scale_row_stride;
+  using Loader = Mxfp4BlockLoader<
+      Element,
+      Core::THREADGROUP_BLOCK_N,
+      Core::THREADGROUP_BLOCK_K,
+      Core::SHARED_STRIDE_B,
+      Core::THREADGROUP_THREADS,
+      RightOperand::GROUP_SIZE>;
+  return Loader(
+      codes,
+      scales,
+      code_row_stride,
+      scale_row_stride,
+      k_offset,
+      staging,
+      thread_context.simdgroup_index,
+      thread_context.simd_lane_id
+  );
+}
+
+template <typename Core, typename RightOperand>
+static METAL_FUNC auto make_integer_loader(
     const typename Core::RightStorage right,
     const constant uzu::matmul::GemmParams* params,
     const size_t block_col,
@@ -136,6 +171,25 @@ static METAL_FUNC auto make_full_precision_loader(
   return Loader(values, params->leading_dimension_b, staging, thread_context);
 }
 
+template <typename Core>
+static METAL_FUNC auto make_staged_loader(
+    const typename Core::RightStorage right,
+    const constant uzu::matmul::GemmParams* params,
+    const size_t block_col,
+    const uint k_offset,
+    threadgroup typename Core::RightElementType* staging,
+    const thread ThreadContext& thread_context
+) {
+  using Right = typename Core::Right;
+  if constexpr (Right::DENSE) {
+    return make_full_precision_loader<Core>(right, params, block_col, k_offset, staging, thread_context);
+  } else if constexpr (Right::MICROFLOAT) {
+    return make_mxfp4_loader<Core, Right>(right, params, block_col, k_offset, staging, thread_context);
+  } else {
+    return make_integer_loader<Core, Right>(right, params, block_col, k_offset, staging, thread_context);
+  }
+}
+
 struct StagedSchedule {
   template <typename Core, bool ALIGNED_M, bool ALIGNED_N, bool, bool>
   static METAL_FUNC typename Core::AccumFragment launch(
@@ -169,14 +223,7 @@ struct StagedSchedule {
         staging + tile.tile_col_offset * Core::SHARED_STRIDE_B,
         int(Core::SHARED_STRIDE_B)
     );
-    auto loader = make_staged_loader<Core, typename Core::RightOperand>(
-        right,
-        params,
-        tile.block_col,
-        tile.k_offset,
-        staging,
-        thread_context
-    );
+    auto loader = make_staged_loader<Core>(right, params, tile.block_col, tile.k_offset, staging, thread_context);
 
     typename Core::AccumFragment accumulator;
     accumulator.clear();

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/common/simdgroup_mma_core.h
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/common/simdgroup_mma_core.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../../../common/integral_constant.h"
+#include "../../../common/soft_cap.h"
 #include "../../../common/thread_context.h"
 #include "../../common/defines.h"
 #include "../../common/loader.h"
@@ -34,6 +35,7 @@ struct SimdgroupMmaCore {
   using Right = RightOperand;
   using LeftElementType = typename Left::ElementType;
   using RightElementType = typename Right::ElementType;
+  using ScaleElementType = typename Right::ScaleElement;
   using LeftStorage = operands::LeftStorage<Left>;
   using RightStorage = operands::RightStorage<Right>;
   static_assert(!Left::QUANTIZED, "simdgroup MMA stages full-precision left operands only");
@@ -140,8 +142,9 @@ struct SimdgroupMmaCore {
       const thread ushort& tile_block_cols,
       const bool needs_epilogue,
       const thread uzu::matmul::TransformScaleAccumulate<float, float>& epilogue,
-      const device RightElementType* bias_block,
+      const device ScaleElementType* bias_block,
       const bool needs_bias,
+      const bool needs_soft_cap,
       const device int32_t* rht_factors_block,
       const bool needs_rht,
       const thread ThreadContext& thread_context
@@ -154,6 +157,9 @@ struct SimdgroupMmaCore {
       if (needs_bias) {
         accumulator.apply_bias(bias_block);
       }
+      if (needs_soft_cap) {
+        accumulator.c_fragment.map([&](float value) { return uzu::apply_soft_cap(value, params->soft_cap); });
+      }
       accumulator.store_result(d, params->leading_dimension_d);
     } else {
       if (needs_epilogue) {
@@ -162,6 +168,9 @@ struct SimdgroupMmaCore {
       }
       if (needs_bias) {
         accumulator.apply_bias_safe(bias_block, short2(tile_block_cols, tile_block_rows));
+      }
+      if (needs_soft_cap) {
+        accumulator.c_fragment.map([&](float value) { return uzu::apply_soft_cap(value, params->soft_cap); });
       }
       accumulator.store_result_safe(d, params->leading_dimension_d, short2(tile_block_cols, tile_block_rows));
     }
@@ -187,7 +196,7 @@ struct SimdgroupMmaCore {
       const constant uzu::matmul::GemmParams* params,
       GemmAlignment alignment,
       GemmDTransform output_transform,
-      const device RightElementType* output_bias,
+      const device ScaleElementType* output_bias,
       const device int32_t* rht_factors,
       threadgroup LeftElementType* a_shared,
       threadgroup RightElementType* b_shared,
@@ -228,12 +237,13 @@ struct SimdgroupMmaCore {
     const bool needs_scale = output_transform.contains(GemmDTransform::SCALE);
     const bool needs_accumulate = output_transform.contains(GemmDTransform::ACCUMULATE);
     const bool needs_bias = output_transform.contains(GemmDTransform::BIAS);
+    const bool needs_soft_cap = Right::MICROFLOAT && output_transform.contains(GemmDTransform::SOFT_CAP);
     const bool needs_rht = output_transform.contains(GemmDTransform::RHT);
     const bool needs_epilogue = needs_scale || needs_accumulate;
     const float alpha = needs_scale ? params->ab_scale : 1.0f;
     const float beta = needs_accumulate ? 1.0f : 0.0f;
     uzu::matmul::TransformScaleAccumulate<float, float> epilogue(alpha, beta);
-    const device RightElementType* bias_block = output_bias + block_col;
+    const device ScaleElementType* bias_block = output_bias + block_col;
     const device int32_t* rht_factors_block = rht_factors + block_col;
 
     const bool all_aligned = ((alignment.contains(GemmAlignment::M)) || (tile_block_rows == THREADGROUP_BLOCK_M)) &&
@@ -245,63 +255,47 @@ struct SimdgroupMmaCore {
         alignment.raw_value | ((tile_block_rows == THREADGROUP_BLOCK_M) ? static_cast<uint>(GemmAlignment::M) : 0u) |
         ((tile_block_cols == THREADGROUP_BLOCK_N) ? static_cast<uint>(GemmAlignment::N) : 0u);
 
-    auto run_with_loader = [&](auto loader_b) {
-      auto kernel_invoke = [&](auto gemm_alignment_mask) {
-        constexpr uint gemm_alignment = gemm_alignment_mask.value;
-        k_loop<gemm_alignment>(
-            a_shared,
-            b_shared,
-            params->aligned_inner_iterations,
-            loader_a,
-            loader_b,
-            accumulator,
-            tile_block_rows,
-            tile_block_cols,
-            leftover_block_depth
-        );
-        finalize<gemm_alignment>(
-            accumulator,
-            d,
-            params,
-            tile_block_rows,
-            tile_block_cols,
-            needs_epilogue,
-            epilogue,
-            bias_block,
-            needs_bias,
-            rht_factors_block,
-            needs_rht,
-            thread_context
-        );
-      };
-
-      if (all_aligned) {
-        kernel_invoke(integral_constant<uint, MASK_ALL>{});
-      } else {
-        dispatch_gemm_alignment(dynamic_alignment_mask, kernel_invoke);
+    auto loader_b =
+        schedules::make_staged_loader<SimdgroupMmaCore>(right, params, block_col, k_offset, b_shared, thread_context);
+    auto kernel_invoke = [&](auto gemm_alignment_mask) {
+      constexpr uint gemm_alignment = gemm_alignment_mask.value;
+      k_loop<gemm_alignment>(
+          a_shared,
+          b_shared,
+          params->aligned_inner_iterations,
+          loader_a,
+          loader_b,
+          accumulator,
+          tile_block_rows,
+          tile_block_cols,
+          leftover_block_depth
+      );
+      if constexpr (Right::MICROFLOAT) {
+        // Keeping the outer scale in f32; folding it into staging would narrow the final weights.
+        const float outer_scale = float(right.microfloat_outer_scale[0]);
+        accumulator.c_fragment.map([&](float value) { return value * outer_scale; });
       }
+      finalize<gemm_alignment>(
+          accumulator,
+          d,
+          params,
+          tile_block_rows,
+          tile_block_cols,
+          needs_epilogue,
+          epilogue,
+          bias_block,
+          needs_bias,
+          needs_soft_cap,
+          rht_factors_block,
+          needs_rht,
+          thread_context
+      );
     };
 
-    if constexpr (!Right::QUANTIZED) {
-      auto loader_b = schedules::make_full_precision_loader<SimdgroupMmaCore>(
-          right,
-          params,
-          block_col,
-          k_offset,
-          b_shared,
-          thread_context
-      );
-      run_with_loader(loader_b);
+    if (all_aligned) {
+      kernel_invoke(integral_constant<uint, MASK_ALL>{});
     } else {
-      auto loader_b = schedules::make_staged_loader<SimdgroupMmaCore, RightOperand>(
-          right,
-          params,
-          block_col,
-          k_offset,
-          b_shared,
-          thread_context
-      );
-      run_with_loader(loader_b);
+      dispatch_gemm_alignment(dynamic_alignment_mask, kernel_invoke);
     }
   }
 };

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/error.rs
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/error.rs
@@ -13,8 +13,8 @@ pub enum GemmSpecializationError {
         simdgroup_k: u32,
         group_size: u32,
     },
-    #[error("quantized B requires transposed layout")]
-    QuantizedRequiresTransposedB,
+    #[error("packed B requires transposed layout")]
+    PackedRequiresTransposedB,
     #[error("tiling {tiling} does not match use_mxu={use_mxu}")]
     TilingUseMxuMismatch {
         tiling: GemmTiling,

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/gemm.metal
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/gemm.metal
@@ -11,8 +11,12 @@ using namespace metal;
 using namespace uzu::gemm;
 
 #define A_IS_INT8 (A_PROLOGUE == GemmAPrologueKind::Int8Symmetric)
-#define NEEDS_ASYMMETRIC_WEIGHT_CORRECTION (A_IS_INT8 && B_PROLOGUE != GemmBPrologueKind::ScaleSymmetricDequant)
-#define GEMM_MXU_QUANT (USE_MXU && B_PROLOGUE != GemmBPrologueKind::FullPrecision && !A_IS_INT8)
+#define B_IS_INTEGER (B_PROLOGUE != GemmBPrologueKind::FullPrecision)
+#define B_IS_MXFP4 (B_PROLOGUE == GemmBPrologueKind::FullPrecision && BITS == 4)
+#define B_IS_DENSE (!B_IS_INTEGER && !B_IS_MXFP4)
+#define NEEDS_ASYMMETRIC_WEIGHT_CORRECTION                                                                             \
+  (A_IS_INT8 && B_IS_INTEGER && B_PROLOGUE != GemmBPrologueKind::ScaleSymmetricDequant)
+#define GEMM_MXU_QUANT (USE_MXU && B_IS_INTEGER && !A_IS_INT8)
 #define GEMM_TGA_ELEMENTS                                                                                              \
   ((USE_MXU) ? 1 : (gemm_tiling_block_m(GEMM_TILING) * (gemm_tiling_block_k(GEMM_TILING) + 16 / int(sizeof(AT)))))
 #define GEMM_INTEGER_TGB_ELEMENTS                                                                                      \
@@ -36,10 +40,11 @@ template <
     uint GROUP_SIZE,
     GemmAPrologueKind A_PROLOGUE,
     uint A_GROUP_SIZE>
-VARIANTS(AT, bfloat, float)
-VARIANTS(BT, bfloat, float)
-VARIANTS(DT, bfloat, float)
+VARIANTS(AT, half, bfloat, float)
+VARIANTS(BT, half, bfloat, float)
+VARIANTS(DT, half, bfloat, float)
 CONSTRAINT(BT != "float" || (AT == "float" && DT == "float"))
+CONSTRAINT(B_IS_MXFP4 || (AT != "half" && BT != "half" && DT != "half"))
 VARIANTS(
     GEMM_TILING,
     GemmTiling::Tile8x32x32_Simdgroups1x1,
@@ -76,26 +81,34 @@ CONSTRAINT(
      GEMM_TILING == GemmTiling::Tile64x32x256_Simdgroups4x1 ||
      GEMM_TILING == GemmTiling::Tile64x64x256_Simdgroups2x2 ||
      GEMM_TILING == GemmTiling::Tile128x128x256_Simdgroups4x4))
-CONSTRAINT((B_PROLOGUE == GemmBPrologueKind::FullPrecision) == (BITS == 0))
+CONSTRAINT(B_IS_DENSE == (BITS == 0))
 CONSTRAINT((BITS == 0) == (GROUP_SIZE == 0))
+CONSTRAINT(!B_IS_MXFP4 || (GROUP_SIZE == 16 || GROUP_SIZE == 32))
+CONSTRAINT(!B_IS_MXFP4 || !USE_MXU)
 CONSTRAINT(B_PROLOGUE == GemmBPrologueKind::FullPrecision || BT != "float")
 CONSTRAINT(
     GROUP_SIZE != 16 ||
     GEMM_TILING == GemmTiling::Tile64x64x16_Simdgroups2x2)
 CONSTRAINT(
-    B_PROLOGUE == GemmBPrologueKind::FullPrecision ||
+    !B_IS_MXFP4 ||
+    GEMM_TILING == GemmTiling::Tile64x64x16_Simdgroups2x2 ||
+    GEMM_TILING == GemmTiling::Tile8x32x32_Simdgroups1x1 ||
+    GEMM_TILING == GemmTiling::Tile32x32x32_Simdgroups2x2 ||
+    GEMM_TILING == GemmTiling::Tile64x64x32_Simdgroups2x2)
+CONSTRAINT(
+    B_IS_DENSE ||
     (TRANSPOSE_B &&
      (GEMM_TILING != GemmTiling::Tile64x64x16_Simdgroups2x2 ||
       GROUP_SIZE == 16)))
 CONSTRAINT(
-    B_PROLOGUE == GemmBPrologueKind::FullPrecision ||
+    B_IS_DENSE ||
     GEMM_TILING != GemmTiling::Tile128x128x256_Simdgroups4x4 ||
     GROUP_SIZE <= 64)
 CONSTRAINT(
     !(GEMM_TILING == GemmTiling::Tile16x32x256_Simdgroups1x1 ||
       GEMM_TILING == GemmTiling::Tile16x128x256_Simdgroups1x4) ||
     (TRANSPOSE_B &&
-     (B_PROLOGUE == GemmBPrologueKind::FullPrecision ||
+     (B_IS_DENSE ||
       A_PROLOGUE == GemmAPrologueKind::Int8Symmetric)))
 CONSTRAINT(A_PROLOGUE == GemmAPrologueKind::FullPrecision || USE_MXU)
 CONSTRAINT(A_PROLOGUE == GemmAPrologueKind::FullPrecision || BITS == 4 || BITS == 8)
@@ -104,7 +117,9 @@ CONSTRAINT(
     (GROUP_SIZE % METAL_SIMD_SIZE == 0 && GROUP_SIZE != 0))
 CONSTRAINT(
     A_PROLOGUE == GemmAPrologueKind::FullPrecision ||
-    (TRANSPOSE_B && B_PROLOGUE != GemmBPrologueKind::FullPrecision))
+    (TRANSPOSE_B && !B_IS_DENSE))
+CONSTRAINT(A_PROLOGUE == GemmAPrologueKind::FullPrecision || !B_IS_MXFP4)
+CONSTRAINT(B_IS_DENSE || TRANSPOSE_B)
 CONSTRAINT(A_PROLOGUE == GemmAPrologueKind::FullPrecision || (AT == "bfloat" && DT == "bfloat"))
 CONSTRAINT((A_PROLOGUE == GemmAPrologueKind::FullPrecision) == (A_GROUP_SIZE == 0))
 CONSTRAINT(A_PROLOGUE == GemmAPrologueKind::FullPrecision || A_GROUP_SIZE >= 32)
@@ -118,6 +133,8 @@ KERNEL(Gemm)(
         OPTIONAL(B_PROLOGUE == GemmBPrologueKind::ScaleBiasDequant),
     const device uint8_t* zero_points
         OPTIONAL(B_PROLOGUE == GemmBPrologueKind::ScaleZeroPointDequant),
+    const device uint8_t* microfloat_scales OPTIONAL(B_IS_MXFP4),
+    const device BT* microfloat_outer_scale OPTIONAL(B_IS_MXFP4),
     const device BT* output_bias
         OPTIONAL(output_transform.contains(GemmDTransform::BIAS)),
     const device int32_t* rht_factors
@@ -135,7 +152,8 @@ KERNEL(Gemm)(
     const bool stage_weight_scales SPECIALIZE,
     const bool hoist_operand_addressing SPECIALIZE,
     threadgroup AT a_shared[GEMM_TGA_ELEMENTS],
-    threadgroup BT b_shared[GEMM_TGB_ELEMENTS],
+    threadgroup typename operands::RightOperand<B_PROLOGUE, BITS, GROUP_SIZE, BT>::ElementType
+        b_shared[GEMM_TGB_ELEMENTS],
     const uint group_x GROUPS(group_count_x),
     const uint group_y GROUPS(group_count_y),
     const uint group_z GROUPS(group_count_z),
@@ -151,14 +169,22 @@ KERNEL(Gemm)(
   (void)thread_y;
   (void)thread_z;
 
-  using LeftOperand = operands::LeftOperandFor<A_PROLOGUE, AT, ushort(A_GROUP_SIZE)>;
-  using RightOperand = operands::RightOperandFor<B_PROLOGUE, ushort(BITS), ushort(GROUP_SIZE), BT>;
+  using LeftOperand = operands::LeftOperand<A_PROLOGUE, AT, ushort(A_GROUP_SIZE)>;
+  using RightOperand = operands::RightOperand<B_PROLOGUE, ushort(BITS), ushort(GROUP_SIZE), BT>;
   static_assert(
       NEEDS_ASYMMETRIC_WEIGHT_CORRECTION == (A_IS_INT8 && RightOperand::NEEDS_CORRECTION),
       "kernel bindings and operand correction policy must agree"
   );
   const auto left_storage = operands::pack_left<LeftOperand, AT>(a, a_int8, a_scales, a_group_sums);
-  const auto right_storage = operands::pack_right<RightOperand, BT>(b, scales, biases, zero_points, signed_codes);
+  const auto right_storage = operands::pack_right<RightOperand, BT>(
+      b,
+      scales,
+      biases,
+      zero_points,
+      microfloat_scales,
+      microfloat_outer_scale,
+      signed_codes
+  );
 
   static_assert(
       !A_IS_INT8 || GEMM_TGB_ELEMENTS >= GEMM_INTEGER_TGB_ELEMENTS,

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/kernel.rs
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/kernel.rs
@@ -191,6 +191,12 @@ impl GemmKernel {
         let use_mxu = plan.engine == GemmEngine::Mxu;
 
         match b {
+            MatmulB::Microfloat {
+                metadata,
+                ..
+            } => {
+                return Err(MatmulError::UnsupportedMicrofloat(metadata.encoding.format).into());
+            },
             MatmulB::FullPrecision {
                 b: weights,
             } => {

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/kernel.rs
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/kernel.rs
@@ -154,7 +154,7 @@ impl GemmKernel {
             .validate_engine(plan.engine)
             .map_err(|error| MetalError::KernelDispatchFailed(Box::new(error)))?;
 
-        let is_quant = !matches!(arguments.b, MatmulB::FullPrecision { .. });
+        let is_quant = shape.is_quant();
         if is_quant {
             let d_mask = arguments.d_transform.mask();
             if d_mask.contains(GemmDTransform::ACCUMULATE) {
@@ -167,6 +167,7 @@ impl GemmKernel {
         }
 
         let ab_scale = arguments.d_transform.ab_scale;
+        let soft_cap = arguments.d_transform.soft_cap.unwrap_or(0.0);
         let output_bias = arguments.d_transform.bias;
         let rht_factors = arguments.d_transform.rht_factors;
         let output_transform = arguments.d_transform.mask();
@@ -192,10 +193,67 @@ impl GemmKernel {
 
         match b {
             MatmulB::Microfloat {
-                metadata,
+                codes,
+                scales,
+                outer_scales,
                 ..
             } => {
-                return Err(MatmulError::UnsupportedMicrofloat(metadata.encoding.format).into());
+                if output_transform.contains(GemmDTransform::RHT) {
+                    return Err(MatmulError::UnsupportedDOp {
+                        bit: GemmDTransform::RHT,
+                        path: "MXFP4 GEMM",
+                    }
+                    .into());
+                }
+                let MatmulA::FullPrecision {
+                    values: a,
+                    offset: a_offset,
+                } = a
+                else {
+                    return Err(MatmulError::IncompatibleA {
+                        path: "MXFP4 GEMM",
+                        reason: "int8 activations require integer weights",
+                    }
+                    .into());
+                };
+                let tiling = plan.tiling;
+                let alignment = GemmAlignment::new(
+                    m.is_multiple_of(tiling.block_m()),
+                    n.is_multiple_of(tiling.block_n()),
+                    k.is_multiple_of(tiling.block_k()),
+                );
+                let params = packed_params(shape, plan, ab_scale, soft_cap);
+                let group_count_x = n.div_ceil(tiling.block_n());
+                let group_count_y = m.div_ceil(tiling.block_m());
+                let specialization = GemmSpecialization::from_plan(
+                    plan,
+                    shape,
+                    output_transform,
+                    alignment,
+                    GemmAPrologueKind::FullPrecision,
+                    None,
+                )?;
+                let kernel = self.get_or_create(encoder.context(), specialization)?;
+                kernel.encode(
+                    Some((a, a_offset)),
+                    codes,
+                    &mut *d,
+                    None::<&Allocation<Metal>>,
+                    None::<&Allocation<Metal>>,
+                    None::<&Allocation<Metal>>,
+                    Some(scales),
+                    Some(outer_scales),
+                    output_bias,
+                    None::<&Allocation<Metal>>,
+                    None::<&Allocation<Metal>>,
+                    None::<&Allocation<Metal>>,
+                    None::<&Allocation<Metal>>,
+                    std::slice::from_ref(&params),
+                    group_count_x,
+                    group_count_y,
+                    1,
+                    encoder,
+                );
             },
             MatmulB::FullPrecision {
                 b: weights,
@@ -274,12 +332,12 @@ impl GemmKernel {
                     aligned_inner_iterations: k / tiling.block_k(),
                     use_morton,
                     ab_scale,
+                    soft_cap,
                 };
 
                 let specialization = GemmSpecialization::from_plan(
                     plan,
                     shape,
-                    self.weights_data_type,
                     output_transform,
                     alignment,
                     GemmAPrologueKind::FullPrecision,
@@ -290,6 +348,8 @@ impl GemmKernel {
                     Some((a, a_offset)),
                     weights,
                     &mut *d,
+                    None::<&Allocation<Metal>>,
+                    None::<&Allocation<Metal>>,
                     None::<&Allocation<Metal>>,
                     None::<&Allocation<Metal>>,
                     None::<&Allocation<Metal>>,
@@ -377,7 +437,7 @@ impl GemmKernel {
                 let tiling = plan.tiling;
                 let alignment =
                     GemmAlignment::new(m % tiling.block_m() == 0, n % tiling.block_n() == 0, k % tiling.block_k() == 0);
-                let params = quant_params(shape, plan, ab_scale);
+                let params = packed_params(shape, plan, ab_scale, soft_cap);
                 let group_count_x = n.div_ceil(tiling.block_n());
                 let group_count_y = m.div_ceil(tiling.block_m());
 
@@ -401,7 +461,6 @@ impl GemmKernel {
                     let specialization = GemmSpecialization::from_plan(
                         plan,
                         shape,
-                        self.weights_data_type,
                         output_transform,
                         alignment,
                         a_prologue,
@@ -415,6 +474,8 @@ impl GemmKernel {
                         scales,
                         biases,
                         zero_points,
+                        None::<&Allocation<Metal>>,
+                        None::<&Allocation<Metal>>,
                         output_bias,
                         rht_factors,
                         a_int8,
@@ -481,15 +542,8 @@ impl GemmKernel {
         let base_gy = m.div_ceil(tiling.block_m());
         let alignment =
             GemmAlignment::new(m.is_multiple_of(tiling.block_m()), n.is_multiple_of(tiling.block_n()), true);
-        let part_spec = GemmSpecialization::from_plan(
-            plan,
-            shape,
-            self.weights_data_type,
-            GemmDTransform::empty(),
-            alignment,
-            a_prologue,
-            a_group_size,
-        )?;
+        let part_spec =
+            GemmSpecialization::from_plan(plan, shape, GemmDTransform::empty(), alignment, a_prologue, a_group_size)?;
 
         let elem = (m as usize) * (n as usize);
         let slice_bytes = elem * self.output_data_type.size_in_bytes();
@@ -507,6 +561,7 @@ impl GemmKernel {
             aligned_inner_iterations: kp / k_step,
             use_morton: false,
             ab_scale: 1.0,
+            soft_cap: 0.0,
         };
         let part_kernel = self.get_or_create(encoder.context(), part_spec)?;
         part_kernel.encode(
@@ -516,6 +571,8 @@ impl GemmKernel {
             scales,
             biases,
             zero_points,
+            None::<&Allocation<Metal>>,
+            None::<&Allocation<Metal>>,
             None::<&Allocation<Metal>>,
             None::<&Allocation<Metal>>,
             a_int8,
@@ -585,10 +642,11 @@ fn validate_int8_activation_arguments(
     Ok(())
 }
 
-fn quant_params(
+fn packed_params(
     shape: MatmulShape,
     plan: GemmPlan,
     ab_scale: f32,
+    soft_cap: f32,
 ) -> GemmParams {
     let MatmulShape {
         m,
@@ -609,5 +667,6 @@ fn quant_params(
         aligned_inner_iterations: outer_block_k(shape, plan.engine, plan.tiling).map_or(0, |step| k / step),
         use_morton: false,
         ab_scale,
+        soft_cap,
     }
 }

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/selection.rs
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/selection.rs
@@ -5,7 +5,10 @@ use super::{GemmEngine, GemmPlan, policy};
 use crate::{
     backends::common::{
         gpu_types::gemm::{GemmBPrologueKind, GemmTiling},
-        kernel::{activation_transform::ACTIVATION_SCALE_GROUP_SIZE, matmul::MatmulShape},
+        kernel::{
+            activation_transform::ACTIVATION_SCALE_GROUP_SIZE,
+            matmul::{MatmulBKind, MatmulShape},
+        },
     },
     data_type::DataType,
 };
@@ -23,8 +26,12 @@ pub struct GemmProblem {
 pub(super) enum GemmPlanError {
     #[error("MXU engine is not available for this GEMM")]
     MxuUnavailable,
-    #[error("quantized GEMM requires transposed contiguous B")]
-    UnsupportedQuantLayout,
+    #[error("packed GEMM requires transposed contiguous B")]
+    UnsupportedPackedLayout,
+    #[error("MXFP4 GEMM currently requires the simdgroup engine")]
+    UnsupportedMicrofloatEngine,
+    #[error("MXFP4 GEMM requires full-precision activations")]
+    UnsupportedMicrofloatActivation,
 }
 
 impl GemmProblem {
@@ -69,8 +76,16 @@ impl GemmProblem {
         if engine == GemmEngine::Mxu && !self.supports_mxu {
             return Err(GemmPlanError::MxuUnavailable);
         }
-        if self.shape.is_quant() && (!self.shape.b_transpose || self.shape.b_leading_dimension.is_some()) {
-            return Err(GemmPlanError::UnsupportedQuantLayout);
+        if self.shape.b_kind == MatmulBKind::Mxfp4 && !self.shape.a_full_precision {
+            return Err(GemmPlanError::UnsupportedMicrofloatActivation);
+        }
+        if self.shape.b_kind == MatmulBKind::Mxfp4 && engine != GemmEngine::Simdgroup {
+            return Err(GemmPlanError::UnsupportedMicrofloatEngine);
+        }
+        if self.shape.b_kind != MatmulBKind::Dense
+            && (!self.shape.b_transpose || self.shape.b_leading_dimension.is_some())
+        {
+            return Err(GemmPlanError::UnsupportedPackedLayout);
         }
         Ok(())
     }
@@ -93,6 +108,9 @@ impl GemmProblem {
         tiling: GemmTiling,
     ) -> u32 {
         let shape = self.shape;
+        if shape.b_kind == MatmulBKind::Mxfp4 {
+            return 1;
+        }
         let splittable = shape.is_quant() || (shape.b_transpose && shape.b_leading_dimension.is_none());
         if !splittable || !self.split_k_output_supported() {
             return 1;
@@ -153,6 +171,9 @@ pub(super) fn outer_block_k(
 }
 
 fn mxu_is_eligible(shape: MatmulShape) -> bool {
+    if shape.b_kind == MatmulBKind::Mxfp4 {
+        return false;
+    }
     if !shape.a_full_precision || shape.b_prologue == GemmBPrologueKind::FullPrecision {
         return true;
     }
@@ -167,11 +188,13 @@ fn select_tiling(
     apple_gpu_family: MTLGPUFamily,
 ) -> GemmTiling {
     match engine {
-        GemmEngine::Simdgroup if shape.is_quant() => {
+        GemmEngine::Simdgroup if shape.b_kind != MatmulBKind::Dense => {
             policy::simdgroup_quant_tile(shape.m, shape.n, shape.b_group_size.unwrap_or(0), apple_gpu_family)
         },
         GemmEngine::Simdgroup => policy::simdgroup_fp_tile(shape.m, shape.n, shape.k),
-        GemmEngine::Mxu if !shape.a_full_precision || shape.is_quant() => select_mxu_quant_tiling(shape),
+        GemmEngine::Mxu if !shape.a_full_precision || shape.b_kind != MatmulBKind::Dense => {
+            select_mxu_quant_tiling(shape)
+        },
         GemmEngine::Mxu if shape.b_transpose => policy::mxu_fp_tile(shape.m, shape.n, shape.k),
         GemmEngine::Mxu => policy::mxu_mn_tile(false, shape.m, shape.n),
     }

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/specialization.rs
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/specialization.rs
@@ -1,17 +1,13 @@
 use super::{GemmEngine, GemmPlan, error::GemmSpecializationError};
-use crate::{
-    backends::common::{
-        gpu_types::gemm::{GemmAPrologueKind, GemmAlignment, GemmBPrologueKind, GemmDTransform, GemmTiling},
-        kernel::matmul::MatmulShape,
-    },
-    data_type::DataType,
+use crate::backends::common::{
+    gpu_types::gemm::{GemmAPrologueKind, GemmAlignment, GemmBPrologueKind, GemmDTransform, GemmTiling},
+    kernel::matmul::MatmulShape,
 };
 
 const STAGE_WEIGHT_SCALE_MIN_GROUPS: u32 = 6;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(super) struct GemmSpecialization {
-    pub(super) weights_data_type: DataType,
     pub(super) tiling: GemmTiling,
     pub(super) use_mxu: bool,
     pub(super) output_transform: GemmDTransform,
@@ -31,7 +27,6 @@ impl GemmSpecialization {
     pub(super) fn from_plan(
         plan: GemmPlan,
         shape: MatmulShape,
-        weights_data_type: DataType,
         output_transform: GemmDTransform,
         alignment: GemmAlignment,
         a_prologue: GemmAPrologueKind,
@@ -39,7 +34,6 @@ impl GemmSpecialization {
     ) -> Result<Self, GemmSpecializationError> {
         let use_tuned_addressing = shape.is_quant() || plan.split_k > 1;
         let specialization = Self {
-            weights_data_type,
             tiling: plan.tiling,
             use_mxu: plan.engine == GemmEngine::Mxu,
             output_transform,
@@ -99,8 +93,8 @@ impl GemmSpecialization {
                 });
             }
         }
-        if self.b_prologue != GemmBPrologueKind::FullPrecision && !self.transpose_b {
-            return Err(GemmSpecializationError::QuantizedRequiresTransposedB);
+        if self.bits_per_b.is_some() && !self.transpose_b {
+            return Err(GemmSpecializationError::PackedRequiresTransposedB);
         }
         Ok(())
     }

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/common/arguments.h
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/common/arguments.h
@@ -16,6 +16,7 @@ struct GemvOperands {
   const device BT* scales;
   const device uint8_t* zero_points;
   const device BT* biases;
+  const device BT* outer_scales;
   const device AT* a;
   device DT* d;
   const device BT* output_bias;

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/common/epilogue.h
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/common/epilogue.h
@@ -54,7 +54,7 @@ struct Epilogue {
           if (params.output_transform.contains(GemmDTransform::BIAS)) {
             value += static_cast<DT>(ops.output_bias[global_row]);
           }
-          ops.d[input_row * params.out_vec_size + global_row] = value;
+          ops.d[size_t(input_row) * params.out_vec_size + global_row] = value;
         }
       }
     }
@@ -75,21 +75,18 @@ private:
       if (!(FULL_TILE || input_row < params.batch_size)) {
         return;
       }
-      device DT* output = ops.d + input_row * params.out_vec_size + tile.row0;
       Tile::for_each_output_row([&](auto output_index) UZU_ALWAYS_INLINE {
         constexpr uint R = decltype(output_index)::value;
         const uint global_row = tile.row0 + R;
         if (!OutputTile<Tile, FULL_TILE>::row_in_range(global_row, params.out_vec_size)) {
           return;
         }
-        if (tile.clamped && params.output_transform.contains(GemmDTransform::ACCUMULATE)) {
-          return;
-        }
+        device DT* output = ops.d + size_t(input_row) * params.out_vec_size + global_row;
         if constexpr (STAGE_HADAMARD) {
           shared_results[I * Tile::OUTPUT_ROWS + tile.local_row + R] =
-              transform<false>(result[I][R], output + R, global_row, ops, params);
+              transform<false>(result[I][R], output, global_row, ops, params);
         } else {
-          output[R] = static_cast<DT>(transform<true>(result[I][R], output + R, global_row, ops, params));
+          *output = static_cast<DT>(transform<true>(result[I][R], output, global_row, ops, params));
         }
       });
     });

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/common/microfloat_b_source.h
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/common/microfloat_b_source.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "../../common/microfloat.h"
+#include "arguments.h"
+#include "tile.h"
+
+namespace uzu {
+namespace gemm {
+
+template <typename Tile, typename AT, typename BT, typename DT, uint GROUP_SIZE, bool FULL_TILE>
+struct MicrofloatBSource {
+  using U = float;
+
+  static METAL_FUNC void accumulate(
+      thread U (&result)[Tile::INPUT_ROWS][Tile::ROWS_PER_LANE],
+      const thread GemvOperands<AT, BT, DT>& ops,
+      const thread GemvParams& params,
+      const thread OutputTile<Tile, FULL_TILE>& tile
+  ) {
+    static_assert(Tile::INPUT_ROWS == 1, "microfloat GEMV uses one input row");
+    static_assert(Tile::K_SPLIT == 1, "microfloat GEMV does not split K");
+    const uint code_row_bytes = params.in_vec_size / 2;
+    const uint scale_row_bytes = params.in_vec_size / GROUP_SIZE;
+    const float outer_scale = float(ops.outer_scales[0]);
+    const uint last_row = params.out_vec_size > 0 ? params.out_vec_size - 1 : 0;
+
+    size_t weight_rows[Tile::ROWS_PER_LANE];
+    Tile::for_each_output_row([&](auto output_index) UZU_ALWAYS_INLINE {
+      constexpr uint R = decltype(output_index)::value;
+      const uint output_row = tile.row0 + R;
+      const uint lookup_row = FULL_TILE ? output_row : min(output_row, last_row);
+      weight_rows[R] =
+          params.gathered ? ops.gather_indices[size_t(tile.input_row) * params.out_vec_size + lookup_row] : lookup_row;
+    });
+
+    for (uint inner = tile.reduction_lane; inner < params.in_vec_size; inner += Tile::REDUCTION_LANES) {
+      const float input_value = float(ops.a[size_t(tile.input_row) * params.in_vec_size + inner]);
+      Tile::for_each_output_row([&](auto output_index) UZU_ALWAYS_INLINE {
+        constexpr uint R = decltype(output_index)::value;
+        const uint output_row = tile.row0 + R;
+        if (!OutputTile<Tile, FULL_TILE>::row_in_range(output_row, params.out_vec_size)) {
+          return;
+        }
+        const size_t row = weight_rows[R];
+        const uint8_t packed = reinterpret_cast<const device uint8_t*>(ops.b)[row * code_row_bytes + inner / 2];
+        const uint code = (inner & 1u) == 0 ? packed & 0x0fu : packed >> 4u;
+        const uint exponent =
+            reinterpret_cast<const device uint8_t*>(ops.scales)[row * scale_row_bytes + inner / GROUP_SIZE];
+        const float weight = decode_e2m1(code) * decode_e8m0(exponent) * outer_scale;
+        result[0][R] = fma(input_value, weight, result[0][R]);
+      });
+    }
+  }
+};
+
+} // namespace gemm
+} // namespace uzu

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/common/quant_b_source.h
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/common/quant_b_source.h
@@ -32,12 +32,14 @@ struct QuantBSource {
     const uint row_stride = Slice::row_stride(params);
     const uint group_slot = tile.reduction_lane / Tile::GROUP_LANES;
     const uint group_offset = (tile.reduction_lane % Tile::GROUP_LANES) * Slice::VALUES_PER_LANE;
+    const uint last_row = params.out_vec_size > 0 ? params.out_vec_size - 1 : 0;
     uint weight_row_indices[Tile::ROWS_PER_LANE];
     Tile::for_each_output_row([&](auto output_index) UZU_ALWAYS_INLINE {
       constexpr uint R = decltype(output_index)::value;
       const uint output_row = tile.row0 + R;
+      const uint lookup_row = FULL_TILE ? output_row : min(output_row, last_row);
       weight_row_indices[R] =
-          params.gathered ? ops.gather_indices[tile.input_row * params.out_vec_size + output_row] : output_row;
+          params.gathered ? ops.gather_indices[tile.input_row * params.out_vec_size + lookup_row] : lookup_row;
     });
 
     const device uint8_t* weights = reinterpret_cast<const device uint8_t*>(ops.b);

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/common/tile.h
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/common/tile.h
@@ -69,16 +69,12 @@ struct OutputTile {
   uint local_row;
   uint row0;
   bool writer;
-  bool clamped;
 
-  static METAL_FUNC OutputTile
-  make(uint output_tile_idx, uint input_tile_idx, uint simd_group, uint simd_lane, uint out_vec_size) {
+  static METAL_FUNC OutputTile make(uint output_tile_idx, uint input_tile_idx, uint simd_group, uint simd_lane) {
     const uint row_group = simd_group / Tile::K_SPLIT;
     const uint k_slice = simd_group % Tile::K_SPLIT;
     const uint row_block = simd_lane / Tile::REDUCTION_LANES;
     const uint local_row = row_group * Tile::SIMDGROUP_OUTPUT_ROWS + row_block * Tile::ROWS_PER_LANE;
-    const uint unclamped = output_tile_idx * Tile::OUTPUT_ROWS + local_row;
-    const uint last = out_vec_size > Tile::ROWS_PER_LANE ? out_vec_size - Tile::ROWS_PER_LANE : 0;
     OutputTile tile;
     tile.simd_group = simd_group;
     tile.simd_lane = simd_lane;
@@ -88,9 +84,8 @@ struct OutputTile {
     tile.input_row = input_tile_idx * Tile::INPUT_ROWS;
     tile.tile_row = output_tile_idx * Tile::OUTPUT_ROWS;
     tile.local_row = local_row;
-    tile.row0 = FULL_TILE ? unclamped : min(unclamped, last);
+    tile.row0 = tile.tile_row + local_row;
     tile.writer = Tile::K_SPLIT == 1 || k_slice == 0;
-    tile.clamped = !FULL_TILE && unclamped > last;
     return tile;
   }
 

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/gemv.metal
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/gemv.metal
@@ -4,6 +4,7 @@
 #include "common/arguments.h"
 #include "common/epilogue.h"
 #include "common/full_precision_b_source.h"
+#include "common/microfloat_b_source.h"
 #include "common/tile.h"
 #include "common/quant_b_source.h"
 #include "common/reduce.h"
@@ -25,10 +26,11 @@ template <
     uint OUTPUT_ROW_TILE,
     uint REDUCTION_LANES,
     uint GROUP_LANES,
-    uint NUM_SIMDGROUPS>
-VARIANTS(AT, bfloat, float)
-VARIANTS(BT, bfloat, float)
-VARIANTS(DT, bfloat, float)
+    uint NUM_SIMDGROUPS,
+    bool MICROFLOAT>
+VARIANTS(AT, half, bfloat, float)
+VARIANTS(BT, half, bfloat, float)
+VARIANTS(DT, half, bfloat, float)
 CONSTRAINT(BT != "float" || (AT == "float" && DT == "float"))
 VARIANTS(
     B_PROLOGUE,
@@ -45,9 +47,17 @@ VARIANTS(OUTPUT_ROW_TILE, 1, 2, 4, 8, 16, 32, 64)
 VARIANTS(REDUCTION_LANES, 8, 16, 32)
 VARIANTS(GROUP_LANES, 1, 2, 4, 8, 16)
 VARIANTS(NUM_SIMDGROUPS, 2, 4, 8)
+VARIANTS(MICROFLOAT, false, true)
 
-CONSTRAINT((B_PROLOGUE == GemmBPrologueKind::FullPrecision) == (BITS == 0))
-CONSTRAINT((BITS == 0) == (GROUP_SIZE == 0))
+CONSTRAINT(MICROFLOAT || (AT != "half" && BT != "half" && DT != "half"))
+CONSTRAINT(MICROFLOAT || (B_PROLOGUE == GemmBPrologueKind::FullPrecision) == (BITS == 0))
+CONSTRAINT(MICROFLOAT || (BITS == 0) == (GROUP_SIZE == 0))
+CONSTRAINT(!MICROFLOAT || (B_PROLOGUE == GemmBPrologueKind::FullPrecision && BITS == 4))
+CONSTRAINT(!MICROFLOAT || GROUP_SIZE == 16 || GROUP_SIZE == 32)
+CONSTRAINT(
+    !MICROFLOAT ||
+    (K_SPLIT == 1 && INPUT_ALIGNED && INPUT_ROW_TILE == 1 && OUTPUT_ROW_TILE == 32 && REDUCTION_LANES == 32 &&
+     GROUP_LANES == 1 && NUM_SIMDGROUPS == 8))
 CONSTRAINT(B_PROLOGUE == GemmBPrologueKind::FullPrecision || BT != "float")
 CONSTRAINT(BITS == 0 || K_SPLIT == 1)
 CONSTRAINT(BITS != 0 || (INPUT_ROW_TILE == 1 && REDUCTION_LANES == 32 && NUM_SIMDGROUPS == 8 && GROUP_LANES == 1))
@@ -103,7 +113,7 @@ CONSTRAINT(BITS != 4 || (GROUP_SIZE / GROUP_LANES) % 16 == 0)
 CONSTRAINT(BITS != 8 || (GROUP_SIZE / GROUP_LANES) % 8 == 0)
 CONSTRAINT(BITS != 0 || REDUCTION_LANES == 32)
 CONSTRAINT(
-    BITS == 0 || INPUT_ROW_TILE > 1 || (BITS == 4 &&
+    MICROFLOAT || BITS == 0 || INPUT_ROW_TILE > 1 || (BITS == 4 &&
      ((GROUP_SIZE == 16 && GROUP_LANES == 1) || (GROUP_SIZE == 32 && GROUP_LANES == 2) ||
       (GROUP_SIZE == 64 && GROUP_LANES == 4) || (GROUP_SIZE == 128 && GROUP_LANES == 8))) ||
     (BITS == 8 &&
@@ -112,11 +122,12 @@ CONSTRAINT(
 KERNEL(Gemv)(
     const device uint32_t* b,
     const device BT* scales
-        OPTIONAL(B_PROLOGUE != GemmBPrologueKind::FullPrecision),
+        OPTIONAL(B_PROLOGUE != GemmBPrologueKind::FullPrecision || MICROFLOAT),
     const device uint8_t* zero_points
         OPTIONAL(B_PROLOGUE == GemmBPrologueKind::ScaleZeroPointDequant),
     const device BT* biases
         OPTIONAL(B_PROLOGUE == GemmBPrologueKind::ScaleBiasDequant),
+    const device BT* outer_scales OPTIONAL(MICROFLOAT),
     const device AT* a,
     device DT* d,
     const device BT* output_bias
@@ -142,17 +153,19 @@ KERNEL(Gemv)(
     const uint simd_group THREADS(NUM_SIMDGROUPS)
 ) {
   using Ops = GemvOperands<AT, BT, DT>;
-  const Ops ops = {b, scales, zero_points, biases, a, d, output_bias, hadamard_factors, gather_indices};
+  const Ops ops = {b, scales, zero_points, biases, outer_scales, a, d, output_bias, hadamard_factors, gather_indices};
   const GemvParams params =
       {in_vec_size, out_vec_size, batch_size, ab_scale, soft_cap, output_transform, gathered, signed_codes};
   dispatch_bool(full_tile, [&](auto full_tile_constant) {
     constexpr bool FullTile = decltype(full_tile_constant)::value;
     using Tile = GemvTile<INPUT_ROW_TILE, OUTPUT_ROW_TILE, REDUCTION_LANES, GROUP_LANES, NUM_SIMDGROUPS, K_SPLIT>;
     const OutputTile<Tile, FullTile> tile =
-        OutputTile<Tile, FullTile>::make(output_tile_idx, input_tile_idx, simd_group, simd_lane, out_vec_size);
+        OutputTile<Tile, FullTile>::make(output_tile_idx, input_tile_idx, simd_group, simd_lane);
     thread float result[Tile::INPUT_ROWS][Tile::ROWS_PER_LANE] = {{0}};
 
-    if constexpr (BITS == 0) {
+    if constexpr (MICROFLOAT) {
+      MicrofloatBSource<Tile, AT, BT, DT, GROUP_SIZE, FullTile>::accumulate(result, ops, params, tile);
+    } else if constexpr (BITS == 0) {
       FullPrecisionBSource<Tile, AT, BT, DT, INPUT_ALIGNED, FullTile>::accumulate(result, ops, params, tile);
     } else {
       QuantBSource<Tile, AT, BT, DT, B_PROLOGUE, GROUP_SIZE, BITS, INPUT_ALIGNED, FullTile>::accumulate(

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/kernel.rs
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/kernel.rs
@@ -266,6 +266,9 @@ impl GemvKernel {
         let (scales, zero_points, biases) = match &b {
             MatmulB::FullPrecision {
                 ..
+            }
+            | MatmulB::Microfloat {
+                ..
             } => (None, None, None),
             MatmulB::ScaleBiasDequant {
                 scales,
@@ -287,6 +290,12 @@ impl GemvKernel {
         let context = encoder.context();
         let pipeline = self.get_or_create(context, specialization)?;
         match b {
+            MatmulB::Microfloat {
+                metadata,
+                ..
+            } => {
+                return Err(MatmulError::UnsupportedMicrofloat(metadata.encoding.format));
+            },
             MatmulB::FullPrecision {
                 b: weights,
             } => pipeline.encode(

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/kernel.rs
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/kernel.rs
@@ -8,7 +8,7 @@ use crate::{
                 HADAMARD_TRANSFORM_BLOCK_SIZE,
                 gemm::{GemmBPrologueKind, GemmDTransform},
             },
-            kernel::matmul::MatmulShape,
+            kernel::matmul::{MatmulBKind, MatmulShape},
         },
         metal::{context::MetalContext, error::MetalError, kernel::GemvMetalKernel},
     },
@@ -30,6 +30,7 @@ pub struct GemvSpecialization {
     input_row_tile: u32,
     reduction_lanes: u32,
     group_lanes: u32,
+    microfloat: bool,
     gathered: bool,
     signed_codes: bool,
     full_tile: bool,
@@ -47,7 +48,12 @@ impl GemvSpecialization {
         let is_quant = shape.is_quant();
         let bits = shape.b_bits.unwrap_or(0);
         let bf16_io = input_data_type == DataType::BF16 && output_data_type == DataType::BF16;
-        let tile = if is_quant && shape.gathered {
+        let tile = if shape.b_kind == MatmulBKind::Mxfp4 {
+            if shape.m > GEMV_MAX_BATCH && !shape.gathered {
+                return None;
+            }
+            Some(policy::DEFAULT_TILE)
+        } else if is_quant && shape.gathered {
             policy::gathered_tile(bits, shape.b_group_size.unwrap_or(0), shape.m, shape.n)
         } else if is_quant {
             policy::quantized_tile(
@@ -87,8 +93,9 @@ impl GemvSpecialization {
         if !shape.b_transpose || !shape.a_full_precision {
             return None;
         }
+        let microfloat = shape.b_kind == MatmulBKind::Mxfp4;
         let is_quant = shape.is_quant();
-        let bad_leading_dimension = if is_quant {
+        let bad_leading_dimension = if is_quant || microfloat {
             shape.b_leading_dimension.is_some()
         } else {
             shape.b_leading_dimension.is_some_and(|ld| ld != shape.k)
@@ -103,14 +110,16 @@ impl GemvSpecialization {
             return None;
         }
         let bits = shape.b_bits.unwrap_or(0);
-        if !is_quant {
+        if !is_quant && !microfloat {
             let mixed_precision = weights_data_type == DataType::F32
                 && (input_data_type != DataType::F32 || output_data_type != DataType::F32);
             if mixed_precision || shape.n < DEFAULT_RESULTS_PER_SIMDGROUP || shape.m > GEMV_MAX_BATCH {
                 return None;
             }
         }
-        let block_size = if !is_quant {
+        let block_size = if microfloat {
+            shape.b_group_size.unwrap_or(FP_K_BLOCK)
+        } else if !is_quant {
             FP_K_BLOCK
         } else if bits == 4 {
             512
@@ -118,8 +127,7 @@ impl GemvSpecialization {
             256
         };
         let input_aligned = shape.k.is_multiple_of(block_size);
-        // Gathered quantized rows cannot share one input tile.
-        if is_quant && shape.gathered && tile.input_row_tile > 1 {
+        if (is_quant && shape.gathered || microfloat) && tile.input_row_tile > 1 {
             return None;
         }
         let specialization = Self {
@@ -134,9 +142,10 @@ impl GemvSpecialization {
             input_row_tile: tile.input_row_tile,
             reduction_lanes: tile.reduction_lanes,
             group_lanes: tile.group_lanes,
+            microfloat,
             gathered: shape.gathered,
             signed_codes: shape.signed_codes,
-            full_tile: full_tile(shape, tile),
+            full_tile: shape.m.is_multiple_of(tile.input_row_tile) && shape.n.is_multiple_of(tile.output_row_tile()),
         };
         Some(specialization)
     }
@@ -167,19 +176,13 @@ impl GemvSpecialization {
             self.reduction_lanes,
             self.group_lanes,
             self.num_simdgroups,
+            self.microfloat,
             self.output_transform,
             self.gathered,
             self.signed_codes,
             self.full_tile,
         )
     }
-}
-
-fn full_tile(
-    shape: &MatmulShape,
-    tile: policy::GemvTile,
-) -> bool {
-    shape.m.is_multiple_of(tile.input_row_tile) && shape.n.is_multiple_of(tile.output_row_tile())
 }
 
 use std::collections::{HashMap, hash_map::Entry};
@@ -262,90 +265,57 @@ impl GemvKernel {
             });
         };
 
-        // Preserve each weight buffer's residency range.
-        let (scales, zero_points, biases) = match &b {
+        let (weights, scales, zero_points, biases, outer_scales) = match b {
             MatmulB::FullPrecision {
+                b,
+            } => (b.into_parts(), None, None, None, None),
+            MatmulB::Microfloat {
+                codes,
+                scales,
+                outer_scales,
                 ..
-            }
-            | MatmulB::Microfloat {
-                ..
-            } => (None, None, None),
+            } => (codes.into_parts(), Some(scales), None, None, Some(outer_scales)),
             MatmulB::ScaleBiasDequant {
+                b,
                 scales,
                 biases,
                 ..
-            } => (Some(*scales), None, Some(*biases)),
+            } => (b.into_parts(), Some(scales), None, Some(biases), None),
             MatmulB::ScaleZeroPointDequant {
+                b,
                 scales,
                 zero_points,
                 ..
-            } => (Some(*scales), Some(*zero_points), None),
+            } => (b.into_parts(), Some(scales), Some(zero_points), None, None),
             MatmulB::ScaleSymmetricDequant {
+                b,
                 scales,
                 ..
-            } => (Some(*scales), None, None),
+            } => (b.into_parts(), Some(scales), None, None, None),
         };
 
         let output_group_count = n.div_ceil(specialization.output_row_tile());
         let context = encoder.context();
         let pipeline = self.get_or_create(context, specialization)?;
-        match b {
-            MatmulB::Microfloat {
-                metadata,
-                ..
-            } => {
-                return Err(MatmulError::UnsupportedMicrofloat(metadata.encoding.format));
-            },
-            MatmulB::FullPrecision {
-                b: weights,
-            } => pipeline.encode(
-                weights,
-                scales,
-                zero_points,
-                biases,
-                (a, a_offset),
-                &mut *d,
-                output_bias,
-                rht_factors,
-                gather_indices,
-                k,
-                n,
-                m,
-                ab_scale,
-                output_group_count,
-                soft_cap,
-                encoder,
-            ),
-            MatmulB::ScaleBiasDequant {
-                b: weights,
-                ..
-            }
-            | MatmulB::ScaleZeroPointDequant {
-                b: weights,
-                ..
-            }
-            | MatmulB::ScaleSymmetricDequant {
-                b: weights,
-                ..
-            } => pipeline.encode(
-                weights,
-                scales,
-                zero_points,
-                biases,
-                (a, a_offset),
-                &mut *d,
-                output_bias,
-                rht_factors,
-                gather_indices,
-                k,
-                n,
-                m,
-                ab_scale,
-                output_group_count,
-                soft_cap,
-                encoder,
-            ),
-        }
+        pipeline.encode(
+            weights,
+            scales,
+            zero_points,
+            biases,
+            outer_scales,
+            (a, a_offset),
+            &mut *d,
+            output_bias,
+            rht_factors,
+            gather_indices,
+            k,
+            n,
+            m,
+            ab_scale,
+            output_group_count,
+            soft_cap,
+            encoder,
+        );
 
         Ok(())
     }

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/mod.rs
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/mod.rs
@@ -17,7 +17,10 @@ use crate::{
             gpu_types::gemm::{GemmBPrologueKind, GemmTiling},
             kernel::{
                 activation_transform::ACTIVATION_SCALE_GROUP_SIZE,
-                matmul::{A8ActivationPlan, ActivationFormat, MatmulArguments, MatmulError, MatmulKernel, MatmulShape},
+                matmul::{
+                    A8ActivationPlan, ActivationFormat, MatmulArguments, MatmulB, MatmulError, MatmulKernel,
+                    MatmulShape,
+                },
             },
         },
         metal::{Metal, context::MetalContext, error::MetalError},
@@ -217,6 +220,13 @@ impl MatmulKernel for MatmulMetalKernel {
         arguments: MatmulArguments<'a, 'b, 'd, Metal, TB>,
         encoder: &mut Encoder<Metal>,
     ) -> Result<(), MetalError> {
+        if let MatmulB::Microfloat {
+            metadata,
+            ..
+        } = &arguments.b
+        {
+            return Err(MatmulError::UnsupportedMicrofloat(metadata.encoding.format).into());
+        }
         let shape = MatmulShape::from_arguments(&arguments);
         let plan = match self.select_dispatch(&shape, encoder.context()) {
             MatmulDispatch::Gemv(gemv) => {

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/mod.rs
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/mod.rs
@@ -18,8 +18,8 @@ use crate::{
             kernel::{
                 activation_transform::ACTIVATION_SCALE_GROUP_SIZE,
                 matmul::{
-                    A8ActivationPlan, ActivationFormat, MatmulArguments, MatmulB, MatmulError, MatmulKernel,
-                    MatmulShape,
+                    A8ActivationPlan, ActivationFormat, MatmulArguments, MatmulB, MatmulBKind, MatmulError,
+                    MatmulKernel, MatmulShape,
                 },
             },
         },
@@ -142,7 +142,7 @@ impl MatmulKernel for MatmulMetalKernel {
         output_data_type: DataType,
     ) -> Result<Self, MetalError> {
         for data_type in [weights_data_type, input_data_type, output_data_type] {
-            if !matches!(data_type, DataType::BF16 | DataType::F32) {
+            if !matches!(data_type, DataType::F16 | DataType::BF16 | DataType::F32) {
                 return Err(MatmulError::<Metal>::UnsupportedDataType(data_type).into());
             }
         }
@@ -220,14 +220,34 @@ impl MatmulKernel for MatmulMetalKernel {
         arguments: MatmulArguments<'a, 'b, 'd, Metal, TB>,
         encoder: &mut Encoder<Metal>,
     ) -> Result<(), MetalError> {
+        let shape = MatmulShape::from_arguments(&arguments);
+        if shape.b_kind != MatmulBKind::Mxfp4 {
+            for data_type in [self.weights_data_type, self.input_data_type, self.output_data_type] {
+                if data_type == DataType::F16 {
+                    return Err(MatmulError::<Metal>::UnsupportedDataType(data_type).into());
+                }
+            }
+        }
         if let MatmulB::Microfloat {
+            codes,
+            scales,
+            outer_scales,
             metadata,
-            ..
         } = &arguments.b
         {
-            return Err(MatmulError::UnsupportedMicrofloat(metadata.encoding.format).into());
+            let (code_bytes, scale_bytes) = metadata.storage_sizes().map_err(MatmulError::InvalidMicrofloat)?;
+            let rows_match = arguments.gather_indices.is_some() || metadata.rows == arguments.n;
+            if !arguments.b_transpose
+                || arguments.b_leading_dimension.is_some()
+                || !rows_match
+                || metadata.columns != arguments.k
+                || codes.size() < code_bytes
+                || scales.size() < scale_bytes
+                || outer_scales.size() < self.weights_data_type.size_in_bytes()
+            {
+                return Err(MatmulError::InvalidMicrofloatStorage.into());
+            }
         }
-        let shape = MatmulShape::from_arguments(&arguments);
         let plan = match self.select_dispatch(&shape, encoder.context()) {
             MatmulDispatch::Gemv(gemv) => {
                 return self.gemv.encode(arguments, gemv, encoder).map_err(MetalError::from);

--- a/crates/uzu-engine/src/config/weight_matrix/microfloat_spec.rs
+++ b/crates/uzu-engine/src/config/weight_matrix/microfloat_spec.rs
@@ -1,0 +1,11 @@
+use uzu_engine_macros::uzu_config;
+
+use crate::{backends::common::microfloat::MicrofloatFormat, config::weight_matrix::Layout};
+
+#[uzu_config(super::WeightMatrixSpec)]
+pub struct MicrofloatSpec {
+    pub bits: u32,
+    pub group_size: u32,
+    pub scale_mode: MicrofloatFormat,
+    pub layout: Layout,
+}

--- a/crates/uzu-engine/src/config/weight_matrix/mod.rs
+++ b/crates/uzu-engine/src/config/weight_matrix/mod.rs
@@ -4,6 +4,7 @@ pub mod full_precision_spec;
 pub mod hybrid_spec;
 pub mod int_spec;
 pub mod low_rank_spec;
+pub mod microfloat_spec;
 pub mod mlx_spec;
 
 #[uzu_config]
@@ -18,6 +19,7 @@ pub enum Layout {
     low_rank_spec::LowRankSpec,
     hybrid_spec::HybridSpec,
     int_spec::IntSpec,
+    microfloat_spec::MicrofloatSpec,
     mlx_spec::MLXSpec
 )]
 pub struct WeightMatrixSpec;

--- a/crates/uzu-engine/src/encodable_block/embedding_table.rs
+++ b/crates/uzu-engine/src/encodable_block/embedding_table.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     config::weight_matrix::{AnyWeightMatrixSpec, Layout},
     data_type::DataType,
-    encodable_block::weight_matrix::{WeightMatrix, WeightMatrixError},
+    encodable_block::weight_matrix::{QuantizationInfo, WeightMatrix, WeightMatrixError},
     parameters::{ParameterLoaderError, ParameterTree},
 };
 
@@ -65,21 +65,32 @@ impl<B: Backend> EmbeddingTable<B> {
         }
 
         let lookup = match matrix.quantization() {
-            None => LookupKernel::FullPrecision(
-                <B::Kernels as Kernels>::FullPrecisionEmbeddingLookupKernel::new(context, data_type)
-                    .map_err(EmbeddingTableError::BackendError)?,
-            ),
-            Some(info) => LookupKernel::Quantized(
-                <B::Kernels as Kernels>::QuantizedEmbeddingLookupKernel::new(
+            None => {
+                let kernel = <B::Kernels as Kernels>::FullPrecisionEmbeddingLookupKernel::new(context, data_type)
+                    .map_err(EmbeddingTableError::BackendError)?;
+                LookupKernel::FullPrecision(kernel)
+            },
+            Some(QuantizationInfo::Microfloat(_)) => {
+                return Err(EmbeddingTableError::UnsupportedConfiguration(
+                    "microfloat embedding tables are not supported".into(),
+                ));
+            },
+            Some(QuantizationInfo::Integer {
+                mode,
+                method,
+                group_size,
+            }) => {
+                let kernel = <B::Kernels as Kernels>::QuantizedEmbeddingLookupKernel::new(
                     context,
                     data_type,
-                    info.group_size,
-                    info.mode,
-                    info.method,
+                    group_size,
+                    mode,
+                    method,
                     output_hadamard_factors.is_some(),
                 )
-                .map_err(EmbeddingTableError::BackendError)?,
-            ),
+                .map_err(EmbeddingTableError::BackendError)?;
+                LookupKernel::Quantized(kernel)
+            },
         };
 
         Ok(Self {

--- a/crates/uzu-engine/src/encodable_block/linear/matmul.rs
+++ b/crates/uzu-engine/src/encodable_block/linear/matmul.rs
@@ -157,6 +157,7 @@ impl<B: Backend> LinearMatmul<B> {
             k: self.input_dim,
             b_transpose: true,
             b_leading_dimension: None,
+            b_kind: b.kind(),
             b_prologue: b.b_prologue(),
             b_bits: b.bits_per_b(),
             b_group_size: b.group_size(),

--- a/crates/uzu-engine/src/encodable_block/linear/matmul.rs
+++ b/crates/uzu-engine/src/encodable_block/linear/matmul.rs
@@ -8,8 +8,7 @@ use crate::{
         kernel::{
             Kernels,
             matmul::{
-                A8ActivationPlan, ActivationFormat, MatmulA, MatmulArguments, MatmulB, MatmulDOps, MatmulKernel,
-                MatmulShape,
+                A8ActivationPlan, ActivationFormat, MatmulA, MatmulArguments, MatmulDOps, MatmulKernel, MatmulShape,
             },
         },
     },
@@ -63,8 +62,6 @@ fn load_biases<B: Backend>(
 }
 
 impl<B: Backend> LinearMatmul<B> {
-    /// Loads a linear over any parsed spec — full precision, MLX or Int. Hybrid
-    /// compositions live in the wrappers, not here.
     pub fn load(
         context: &B::Context,
         spec: AnyWeightMatrixSpec,
@@ -77,8 +74,9 @@ impl<B: Backend> LinearMatmul<B> {
         bias_tree: Option<&ParameterTree<B>>,
         output_hadamard_factors: Option<Allocation<B>>,
     ) -> Result<Self, LinearMatmulError<B>> {
+        let microfloat = matches!(spec, AnyWeightMatrixSpec::MicrofloatSpec(_));
         for data_type in [weights_data_type, input_data_type, output_data_type] {
-            if !matches!(data_type, DataType::BF16 | DataType::F32) {
+            if !matches!(data_type, DataType::BF16 | DataType::F32) && !(microfloat && data_type == DataType::F16) {
                 return Err(LinearMatmulError::UnsupportedDataType(data_type));
             }
         }
@@ -131,7 +129,7 @@ impl<B: Backend> LinearMatmul<B> {
         self.kernel.lock().encode(
             MatmulArguments {
                 a,
-                b: self.matmul_b(),
+                b: self.matrix.matmul_b(),
                 b_leading_dimension: None,
                 b_transpose: true,
                 d: &mut output,
@@ -152,7 +150,7 @@ impl<B: Backend> LinearMatmul<B> {
         batch_dim: u32,
         a_full_precision: bool,
     ) -> MatmulShape {
-        let b = self.matmul_b();
+        let b = self.matrix.matmul_b();
         MatmulShape {
             m: batch_dim,
             n: self.output_dim,
@@ -174,15 +172,11 @@ impl<B: Backend> LinearMatmul<B> {
         batch_dim: u32,
         context: &B::Context,
     ) -> ActivationFormat {
-        if !self.matmul_b().signed_codes() {
+        if !self.matrix.matmul_b().signed_codes() {
             return ActivationFormat::Bf16;
         }
         let bf16_shape = self.matmul_shape(batch_dim, true);
         self.kernel.lock().select_activation_format(&bf16_shape, context)
-    }
-
-    fn matmul_b(&self) -> MatmulB<'_, B> {
-        self.matrix.matmul_b()
     }
 
     fn d_ops(&self) -> MatmulDOps<'_, B> {

--- a/crates/uzu-engine/src/encodable_block/linear/mod.rs
+++ b/crates/uzu-engine/src/encodable_block/linear/mod.rs
@@ -100,7 +100,8 @@ impl<B: Backend> dyn Linear<B> {
         match spec {
             spec @ (AnyWeightMatrixSpec::FullPrecisionSpec(_)
             | AnyWeightMatrixSpec::MLXSpec(_)
-            | AnyWeightMatrixSpec::IntSpec(_)) => {
+            | AnyWeightMatrixSpec::IntSpec(_)
+            | AnyWeightMatrixSpec::MicrofloatSpec(_)) => {
                 let block = LinearMatmul::load(
                     context,
                     spec,

--- a/crates/uzu-engine/src/encodable_block/weight_matrix.rs
+++ b/crates/uzu-engine/src/encodable_block/weight_matrix.rs
@@ -5,6 +5,7 @@ use crate::{
         Allocation, Backend,
         gpu_types::{QuantizationMethod, QuantizationMode},
         kernel::matmul::MatmulB,
+        microfloat::{MicrofloatEncoding, MicrofloatError, MicrofloatMetadata},
     },
     config::weight_matrix::{AnyWeightMatrixSpec, Layout},
     data_type::DataType,
@@ -15,15 +16,20 @@ use crate::{
 pub enum WeightMatrixError<B: Backend> {
     #[error("Parameter loading error: {0}")]
     ParameterError(#[from] ParameterLoaderError<B>),
+    #[error("Microfloat error: {0}")]
+    MicrofloatError(#[from] MicrofloatError),
     #[error("Unsupported weight matrix configuration: {0}")]
     UnsupportedConfiguration(String),
 }
 
-#[derive(Clone, Copy)]
-pub struct QuantizationInfo {
-    pub mode: QuantizationMode,
-    pub method: QuantizationMethod,
-    pub group_size: u32,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuantizationInfo {
+    Integer {
+        mode: QuantizationMode,
+        method: QuantizationMethod,
+        group_size: u32,
+    },
+    Microfloat(MicrofloatEncoding),
 }
 
 pub struct ParsedWeightSpec {
@@ -32,50 +38,60 @@ pub struct ParsedWeightSpec {
 }
 
 pub fn parse_spec<B: Backend>(spec: &AnyWeightMatrixSpec) -> Result<ParsedWeightSpec, WeightMatrixError<B>> {
-    let (layout, quantized) = match spec {
+    let (layout, quantization) = match spec {
         AnyWeightMatrixSpec::FullPrecisionSpec(spec) => (spec.layout.clone(), None),
         AnyWeightMatrixSpec::MLXSpec(spec) => {
-            (spec.layout.clone(), Some((spec.bits, spec.group_size, QuantizationMethod::ScaleBias)))
+            let quantization = integer_quantization::<B>(spec.bits, spec.group_size, QuantizationMethod::ScaleBias)?;
+            (spec.layout.clone(), Some(quantization))
         },
-        AnyWeightMatrixSpec::IntSpec(spec) => (
-            spec.layout.clone(),
-            Some((
-                spec.bits,
-                spec.group_size,
-                if spec.is_symmetric {
-                    QuantizationMethod::ScaleSymmetric
-                } else {
-                    QuantizationMethod::ScaleZeroPoint
-                },
-            )),
-        ),
-        spec => return Err(WeightMatrixError::UnsupportedConfiguration(format!("{spec:?}"))),
-    };
-    let quantization = match quantized {
-        None => None,
-        Some((bits, group_size, method)) => {
-            let mode = match bits {
-                4 => QuantizationMode::U4,
-                8 => QuantizationMode::U8,
-                _ => {
-                    return Err(WeightMatrixError::UnsupportedConfiguration(format!(
-                        "{method} bits={bits}, group_size={group_size}"
-                    )));
-                },
+        AnyWeightMatrixSpec::IntSpec(spec) => {
+            let method = if spec.is_symmetric {
+                QuantizationMethod::ScaleSymmetric
+            } else {
+                QuantizationMethod::ScaleZeroPoint
             };
-            if group_size == 0 {
-                return Err(WeightMatrixError::UnsupportedConfiguration("group size must be non-zero".into()));
-            }
-            Some(QuantizationInfo {
-                mode,
-                method,
-                group_size,
-            })
+            let quantization = integer_quantization::<B>(spec.bits, spec.group_size, method)?;
+            (spec.layout.clone(), Some(quantization))
         },
+        AnyWeightMatrixSpec::MicrofloatSpec(spec) => {
+            if spec.layout != Layout::OutputInput {
+                return Err(WeightMatrixError::UnsupportedConfiguration(format!(
+                    "microfloat matrices require output-input layout, got {:?}",
+                    spec.layout,
+                )));
+            }
+            let encoding = MicrofloatEncoding::new(spec.scale_mode, spec.bits, spec.group_size)?;
+            (spec.layout.clone(), Some(QuantizationInfo::Microfloat(encoding)))
+        },
+        spec => return Err(WeightMatrixError::UnsupportedConfiguration(format!("{spec:?}"))),
     };
     Ok(ParsedWeightSpec {
         layout,
         quantization,
+    })
+}
+
+fn integer_quantization<B: Backend>(
+    bits: u32,
+    group_size: u32,
+    method: QuantizationMethod,
+) -> Result<QuantizationInfo, WeightMatrixError<B>> {
+    let mode = match bits {
+        4 => QuantizationMode::U4,
+        8 => QuantizationMode::U8,
+        _ => {
+            return Err(WeightMatrixError::UnsupportedConfiguration(format!(
+                "{method} bits={bits}, group_size={group_size}"
+            )));
+        },
+    };
+    if group_size == 0 {
+        return Err(WeightMatrixError::UnsupportedConfiguration("group size must be non-zero".into()));
+    }
+    Ok(QuantizationInfo::Integer {
+        mode,
+        method,
+        group_size,
     })
 }
 
@@ -85,11 +101,19 @@ enum QuantizedCorrection<B: Backend> {
     ZeroPoints(Allocation<B>),
 }
 
-struct Quantized<B: Backend> {
-    scales: Allocation<B>,
-    correction: QuantizedCorrection<B>,
-    info: QuantizationInfo,
-    signed_codes: bool,
+enum Quantized<B: Backend> {
+    Integer {
+        scales: Allocation<B>,
+        correction: QuantizedCorrection<B>,
+        mode: QuantizationMode,
+        group_size: u32,
+        signed_codes: bool,
+    },
+    Microfloat {
+        scales: Allocation<B>,
+        outer_scales: Allocation<B>,
+        metadata: MicrofloatMetadata,
+    },
 }
 
 pub struct WeightMatrix<B: Backend> {
@@ -117,7 +141,7 @@ impl<B: Backend> WeightMatrix<B> {
         }
         let (rows, columns) = physical_shape(&layout, output_dim, input_dim);
 
-        let Some(info) = quantization else {
+        let Some(quantization) = quantization else {
             let values = tree.leaf("weights")?.validate(&[rows, columns], data_type)?.read_allocation()?;
             return Ok(Self {
                 values,
@@ -125,20 +149,43 @@ impl<B: Backend> WeightMatrix<B> {
             });
         };
 
-        let group_size = info.group_size;
-        let packing_divisor = info.mode.packing_divisor();
-        let storage_data_type = info.mode.storage_type();
+        let (mode, method, group_size) = match quantization {
+            QuantizationInfo::Microfloat(encoding) => {
+                let metadata = MicrofloatMetadata::new(encoding, rows, columns)?;
+                let values = tree.leaf("weights")?.validate(&[rows, columns / 2], DataType::U8)?.read_allocation()?;
+                let scales = tree
+                    .leaf("scales")?
+                    .validate(&[rows, columns / encoding.group_size], DataType::U8)?
+                    .read_allocation()?;
+                let outer_scales = tree.leaf("global_scale")?.validate(&[1], data_type)?.read_allocation()?;
+                return Ok(Self {
+                    values,
+                    quantized: Some(Quantized::Microfloat {
+                        scales,
+                        outer_scales,
+                        metadata,
+                    }),
+                });
+            },
+            QuantizationInfo::Integer {
+                mode,
+                method,
+                group_size,
+            } => (mode, method, group_size),
+        };
+
+        let packing_divisor = mode.packing_divisor();
+        let storage_data_type = mode.storage_type();
         if !columns.is_multiple_of(packing_divisor) {
             return Err(WeightMatrixError::UnsupportedConfiguration(format!(
                 "stored columns {columns} are not divisible by packing divisor {packing_divisor}"
             )));
         }
         let groups = columns.div_ceil(group_size);
-
         let values =
             tree.leaf("weights")?.validate(&[rows, columns / packing_divisor], storage_data_type)?.read_allocation()?;
         let scales = tree.leaf("scales")?.validate(&[rows, groups], data_type)?.read_allocation()?;
-        let correction = match info.method {
+        let correction = match method {
             QuantizationMethod::ScaleBias => QuantizedCorrection::Biases(
                 tree.leaf("biases")?.validate(&[rows, groups], data_type)?.read_allocation()?,
             ),
@@ -149,57 +196,117 @@ impl<B: Backend> WeightMatrix<B> {
             ),
             QuantizationMethod::ScaleSymmetric => QuantizedCorrection::Symmetric,
         };
-
         Ok(Self {
             values,
-            quantized: Some(Quantized {
+            quantized: Some(Quantized::Integer {
                 scales,
                 correction,
-                info,
+                mode,
+                group_size,
                 signed_codes: false,
             }),
         })
     }
 
+    /// Borrow weights; code mutation must also update the signed-code state.
     pub fn values(&self) -> &Allocation<B> {
         &self.values
     }
 
     pub fn quantization(&self) -> Option<QuantizationInfo> {
-        self.quantized.as_ref().map(|quantized| quantized.info)
+        match &self.quantized {
+            None => None,
+            Some(Quantized::Microfloat {
+                metadata,
+                ..
+            }) => Some(QuantizationInfo::Microfloat(metadata.encoding)),
+            Some(Quantized::Integer {
+                mode,
+                correction,
+                group_size,
+                ..
+            }) => {
+                let method = match correction {
+                    QuantizedCorrection::Symmetric => QuantizationMethod::ScaleSymmetric,
+                    QuantizedCorrection::Biases(_) => QuantizationMethod::ScaleBias,
+                    QuantizedCorrection::ZeroPoints(_) => QuantizationMethod::ScaleZeroPoint,
+                };
+                Some(QuantizationInfo::Integer {
+                    mode: *mode,
+                    method,
+                    group_size: *group_size,
+                })
+            },
+        }
     }
 
     pub fn scales(&self) -> Option<&Allocation<B>> {
-        self.quantized.as_ref().map(|quantized| &quantized.scales)
+        match &self.quantized {
+            None => None,
+            Some(
+                Quantized::Integer {
+                    scales,
+                    ..
+                }
+                | Quantized::Microfloat {
+                    scales,
+                    ..
+                },
+            ) => Some(scales),
+        }
     }
 
     pub fn zero_points(&self) -> Option<&Allocation<B>> {
-        match &self.quantized.as_ref()?.correction {
-            QuantizedCorrection::ZeroPoints(zero_points) => Some(zero_points),
-            QuantizedCorrection::Biases(_) | QuantizedCorrection::Symmetric => None,
+        match &self.quantized {
+            Some(Quantized::Integer {
+                correction: QuantizedCorrection::ZeroPoints(zero_points),
+                ..
+            }) => Some(zero_points),
+            _ => None,
         }
     }
 
     pub fn biases(&self) -> Option<&Allocation<B>> {
-        match &self.quantized.as_ref()?.correction {
-            QuantizedCorrection::Biases(biases) => Some(biases),
-            QuantizedCorrection::ZeroPoints(_) | QuantizedCorrection::Symmetric => None,
+        match &self.quantized {
+            Some(Quantized::Integer {
+                correction: QuantizedCorrection::Biases(biases),
+                ..
+            }) => Some(biases),
+            _ => None,
         }
     }
 
     pub fn matmul_b(&self) -> MatmulB<'_, B> {
-        let Some(quantized) = self.quantized.as_ref() else {
-            return MatmulB::FullPrecision {
-                b: &self.values,
-            };
+        let (scales, correction, mode, group_size, signed_codes) = match &self.quantized {
+            None => {
+                return MatmulB::FullPrecision {
+                    b: &self.values,
+                };
+            },
+            Some(Quantized::Microfloat {
+                scales,
+                outer_scales,
+                metadata,
+            }) => {
+                return MatmulB::Microfloat {
+                    codes: &self.values,
+                    scales,
+                    outer_scales,
+                    metadata: *metadata,
+                };
+            },
+            Some(Quantized::Integer {
+                scales,
+                correction,
+                mode,
+                group_size,
+                signed_codes,
+            }) => (scales, correction, *mode, *group_size, *signed_codes),
         };
-        let mode = quantized.info.mode;
-        let group_size = quantized.info.group_size;
-        let signed_codes = quantized.signed_codes;
-        match &quantized.correction {
+        match correction {
             QuantizedCorrection::Biases(biases) => MatmulB::ScaleBiasDequant {
                 b: &self.values,
-                scales: &quantized.scales,
+                scales,
                 biases,
                 mode,
                 group_size,
@@ -207,7 +314,7 @@ impl<B: Backend> WeightMatrix<B> {
             },
             QuantizedCorrection::ZeroPoints(zero_points) => MatmulB::ScaleZeroPointDequant {
                 b: &self.values,
-                scales: &quantized.scales,
+                scales,
                 zero_points,
                 mode,
                 group_size,
@@ -215,7 +322,7 @@ impl<B: Backend> WeightMatrix<B> {
             },
             QuantizedCorrection::Symmetric => MatmulB::ScaleSymmetricDequant {
                 b: &self.values,
-                scales: &quantized.scales,
+                scales,
                 mode,
                 group_size,
                 signed_codes,
@@ -224,20 +331,25 @@ impl<B: Backend> WeightMatrix<B> {
     }
 
     pub fn make_codes_signed(&mut self) {
-        let Some(quantized) = self.quantized.as_mut() else {
+        let Some(Quantized::Integer {
+            mode,
+            signed_codes,
+            ..
+        }) = &mut self.quantized
+        else {
             return;
         };
-        if quantized.signed_codes {
+        if *signed_codes {
             return;
         }
-        let Some(sign_flip_mask) = quantized.info.mode.weight_codes_sign_flip_mask() else {
+        let Some(sign_flip_mask) = mode.weight_codes_sign_flip_mask() else {
             return;
         };
         let broadcast_mask = u64::from(sign_flip_mask) * 0x0101_0101_0101_0101;
         let (prefix, words, suffix) = bytemuck::pod_align_to_mut::<u8, u64>(self.values.as_slice_mut());
         words.iter_mut().for_each(|word| *word ^= broadcast_mask);
         prefix.iter_mut().chain(suffix.iter_mut()).for_each(|code| *code ^= sign_flip_mask);
-        quantized.signed_codes = true;
+        *signed_codes = true;
     }
 }
 
@@ -251,3 +363,7 @@ fn physical_shape(
         Layout::InputOutput => (input_dim, output_dim),
     }
 }
+
+#[cfg(test)]
+#[path = "../../unit/encodable_block/weight_matrix/microfloat_test.rs"]
+mod microfloat_test;

--- a/crates/uzu-engine/unit/backends/common/kernel/matmul/microfloat_test.rs
+++ b/crates/uzu-engine/unit/backends/common/kernel/matmul/microfloat_test.rs
@@ -1,5 +1,3 @@
-use std::any::TypeId;
-
 use half::{bf16, f16};
 use uzu_engine_macros::uzu_test;
 
@@ -25,26 +23,20 @@ use crate::{
 fn check_dense_mxfp4<B: Backend, T: ArrayElement>(
     row_count: usize,
     group_size: usize,
-    wide_scale: bool,
+    constant_weights: Option<(u8, u8, f32, f32)>,
     tolerance: f32,
 ) {
     const K: usize = 32;
-    const N: usize = 4;
+    const N: usize = 68;
     const E2M1: [f32; 16] = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0];
 
-    // CPU covers f32 intermediate overflow; Metal retains its f16-range regression.
-    let (wide_codes, wide_exponent, wide_outer_scale, wide_expected) = if TypeId::of::<B>() == TypeId::of::<Cpu>() {
-        (0x77, 254, 0.25, 3.0 * 2.0f32.powi(116))
-    } else {
-        (0x22, 147, 1.0 / 1024.0, 1.0)
-    };
     let encoding =
         MicrofloatEncoding::new(MicrofloatFormat::Mxfp4, 4, group_size as u32).expect("valid MXFP4 encoding");
     let metadata = MicrofloatMetadata::new(encoding, N as u32, K as u32).expect("valid dense MXFP4 metadata");
     let context = create_context::<B>();
     let input: Vec<f32> = (0..row_count * K)
         .map(|index| {
-            if wide_scale {
+            if constant_weights.is_some() {
                 if index % K == 0 {
                     1.0 / 1024.0
                 } else {
@@ -57,28 +49,25 @@ fn check_dense_mxfp4<B: Backend, T: ArrayElement>(
         .collect();
     let codes: Vec<u8> = (0..N * K / 2)
         .map(|index| {
-            if wide_scale {
-                return wide_codes;
+            if let Some((codes, ..)) = constant_weights {
+                return codes;
             }
-            let low = ((index * 5 + 1) % 16) as u8;
-            let high = ((index * 7 + 3) % 16) as u8;
+            let row = index / (K / 2);
+            let low = ((index * 5 + row + 1) % 16) as u8;
+            let high = ((index * 7 + row * 3 + 3) % 16) as u8;
             low | (high << 4)
         })
         .collect();
     let scales: Vec<u8> = (0..N * K / group_size)
         .map(|index| {
-            if wide_scale {
-                wide_exponent
+            if let Some((_, exponent, ..)) = constant_weights {
+                exponent
             } else {
                 126 + (index % 3) as u8
             }
         })
         .collect();
-    let outer_scale: f32 = if wide_scale {
-        wide_outer_scale
-    } else {
-        1.25
-    };
+    let outer_scale = constant_weights.map_or(1.25, |(_, _, scale, _)| scale);
     let mut expected = vec![0.0; row_count * N];
     for row in 0..row_count {
         for output_row in 0..N {
@@ -93,9 +82,9 @@ fn check_dense_mxfp4<B: Backend, T: ArrayElement>(
             }
         }
     }
-    let biases = [0.5, -1.0, 1.5, -2.0];
-    if wide_scale {
-        assert_eq!(expected, vec![wide_expected; row_count * N]);
+    let biases: Vec<f32> = [0.5, -1.0, 1.5, -2.0].into_iter().cycle().take(N).collect();
+    if let Some((_, _, _, value)) = constant_weights {
+        assert_eq!(expected, vec![value; row_count * N]);
     } else {
         for (index, value) in expected.iter_mut().enumerate() {
             *value = ((*value * 0.5 + biases[index % N]) / 16.0).tanh() * 16.0;
@@ -108,10 +97,10 @@ fn check_dense_mxfp4<B: Backend, T: ArrayElement>(
     let codes = alloc_allocation_with_data::<B, u8>(context.as_ref(), &codes);
     let scales = alloc_allocation_with_data::<B, u8>(context.as_ref(), &scales);
     let outer_scales = alloc_allocation_with_data::<B, T>(context.as_ref(), &[outer_scale]);
-    let biases = biases.map(|value| T::from(value).expect("representable bias"));
+    let biases: Vec<T> = biases.into_iter().map(|value| T::from(value).expect("representable bias")).collect();
     let biases = alloc_allocation_with_data::<B, T>(context.as_ref(), &biases);
     let mut output = alloc_allocation_with_data::<B, f32>(context.as_ref(), &vec![f32::NAN; row_count * N]);
-    let d_transform = if wide_scale {
+    let d_transform = if constant_weights.is_some() {
         MatmulDOps::none()
     } else {
         MatmulDOps {
@@ -152,29 +141,66 @@ fn check_dense_mxfp4<B: Backend, T: ArrayElement>(
         .expect("encode MXFP4 matmul");
     submit_encoder(encoder);
     let actual = allocation_to_vec::<B, f32>(&output);
+    let tolerance = if constant_weights.is_some() {
+        0.0
+    } else {
+        tolerance
+    };
     assert_eq_float(
         &expected,
         &actual,
         tolerance,
-        &format!("{} {:?} M={row_count} group={group_size}", std::any::type_name::<B>(), T::data_type()),
+        &format!(
+            "{} {:?} M={row_count} group={group_size} scale={constant_weights:?}",
+            std::any::type_name::<B>(),
+            T::data_type()
+        ),
     );
 }
 
 #[uzu_test]
 fn dense_mxfp4_matches_scalar_reference() {
-    for row_count in [1, 9, 33] {
+    for row_count in [1, 9, 65] {
         for group_size in [16, 32] {
-            check_dense_mxfp4::<Cpu, f16>(row_count, group_size, false, 1e-5);
-            check_dense_mxfp4::<Cpu, bf16>(row_count, group_size, false, 1e-5);
-            check_dense_mxfp4::<Cpu, f32>(row_count, group_size, false, 1e-5);
-            check_dense_mxfp4::<Cpu, f16>(row_count, group_size, true, 1e-5);
-            for_each_non_cpu_backend!(|B| {
-                check_dense_mxfp4::<B, f16>(row_count, group_size, false, 0.01);
-                check_dense_mxfp4::<B, bf16>(row_count, group_size, false, 0.01);
-                check_dense_mxfp4::<B, f32>(row_count, group_size, false, 0.01);
-                check_dense_mxfp4::<B, f16>(row_count, group_size, true, 0.01);
-            });
+            for constant_weights in [None, Some((0x11, 116, 1.0, 2.0f32.powi(-22))), Some((0x77, 134, 1.0, 0.75))] {
+                check_dense_mxfp4::<Cpu, f16>(row_count, group_size, constant_weights, 1e-5);
+                check_dense_mxfp4::<Cpu, bf16>(row_count, group_size, constant_weights, 1e-5);
+                check_dense_mxfp4::<Cpu, f32>(row_count, group_size, constant_weights, 1e-5);
+                for_each_non_cpu_backend!(|B| {
+                    check_dense_mxfp4::<B, f16>(row_count, group_size, constant_weights, 0.01);
+                    check_dense_mxfp4::<B, bf16>(row_count, group_size, constant_weights, 0.01);
+                    check_dense_mxfp4::<B, f32>(row_count, group_size, constant_weights, 0.01);
+                });
+            }
         }
+    }
+}
+
+#[uzu_test]
+fn cpu_mxfp4_preserves_scaled_weight_range() {
+    for group_size in [16, 32] {
+        for constant_weights in [
+            // The unscaled weight exceeds f32, but the outer scale makes it representable.
+            (0x77, 254, 0.25, 3.0 * 2.0f32.powi(116)),
+            (0x77, 254, -0.25, -3.0 * 2.0f32.powi(116)),
+            // Multiplying the scales first would overflow instead.
+            (0x11, 254, 2.0, 2.0f32.powi(117)),
+            (0x77, 254, 0.0, 0.0),
+        ] {
+            check_dense_mxfp4::<Cpu, f16>(1, group_size, Some(constant_weights), 0.0);
+            check_dense_mxfp4::<Cpu, bf16>(1, group_size, Some(constant_weights), 0.0);
+            check_dense_mxfp4::<Cpu, f32>(1, group_size, Some(constant_weights), 0.0);
+        }
+        for constant_weights in [
+            // Subnormal scales can still produce normal decoded weights.
+            (0x77, 254, 2.0f32.powi(-133), 3.0 * 2.0f32.powi(-15)),
+            (0x77, 0, 2.0f32.powi(127), 6.0 / 1024.0),
+        ] {
+            check_dense_mxfp4::<Cpu, bf16>(1, group_size, Some(constant_weights), 0.0);
+            check_dense_mxfp4::<Cpu, f32>(1, group_size, Some(constant_weights), 0.0);
+        }
+        let constant_weights = (0x77, 254, f32::from_bits(1), 3.0 * 2.0f32.powi(-31));
+        check_dense_mxfp4::<Cpu, f32>(1, group_size, Some(constant_weights), 0.0);
     }
 }
 

--- a/crates/uzu-engine/unit/backends/common/kernel/matmul/microfloat_test.rs
+++ b/crates/uzu-engine/unit/backends/common/kernel/matmul/microfloat_test.rs
@@ -1,0 +1,261 @@
+use half::{bf16, f16};
+use uzu_engine_macros::uzu_test;
+
+use crate::{
+    array::ArrayElement,
+    backends::{
+        common::{
+            Backend, Encoder, Kernels,
+            kernel::matmul::{MatmulA, MatmulArguments, MatmulB, MatmulDOps, MatmulError, MatmulKernel},
+            microfloat::{MicrofloatEncoding, MicrofloatError, MicrofloatFormat, MicrofloatMetadata},
+        },
+        cpu::Cpu,
+    },
+    data_type::DataType,
+    tests::{
+        assert::assert_eq_float,
+        helpers::{alloc_allocation_with_data, allocation_to_vec, create_context, submit_encoder},
+    },
+};
+
+fn check_dense_mxfp4<T: ArrayElement>(
+    row_count: usize,
+    group_size: usize,
+    wide_scale: bool,
+) {
+    const K: usize = 32;
+    const N: usize = 4;
+    const E2M1: [f32; 16] = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0];
+
+    let encoding =
+        MicrofloatEncoding::new(MicrofloatFormat::Mxfp4, 4, group_size as u32).expect("valid MXFP4 encoding");
+    let metadata = MicrofloatMetadata::new(encoding, N as u32, K as u32).expect("valid dense MXFP4 metadata");
+    let context = create_context::<Cpu>();
+    let input: Vec<f32> = (0..row_count * K)
+        .map(|index| {
+            if wide_scale {
+                if index % K == 0 {
+                    1.0 / 1024.0
+                } else {
+                    0.0
+                }
+            } else {
+                (index % 13) as f32 * 0.125 - 0.5
+            }
+        })
+        .collect();
+    let codes: Vec<u8> = (0..N * K / 2)
+        .map(|index| {
+            if wide_scale {
+                return 0x77;
+            }
+            let low = ((index * 5 + 1) % 16) as u8;
+            let high = ((index * 7 + 3) % 16) as u8;
+            low | (high << 4)
+        })
+        .collect();
+    let scales: Vec<u8> = (0..N * K / group_size)
+        .map(|index| {
+            if wide_scale {
+                254
+            } else {
+                126 + (index % 3) as u8
+            }
+        })
+        .collect();
+    let outer_scale: f32 = if wide_scale {
+        0.25
+    } else {
+        1.25
+    };
+    let mut expected = vec![0.0; row_count * N];
+    for row in 0..row_count {
+        for output_row in 0..N {
+            for inner in 0..K {
+                let packed = codes[output_row * K / 2 + inner / 2];
+                let code = (packed >> (4 * (inner % 2))) & 0x0f;
+                let exponent = scales[output_row * K / group_size + inner / group_size];
+                let weight = (f64::from(E2M1[code as usize])
+                    * 2.0f64.powi(i32::from(exponent) - 127)
+                    * f64::from(outer_scale)) as f32;
+                expected[row * N + output_row] += input[row * K + inner] * weight;
+            }
+        }
+    }
+    let biases = [0.5, -1.0, 1.5, -2.0];
+    if wide_scale {
+        // The unscaled weight exceeds f32, but the outer scale makes it representable.
+        assert_eq!(expected, vec![3.0 * 2.0f32.powi(116); row_count * N]);
+    } else {
+        for (index, value) in expected.iter_mut().enumerate() {
+            *value = ((*value * 0.5 + biases[index % N]) / 16.0).tanh() * 16.0;
+        }
+    }
+
+    let input: Vec<T> = input.into_iter().map(|value| T::from(value).expect("representable input")).collect();
+    let outer_scale = T::from(outer_scale).expect("representable outer scale");
+    let input = alloc_allocation_with_data::<Cpu, T>(context.as_ref(), &input);
+    let codes = alloc_allocation_with_data::<Cpu, u8>(context.as_ref(), &codes);
+    let scales = alloc_allocation_with_data::<Cpu, u8>(context.as_ref(), &scales);
+    let outer_scales = alloc_allocation_with_data::<Cpu, T>(context.as_ref(), &[outer_scale]);
+    let biases = biases.map(|value| T::from(value).expect("representable bias"));
+    let biases = alloc_allocation_with_data::<Cpu, T>(context.as_ref(), &biases);
+    let mut output = alloc_allocation_with_data::<Cpu, f32>(context.as_ref(), &vec![f32::NAN; row_count * N]);
+    let d_transform = if wide_scale {
+        MatmulDOps::none()
+    } else {
+        MatmulDOps {
+            ab_scale: 0.5,
+            bias: Some(&biases),
+            soft_cap: Some(16.0),
+            ..MatmulDOps::none()
+        }
+    };
+    let mut kernel = <<Cpu as Backend>::Kernels as Kernels>::MatmulKernel::new(
+        context.as_ref(),
+        T::data_type(),
+        T::data_type(),
+        DataType::F32,
+    )
+    .expect("create matmul kernel");
+    let mut encoder = Encoder::<Cpu>::new(context.as_ref()).expect("create encoder");
+    kernel
+        .encode(
+            MatmulArguments {
+                a: MatmulA::FullPrecision {
+                    values: &input,
+                    offset: 0,
+                },
+                b: MatmulB::<Cpu>::Microfloat {
+                    codes: &codes,
+                    scales: &scales,
+                    outer_scales: &outer_scales,
+                    metadata,
+                },
+                b_leading_dimension: None,
+                b_transpose: true,
+                d: &mut output,
+                d_transform,
+                gather_indices: None,
+                m: row_count as u32,
+                n: N as u32,
+                k: K as u32,
+            },
+            &mut encoder,
+        )
+        .expect("encode MXFP4 matmul");
+    submit_encoder(encoder);
+    let actual = allocation_to_vec::<Cpu, f32>(&output);
+    assert_eq_float(&expected, &actual, 1e-5, &format!("CPU {:?} M={row_count} group={group_size}", T::data_type()));
+}
+
+#[uzu_test]
+fn cpu_dense_mxfp4_matches_scalar_reference() {
+    for row_count in [1, 9, 33] {
+        for group_size in [16, 32] {
+            check_dense_mxfp4::<f16>(row_count, group_size, false);
+            check_dense_mxfp4::<bf16>(row_count, group_size, false);
+            check_dense_mxfp4::<f32>(row_count, group_size, false);
+            check_dense_mxfp4::<f16>(row_count, group_size, true);
+        }
+    }
+}
+
+#[uzu_test]
+fn cpu_rejects_invalid_mxfp4_operands_before_dispatch() {
+    let context = create_context::<Cpu>();
+    let encoding = MicrofloatEncoding::new(MicrofloatFormat::Mxfp4, 4, 16).expect("valid MXFP4 encoding");
+    let metadata = MicrofloatMetadata::new(encoding, 4, 32).expect("valid MXFP4 metadata");
+    let input = alloc_allocation_with_data::<Cpu, f32>(context.as_ref(), &[1.0; 32]);
+    let mut output = alloc_allocation_with_data::<Cpu, f32>(context.as_ref(), &[f32::NAN; 4]);
+    let mut kernel = <<Cpu as Backend>::Kernels as Kernels>::MatmulKernel::new(
+        context.as_ref(),
+        DataType::F32,
+        DataType::F32,
+        DataType::F32,
+    )
+    .expect("create CPU matmul kernel");
+
+    for (metadata, code_bytes, scale_bytes, outer_bytes, invalid_metadata) in [
+        (
+            MicrofloatMetadata {
+                rows: 0,
+                ..metadata
+            },
+            64,
+            8,
+            4,
+            Some(MicrofloatError::EmptyShape),
+        ),
+        (
+            MicrofloatMetadata {
+                columns: 33,
+                ..metadata
+            },
+            64,
+            8,
+            4,
+            Some(MicrofloatError::MisalignedColumns {
+                columns: 33,
+                group_size: 16,
+            }),
+        ),
+        (
+            MicrofloatMetadata {
+                encoding: MicrofloatEncoding {
+                    group_size: 0,
+                    ..encoding
+                },
+                ..metadata
+            },
+            64,
+            8,
+            4,
+            Some(MicrofloatError::UnsupportedGroupSize {
+                format: MicrofloatFormat::Mxfp4,
+                group_size: 0,
+            }),
+        ),
+        (metadata, 63, 8, 4, None),
+        (metadata, 64, 7, 4, None),
+        (metadata, 64, 8, 3, None),
+    ] {
+        let codes = alloc_allocation_with_data::<Cpu, u8>(context.as_ref(), &vec![0x22; code_bytes]);
+        let scales = alloc_allocation_with_data::<Cpu, u8>(context.as_ref(), &vec![127; scale_bytes]);
+        let outer_scales = alloc_allocation_with_data::<Cpu, u8>(context.as_ref(), &vec![0; outer_bytes]);
+        let mut encoder = Encoder::<Cpu>::new(context.as_ref()).expect("create CPU encoder");
+        let result = kernel.encode(
+            MatmulArguments {
+                a: MatmulA::FullPrecision {
+                    values: &input,
+                    offset: 0,
+                },
+                b: MatmulB::<Cpu>::Microfloat {
+                    codes: &codes,
+                    scales: &scales,
+                    outer_scales: &outer_scales,
+                    metadata,
+                },
+                b_leading_dimension: None,
+                b_transpose: true,
+                d: &mut output,
+                d_transform: MatmulDOps::none(),
+                gather_indices: None,
+                m: 1,
+                n: 4,
+                k: 32,
+            },
+            &mut encoder,
+        );
+        let error = result.expect_err("reject invalid MXFP4 operand during encoding");
+        let error = (&error as &dyn std::error::Error)
+            .source()
+            .and_then(|source| source.downcast_ref::<MatmulError<Cpu>>())
+            .expect("preserve matmul error");
+        match (invalid_metadata, error) {
+            (Some(expected), MatmulError::InvalidMicrofloat(actual)) => assert_eq!(*actual, expected),
+            (None, MatmulError::InvalidMicrofloatStorage) => {},
+            (expected, actual) => panic!("expected metadata error {expected:?}, got {actual:?}"),
+        }
+    }
+}

--- a/crates/uzu-engine/unit/backends/common/kernel/matmul/microfloat_test.rs
+++ b/crates/uzu-engine/unit/backends/common/kernel/matmul/microfloat_test.rs
@@ -1,3 +1,5 @@
+use std::any::TypeId;
+
 use half::{bf16, f16};
 use uzu_engine_macros::uzu_test;
 
@@ -14,23 +16,32 @@ use crate::{
     data_type::DataType,
     tests::{
         assert::assert_eq_float,
-        helpers::{alloc_allocation_with_data, allocation_to_vec, create_context, submit_encoder},
+        helpers::{
+            alloc_allocation_with_data, allocation_to_vec, create_context, for_each_non_cpu_backend, submit_encoder,
+        },
     },
 };
 
-fn check_dense_mxfp4<T: ArrayElement>(
+fn check_dense_mxfp4<B: Backend, T: ArrayElement>(
     row_count: usize,
     group_size: usize,
     wide_scale: bool,
+    tolerance: f32,
 ) {
     const K: usize = 32;
     const N: usize = 4;
     const E2M1: [f32; 16] = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0];
 
+    // CPU covers f32 intermediate overflow; Metal retains its f16-range regression.
+    let (wide_codes, wide_exponent, wide_outer_scale, wide_expected) = if TypeId::of::<B>() == TypeId::of::<Cpu>() {
+        (0x77, 254, 0.25, 3.0 * 2.0f32.powi(116))
+    } else {
+        (0x22, 147, 1.0 / 1024.0, 1.0)
+    };
     let encoding =
         MicrofloatEncoding::new(MicrofloatFormat::Mxfp4, 4, group_size as u32).expect("valid MXFP4 encoding");
     let metadata = MicrofloatMetadata::new(encoding, N as u32, K as u32).expect("valid dense MXFP4 metadata");
-    let context = create_context::<Cpu>();
+    let context = create_context::<B>();
     let input: Vec<f32> = (0..row_count * K)
         .map(|index| {
             if wide_scale {
@@ -47,7 +58,7 @@ fn check_dense_mxfp4<T: ArrayElement>(
     let codes: Vec<u8> = (0..N * K / 2)
         .map(|index| {
             if wide_scale {
-                return 0x77;
+                return wide_codes;
             }
             let low = ((index * 5 + 1) % 16) as u8;
             let high = ((index * 7 + 3) % 16) as u8;
@@ -57,14 +68,14 @@ fn check_dense_mxfp4<T: ArrayElement>(
     let scales: Vec<u8> = (0..N * K / group_size)
         .map(|index| {
             if wide_scale {
-                254
+                wide_exponent
             } else {
                 126 + (index % 3) as u8
             }
         })
         .collect();
     let outer_scale: f32 = if wide_scale {
-        0.25
+        wide_outer_scale
     } else {
         1.25
     };
@@ -84,8 +95,7 @@ fn check_dense_mxfp4<T: ArrayElement>(
     }
     let biases = [0.5, -1.0, 1.5, -2.0];
     if wide_scale {
-        // The unscaled weight exceeds f32, but the outer scale makes it representable.
-        assert_eq!(expected, vec![3.0 * 2.0f32.powi(116); row_count * N]);
+        assert_eq!(expected, vec![wide_expected; row_count * N]);
     } else {
         for (index, value) in expected.iter_mut().enumerate() {
             *value = ((*value * 0.5 + biases[index % N]) / 16.0).tanh() * 16.0;
@@ -94,13 +104,13 @@ fn check_dense_mxfp4<T: ArrayElement>(
 
     let input: Vec<T> = input.into_iter().map(|value| T::from(value).expect("representable input")).collect();
     let outer_scale = T::from(outer_scale).expect("representable outer scale");
-    let input = alloc_allocation_with_data::<Cpu, T>(context.as_ref(), &input);
-    let codes = alloc_allocation_with_data::<Cpu, u8>(context.as_ref(), &codes);
-    let scales = alloc_allocation_with_data::<Cpu, u8>(context.as_ref(), &scales);
-    let outer_scales = alloc_allocation_with_data::<Cpu, T>(context.as_ref(), &[outer_scale]);
+    let input = alloc_allocation_with_data::<B, T>(context.as_ref(), &input);
+    let codes = alloc_allocation_with_data::<B, u8>(context.as_ref(), &codes);
+    let scales = alloc_allocation_with_data::<B, u8>(context.as_ref(), &scales);
+    let outer_scales = alloc_allocation_with_data::<B, T>(context.as_ref(), &[outer_scale]);
     let biases = biases.map(|value| T::from(value).expect("representable bias"));
-    let biases = alloc_allocation_with_data::<Cpu, T>(context.as_ref(), &biases);
-    let mut output = alloc_allocation_with_data::<Cpu, f32>(context.as_ref(), &vec![f32::NAN; row_count * N]);
+    let biases = alloc_allocation_with_data::<B, T>(context.as_ref(), &biases);
+    let mut output = alloc_allocation_with_data::<B, f32>(context.as_ref(), &vec![f32::NAN; row_count * N]);
     let d_transform = if wide_scale {
         MatmulDOps::none()
     } else {
@@ -111,14 +121,10 @@ fn check_dense_mxfp4<T: ArrayElement>(
             ..MatmulDOps::none()
         }
     };
-    let mut kernel = <<Cpu as Backend>::Kernels as Kernels>::MatmulKernel::new(
-        context.as_ref(),
-        T::data_type(),
-        T::data_type(),
-        DataType::F32,
-    )
-    .expect("create matmul kernel");
-    let mut encoder = Encoder::<Cpu>::new(context.as_ref()).expect("create encoder");
+    let mut kernel =
+        <B::Kernels as Kernels>::MatmulKernel::new(context.as_ref(), T::data_type(), T::data_type(), DataType::F32)
+            .expect("create matmul kernel");
+    let mut encoder = Encoder::<B>::new(context.as_ref()).expect("create encoder");
     kernel
         .encode(
             MatmulArguments {
@@ -126,7 +132,7 @@ fn check_dense_mxfp4<T: ArrayElement>(
                     values: &input,
                     offset: 0,
                 },
-                b: MatmulB::<Cpu>::Microfloat {
+                b: MatmulB::<B>::Microfloat {
                     codes: &codes,
                     scales: &scales,
                     outer_scales: &outer_scales,
@@ -145,18 +151,29 @@ fn check_dense_mxfp4<T: ArrayElement>(
         )
         .expect("encode MXFP4 matmul");
     submit_encoder(encoder);
-    let actual = allocation_to_vec::<Cpu, f32>(&output);
-    assert_eq_float(&expected, &actual, 1e-5, &format!("CPU {:?} M={row_count} group={group_size}", T::data_type()));
+    let actual = allocation_to_vec::<B, f32>(&output);
+    assert_eq_float(
+        &expected,
+        &actual,
+        tolerance,
+        &format!("{} {:?} M={row_count} group={group_size}", std::any::type_name::<B>(), T::data_type()),
+    );
 }
 
 #[uzu_test]
-fn cpu_dense_mxfp4_matches_scalar_reference() {
+fn dense_mxfp4_matches_scalar_reference() {
     for row_count in [1, 9, 33] {
         for group_size in [16, 32] {
-            check_dense_mxfp4::<f16>(row_count, group_size, false);
-            check_dense_mxfp4::<bf16>(row_count, group_size, false);
-            check_dense_mxfp4::<f32>(row_count, group_size, false);
-            check_dense_mxfp4::<f16>(row_count, group_size, true);
+            check_dense_mxfp4::<Cpu, f16>(row_count, group_size, false, 1e-5);
+            check_dense_mxfp4::<Cpu, bf16>(row_count, group_size, false, 1e-5);
+            check_dense_mxfp4::<Cpu, f32>(row_count, group_size, false, 1e-5);
+            check_dense_mxfp4::<Cpu, f16>(row_count, group_size, true, 1e-5);
+            for_each_non_cpu_backend!(|B| {
+                check_dense_mxfp4::<B, f16>(row_count, group_size, false, 0.01);
+                check_dense_mxfp4::<B, bf16>(row_count, group_size, false, 0.01);
+                check_dense_mxfp4::<B, f32>(row_count, group_size, false, 0.01);
+                check_dense_mxfp4::<B, f16>(row_count, group_size, true, 0.01);
+            });
         }
     }
 }

--- a/crates/uzu-engine/unit/backends/common/kernel/matmul/mod.rs
+++ b/crates/uzu-engine/unit/backends/common/kernel/matmul/mod.rs
@@ -2,6 +2,7 @@ mod a8w_bench;
 mod dispatch_paths_test;
 mod gemm_bench;
 mod gemv_test;
+mod microfloat_test;
 mod quant_dispatch_test;
 mod quant_gemm_bench;
 mod quant_gemv_bench;

--- a/crates/uzu-engine/unit/backends/cpu/kernel/matmul/reference_test.rs
+++ b/crates/uzu-engine/unit/backends/cpu/kernel/matmul/reference_test.rs
@@ -1,0 +1,20 @@
+use uzu_engine_macros::uzu_test;
+
+use super::{decode_e2m1, decode_e8m0};
+
+#[uzu_test]
+fn decodes_e2m1_and_e8m0_edges() {
+    let expected = [0.0f32, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0];
+
+    for (code, value) in expected.into_iter().enumerate() {
+        assert_eq!(decode_e2m1(code as u8), value);
+        assert_eq!(decode_e2m1(code as u8 | 0b1000), -value);
+    }
+    assert_eq!(decode_e2m1(0).to_bits(), 0.0f32.to_bits());
+    assert_eq!(decode_e2m1(8).to_bits(), (-0.0f32).to_bits());
+    assert_eq!(decode_e8m0(0).to_bits(), 0x0040_0000);
+    assert_eq!(decode_e8m0(1), 2.0f32.powi(-126));
+    assert_eq!(decode_e8m0(127), 1.0);
+    assert_eq!(decode_e8m0(254), 2.0f32.powi(127));
+    assert!(decode_e8m0(255).is_nan());
+}

--- a/crates/uzu-engine/unit/backends/metal/kernel/matmul/gemm/selection_test.rs
+++ b/crates/uzu-engine/unit/backends/metal/kernel/matmul/gemm/selection_test.rs
@@ -3,7 +3,10 @@ use uzu_engine_macros::uzu_test;
 
 use super::{super::specialization::GemmSpecialization, *};
 use crate::backends::{
-    common::gpu_types::gemm::{GemmAPrologueKind, GemmAlignment, GemmDTransform},
+    common::{
+        gpu_types::gemm::{GemmAPrologueKind, GemmAlignment, GemmDTransform},
+        kernel::matmul::MatmulBKind,
+    },
     metal::kernel::matmul::MatmulMetalKernel,
 };
 
@@ -18,6 +21,7 @@ fn shape(
         k,
         b_transpose: true,
         b_leading_dimension: None,
+        b_kind: MatmulBKind::Dense,
         b_prologue: GemmBPrologueKind::FullPrecision,
         b_bits: None,
         b_group_size: None,
@@ -29,6 +33,7 @@ fn shape(
 }
 
 fn quant(mut shape: MatmulShape) -> MatmulShape {
+    shape.b_kind = MatmulBKind::Integer;
     shape.b_prologue = GemmBPrologueKind::ScaleSymmetricDequant;
     shape.b_bits = Some(4);
     shape.b_group_size = Some(64);
@@ -163,7 +168,7 @@ fn forced_engine_errors_are_preserved() {
     invalid_layout.b_transpose = false;
     assert_eq!(
         problem(invalid_layout, DataType::BF16).select_plan_for_engine(GemmEngine::Mxu),
-        Err(GemmPlanError::UnsupportedQuantLayout)
+        Err(GemmPlanError::UnsupportedPackedLayout)
     );
 }
 
@@ -173,7 +178,6 @@ fn specialization_flags_are_preserved() {
         GemmSpecialization::from_plan(
             plan(split_k),
             shape,
-            DataType::BF16,
             GemmDTransform::empty(),
             GemmAlignment::new(true, true, true),
             GemmAPrologueKind::FullPrecision,

--- a/crates/uzu-engine/unit/backends/metal/kernel/matmul/gemv/policy_test.rs
+++ b/crates/uzu-engine/unit/backends/metal/kernel/matmul/gemv/policy_test.rs
@@ -5,7 +5,7 @@ use super::*;
 use crate::{
     backends::common::{
         gpu_types::gemm::{GemmBPrologueKind, GemmDTransform},
-        kernel::matmul::MatmulShape,
+        kernel::matmul::{MatmulBKind, MatmulShape},
     },
     data_type::DataType,
 };
@@ -174,6 +174,7 @@ fn quant_shape(
         k: 4096,
         b_transpose: true,
         b_leading_dimension: None,
+        b_kind: MatmulBKind::Integer,
         b_prologue: GemmBPrologueKind::ScaleZeroPointDequant,
         b_bits: Some(4),
         b_group_size: Some(32),
@@ -192,6 +193,7 @@ fn block_unaligned_quantized_k_stays_on_gemv() {
         k: 1152,
         b_transpose: true,
         b_leading_dimension: None,
+        b_kind: MatmulBKind::Integer,
         b_prologue: GemmBPrologueKind::ScaleZeroPointDequant,
         b_bits: Some(4),
         b_group_size: Some(64),

--- a/crates/uzu-engine/unit/backends/metal/kernel/matmul/qmv/routes_test.rs
+++ b/crates/uzu-engine/unit/backends/metal/kernel/matmul/qmv/routes_test.rs
@@ -9,7 +9,7 @@ use crate::{
     backends::{
         common::{
             gpu_types::gemm::{GemmBPrologueKind, GemmDTransform},
-            kernel::matmul::MatmulShape,
+            kernel::matmul::{MatmulBKind, MatmulShape},
         },
         metal::kernel::matmul::{MatmulDispatch, MatmulMetalKernel, gemv::GemvSpecialization},
     },
@@ -56,6 +56,7 @@ fn problem(
         k,
         b_transpose: true,
         b_leading_dimension: None,
+        b_kind: MatmulBKind::Integer,
         b_prologue: prologue,
         b_bits: Some(bits),
         b_group_size: Some(group),

--- a/crates/uzu-engine/unit/encodable_block/weight_matrix/microfloat_test.rs
+++ b/crates/uzu-engine/unit/encodable_block/weight_matrix/microfloat_test.rs
@@ -7,14 +7,17 @@ use uzu_engine_macros::uzu_test;
 
 use crate::{
     array::ArrayElement,
-    backends::{common::Encoder, cpu::Cpu},
+    backends::{
+        common::{Backend, Encoder},
+        cpu::Cpu,
+    },
     data_type::DataType,
     encodable_block::{
         linear::{Linear, LinearBlockError, LinearMatmulError},
         weight_matrix::WeightMatrixError,
     },
     parameters::{ParameterLoader, ParameterLoaderError},
-    tests::helpers::{alloc_allocation_with_data, allocation_to_vec, create_context},
+    tests::helpers::{alloc_allocation_with_data, allocation_to_vec, create_context, for_each_non_cpu_backend},
 };
 
 fn add_tensor(
@@ -81,12 +84,12 @@ fn dense_microfloat_parameter_file<T: ArrayElement>(edit_header: impl FnOnce(&mu
     file
 }
 
-fn execute_loaded_projection<T: ArrayElement + PartialEq + Debug>(batch_dim: u32) {
-    let context = create_context::<Cpu>();
+fn execute_loaded_projection<B: Backend, T: ArrayElement + PartialEq + Debug>(batch_dim: u32) {
+    let context = create_context::<B>();
     let file = dense_microfloat_parameter_file::<T>(|_| {});
-    let loader = ParameterLoader::<Cpu>::new(&file, context.as_ref()).expect("load dense MXFP4 fixture");
+    let loader = ParameterLoader::<B>::new(&file, context.as_ref()).expect("load dense MXFP4 fixture");
     let tree = loader.tree();
-    let projection = <dyn Linear<Cpu>>::new(32, [2], true, context.as_ref(), T::data_type(), &tree)
+    let projection = <dyn Linear<B>>::new(32, [2], true, context.as_ref(), T::data_type(), &tree)
         .expect("load dense MXFP4 projection");
     tree.assert_all_tensors_validated().expect("validate dense MXFP4 tensors");
 
@@ -102,13 +105,13 @@ fn execute_loaded_projection<T: ArrayElement + PartialEq + Debug>(batch_dim: u32
             })
         })
         .collect();
-    let input = alloc_allocation_with_data::<Cpu, T>(context.as_ref(), &input);
-    let mut encoder = Encoder::<Cpu>::new(context.as_ref()).expect("create encoder");
+    let input = alloc_allocation_with_data::<B, T>(context.as_ref(), &input);
+    let mut encoder = Encoder::<B>::new(context.as_ref()).expect("create encoder");
     let output = projection.encode(input, batch_dim, &mut encoder).expect("encode MXFP4 projection");
     let command_buffer = encoder.end_encoding();
     let command_buffer = command_buffer.submit();
     let completed = command_buffer.wait_until_completed().expect("execute MXFP4 projection");
-    let values = allocation_to_vec::<Cpu, T>(&output);
+    let values = allocation_to_vec::<B, T>(&output);
     // Releasing scratch before the completion handle returns its allocation pool.
     drop(output);
     drop(completed);
@@ -122,15 +125,19 @@ fn execute_loaded_projection<T: ArrayElement + PartialEq + Debug>(batch_dim: u32
         })
         .map(|value| T::from(value).expect("representable expected output"))
         .collect();
-    assert_eq!(values, expected, "CPU {:?} batch={batch_dim}", T::data_type());
+    assert_eq!(values, expected, "{} {:?} batch={batch_dim}", std::any::type_name::<B>(), T::data_type());
 }
 
 #[uzu_test]
 fn loads_and_executes_dense_mxfp4_projection() {
     for batch_dim in [1, 9] {
-        execute_loaded_projection::<bf16>(batch_dim);
-        execute_loaded_projection::<f16>(batch_dim);
-        execute_loaded_projection::<f32>(batch_dim);
+        execute_loaded_projection::<Cpu, bf16>(batch_dim);
+        execute_loaded_projection::<Cpu, f16>(batch_dim);
+        execute_loaded_projection::<Cpu, f32>(batch_dim);
+        for_each_non_cpu_backend!(|B| {
+            execute_loaded_projection::<B, bf16>(batch_dim);
+            execute_loaded_projection::<B, f16>(batch_dim);
+        });
     }
 }
 

--- a/crates/uzu-engine/unit/encodable_block/weight_matrix/microfloat_test.rs
+++ b/crates/uzu-engine/unit/encodable_block/weight_matrix/microfloat_test.rs
@@ -1,0 +1,189 @@
+use std::{fmt::Debug, fs::File, io::Write};
+
+use half::{bf16, f16};
+use serde_json::{Map, Value, json};
+use tempfile::tempfile;
+use uzu_engine_macros::uzu_test;
+
+use crate::{
+    array::ArrayElement,
+    backends::{common::Encoder, cpu::Cpu},
+    data_type::DataType,
+    encodable_block::{
+        linear::{Linear, LinearBlockError, LinearMatmulError},
+        weight_matrix::WeightMatrixError,
+    },
+    parameters::{ParameterLoader, ParameterLoaderError},
+    tests::helpers::{alloc_allocation_with_data, allocation_to_vec, create_context},
+};
+
+fn add_tensor(
+    header: &mut Map<String, Value>,
+    payload: &mut Vec<u8>,
+    name: &str,
+    shape: &[u32],
+    data_type: &str,
+    data: &[u8],
+) {
+    let begin = payload.len();
+    payload.extend_from_slice(data);
+    header.insert(
+        name.into(),
+        json!({
+            "dtype": data_type,
+            "shape": shape,
+            "data_offsets": [begin, payload.len()]
+        }),
+    );
+}
+
+fn dense_microfloat_parameter_file<T: ArrayElement>(edit_header: impl FnOnce(&mut Map<String, Value>)) -> File {
+    const ROWS: u32 = 2;
+    const COLUMNS: u32 = 32;
+    const GROUP_SIZE: u32 = 16;
+
+    let mut header = Map::new();
+    header.insert(
+        "__metadata__".into(),
+        json!({
+            "weights.spec": json!({
+                "type": "MicrofloatSpec",
+                "bits": 4,
+                "group_size": GROUP_SIZE,
+                "scale_mode": "mxfp4",
+                "layout": "output_input"
+            }).to_string()
+        }),
+    );
+    let mut payload = Vec::new();
+    let codes: Vec<u8> = [0x21, 0xbc, 0x76, 0x09].into_iter().flat_map(|code| [code; 8]).collect();
+    let scales = [126, 128, 127, 125];
+    let global_scale = T::from(0.75).expect("representable outer scale");
+    let biases = [T::from(1.5).unwrap(), T::from(-0.75).unwrap()];
+    let data_type = match T::data_type() {
+        DataType::F16 => "F16",
+        DataType::BF16 => "BF16",
+        DataType::F32 => "F32",
+        _ => unreachable!(),
+    };
+    add_tensor(&mut header, &mut payload, "weights.weights", &[ROWS, COLUMNS / 2], "U8", &codes);
+    add_tensor(&mut header, &mut payload, "weights.scales", &[ROWS, COLUMNS / GROUP_SIZE], "U8", &scales);
+    add_tensor(&mut header, &mut payload, "weights.global_scale", &[1], data_type, bytemuck::bytes_of(&global_scale));
+    add_tensor(&mut header, &mut payload, "biases", &[ROWS], data_type, bytemuck::cast_slice(&biases));
+
+    edit_header(&mut header);
+    let mut header = serde_json::to_vec(&Value::Object(header)).expect("serialize safetensors header");
+    header.extend(std::iter::repeat_n(b' ', (8 - header.len() % 8) % 8));
+    let mut file = tempfile().expect("create dense MXFP4 fixture");
+    file.write_all(&(header.len() as u64).to_le_bytes()).expect("write safetensors header length");
+    file.write_all(&header).expect("write safetensors header");
+    file.write_all(&payload).expect("write safetensors payload");
+    file
+}
+
+fn execute_loaded_projection<T: ArrayElement + PartialEq + Debug>(batch_dim: u32) {
+    let context = create_context::<Cpu>();
+    let file = dense_microfloat_parameter_file::<T>(|_| {});
+    let loader = ParameterLoader::<Cpu>::new(&file, context.as_ref()).expect("load dense MXFP4 fixture");
+    let tree = loader.tree();
+    let projection = <dyn Linear<Cpu>>::new(32, [2], true, context.as_ref(), T::data_type(), &tree)
+        .expect("load dense MXFP4 projection");
+    tree.assert_all_tensors_validated().expect("validate dense MXFP4 tensors");
+
+    let input: Vec<T> = (0..batch_dim)
+        .flat_map(|row| {
+            (0..32).map(move |column| {
+                let value = match (row % 2, column) {
+                    (1, 16..) => 0.5,
+                    (1, column) if column % 2 == 1 => -1.0,
+                    _ => 1.0,
+                };
+                T::from(value).expect("representable input")
+            })
+        })
+        .collect();
+    let input = alloc_allocation_with_data::<Cpu, T>(context.as_ref(), &input);
+    let mut encoder = Encoder::<Cpu>::new(context.as_ref()).expect("create encoder");
+    let output = projection.encode(input, batch_dim, &mut encoder).expect("encode MXFP4 projection");
+    let command_buffer = encoder.end_encoding();
+    let command_buffer = command_buffer.submit();
+    let completed = command_buffer.wait_until_completed().expect("execute MXFP4 projection");
+    let values = allocation_to_vec::<Cpu, T>(&output);
+    // Releasing scratch before the completion handle returns its allocation pool.
+    drop(output);
+    drop(completed);
+    let expected: Vec<T> = (0..batch_dim)
+        .flat_map(|row| {
+            if row % 2 == 0 {
+                [-36.0, 58.5]
+            } else {
+                [-21.0, -13.125]
+            }
+        })
+        .map(|value| T::from(value).expect("representable expected output"))
+        .collect();
+    assert_eq!(values, expected, "CPU {:?} batch={batch_dim}", T::data_type());
+}
+
+#[uzu_test]
+fn loads_and_executes_dense_mxfp4_projection() {
+    for batch_dim in [1, 9] {
+        execute_loaded_projection::<bf16>(batch_dim);
+        execute_loaded_projection::<f16>(batch_dim);
+        execute_loaded_projection::<f32>(batch_dim);
+    }
+}
+
+#[uzu_test]
+fn rejects_invalid_mxfp4_artifact_tensors() {
+    let context = create_context::<Cpu>();
+    for (tensor, field, value) in [
+        ("weights.weights", "dtype", json!("I8")),
+        ("weights.scales", "shape", json!([4])),
+        ("weights.global_scale", "data_offsets", json!([36, 38])),
+    ] {
+        let file = dense_microfloat_parameter_file::<f32>(|header| {
+            header[tensor][field] = value;
+        });
+        let loader = ParameterLoader::<Cpu>::new(&file, context.as_ref()).expect("read artifact header");
+        let tree = loader.tree();
+        let result = <dyn Linear<Cpu>>::new(32, [2], true, context.as_ref(), DataType::F32, &tree);
+        let error = result.err().expect("reject invalid MXFP4 tensor before projection encoding");
+        let LinearBlockError::LinearMatmulError(LinearMatmulError::WeightMatrix(WeightMatrixError::ParameterError(
+            error,
+        ))) = error
+        else {
+            panic!("unexpected projection error: {error}");
+        };
+        match (field, error) {
+            (
+                "dtype",
+                ParameterLoaderError::InvalidTensor {
+                    data_type: DataType::I8,
+                    expected_data_type: DataType::U8,
+                    ..
+                },
+            ) => {},
+            (
+                "shape",
+                ParameterLoaderError::InvalidTensor {
+                    shape,
+                    expected_shape,
+                    ..
+                },
+            ) => {
+                assert_eq!(&*shape, &[4]);
+                assert_eq!(&*expected_shape, &[2, 2]);
+            },
+            (
+                "data_offsets",
+                ParameterLoaderError::InvalidTensorSize {
+                    size: 2,
+                    expected_size: 4,
+                    ..
+                },
+            ) => {},
+            (_, error) => panic!("unexpected error for {tensor}: {error}"),
+        }
+    }
+}


### PR DESCRIPTION
Adds dense Metal execution for MXFP4 through the shared matmul path: GEMV for small batches and staged simdgroup GEMM for larger batches.

Depends on #818. Until that groundwork lands, the full PR diff includes it; the [Metal-only diff](https://github.com/xhjkl/uzu/compare/feat/mxfp4-weight-storage...feat/mxfp4-metal-matmul) shows this slice separately.

Routed expert scheduling remains out of scope.