### PR TITLE
Preserve Qwen prefix cache across coding tool turns

### DIFF
--- a/crates/legacy/cli/src/server/chat_completions.rs
+++ b/crates/legacy/cli/src/server/chat_completions.rs
@@ -261,7 +261,9 @@ fn to_chat_messages(messages: &[OaiMessage]) -> Vec<ChatMessage> {
             if let Some(identifier) = &message.tool_call_id {
                 let result = tool_call_result_block(identifier, message.content.clone().unwrap_or_default());
                 chat_message = chat_message.with_block(result);
-            } else if let Some(content) = &message.content {
+            } else if let Some(content) = &message.content
+                && (chat_message.role != (ChatRole::Assistant {}) || !content.is_empty())
+            {
                 chat_message = chat_message.with_text(content.clone());
             }
             for tool_call in message.tool_calls.iter().flatten() {
@@ -712,20 +714,38 @@ fn messages_have_prefix(
         })
 }
 
+fn prefix_cache_reset_reason(
+    messages: &[ChatMessage],
+    current: &[ChatMessage],
+) -> Option<&'static str> {
+    if current.is_empty() {
+        Some("empty_history")
+    } else if messages.len() <= current.len() {
+        Some("not_extension")
+    } else if !messages_have_prefix(messages, current) {
+        Some("history_mismatch")
+    } else {
+        None
+    }
+}
+
 /// Returns only the messages the session has not seen yet when the request
 /// extends the session's current history; otherwise resets the session and
 /// returns the full list. Token-level reuse itself is decided inside the
-/// session, which falls back to a full prefill if the rendered tokens diverge.
+/// session, which falls back to a full prefill when the encoded history cannot
+/// be safely continued.
 async fn prepare_input(
     session: &ChatSession,
     mut messages: Vec<ChatMessage>,
     prefix_cache: bool,
+    log: &RequestLog,
 ) -> Result<Vec<ChatMessage>, uzu::session::chat::ChatSessionError> {
     if prefix_cache {
         let current = session.messages().await;
-        if !current.is_empty() && messages.len() > current.len() && messages_have_prefix(&messages, &current) {
+        let Some(reason) = prefix_cache_reset_reason(&messages, &current) else {
             return Ok(messages.split_off(current.len()));
-        }
+        };
+        log.prefix_cache_reset(reason, current.len(), messages.len());
     }
     session.reset().await?;
     Ok(messages)
@@ -780,7 +800,7 @@ async fn run_blocking(
             },
         }
     };
-    let input = match prepare_input(&session, messages, prefix_cache).await {
+    let input = match prepare_input(&session, messages, prefix_cache, &log).await {
         Ok(input) => input,
         Err(error) => {
             log.fail(&error.to_string());
@@ -898,7 +918,7 @@ async fn run_stream(
         },
     };
     let has_tools = messages.iter().any(|message| !message.tool_namespaces().is_empty());
-    let input = match prepare_input(&session, messages, prefix_cache).await {
+    let input = match prepare_input(&session, messages, prefix_cache, &log).await {
         Ok(input) => input,
         Err(error) => {
             log.fail(&error.to_string());

--- a/crates/legacy/cli/src/server/request_log.rs
+++ b/crates/legacy/cli/src/server/request_log.rs
@@ -4,9 +4,9 @@ use uuid::Uuid;
 use uzu::types::session::chat::ChatReplyStats;
 
 /// Per-request console logging: one line when the request arrives, one when it
-/// ends, correlated by a short tag derived from the request id. Each line is a
-/// single `println!`, which holds the stdout lock for the whole write, so lines
-/// from concurrent requests never interleave.
+/// ends, and optional cache-reset metadata, correlated by a short tag derived
+/// from the request id. Each line is a single `println!`, which holds the stdout
+/// lock for the whole write, so lines from concurrent requests never interleave.
 pub struct RequestLog {
     tag: String,
     started: Instant,
@@ -44,6 +44,18 @@ impl RequestLog {
     /// For requests rejected before an id could be assigned to them.
     pub fn rejected(error: &str) {
         println!("[req {}] rejected: {error}", short_tag(&Uuid::new_v4().simple().to_string()));
+    }
+
+    pub fn prefix_cache_reset(
+        &self,
+        reason: &'static str,
+        stored_messages: usize,
+        incoming_messages: usize,
+    ) {
+        println!(
+            "[req {}] prefix cache reset: reason={reason}, stored_messages={stored_messages}, incoming_messages={incoming_messages}",
+            self.tag,
+        );
     }
 
     pub fn finish(

--- a/crates/legacy/cli/unit/server/chat_completions_test.rs
+++ b/crates/legacy/cli/unit/server/chat_completions_test.rs
@@ -405,6 +405,155 @@ fn assistant_reasoning_content_round_trips_in_session_block_order() {
 }
 
 #[test]
+fn prefix_match_normalizes_empty_assistant_content() {
+    for reasoning in [None, Some("thoughts")] {
+        let mut stored = ChatMessage::assistant();
+        if let Some(reasoning) = reasoning {
+            stored = stored.with_reasoning(reasoning.to_string());
+        }
+        stored = stored.with_tool_call(uzu::types::basic::ToolCall {
+            identifier: Some("c1".to_string()),
+            name: "f".to_string(),
+            arguments: uzu::types::basic::Value {
+                json: "{}".to_string(),
+            },
+        });
+
+        for content in [
+            None,
+            Some(serde_json::Value::Null),
+            Some(serde_json::json!("")),
+            Some(serde_json::json!([])),
+            Some(serde_json::json!([{"type": "text", "text": ""}])),
+        ] {
+            let mut assistant = serde_json::json!({
+                "role": "assistant",
+                "reasoning_content": reasoning,
+                "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "f", "arguments": "{}"}}],
+            });
+            if let Some(content) = content {
+                assistant["content"] = content;
+            }
+            let body = serde_json::json!({
+                "messages": [assistant, {"role": "tool", "tool_call_id": "c1", "content": "done"}],
+            });
+            let messages = to_chat_messages(&request(&body.to_string()).messages);
+
+            assert_eq!(messages[0].text(), None, "{body}");
+            assert_eq!(messages[0].reasoning().as_deref(), reasoning, "{body}");
+            assert!(messages_have_prefix(&messages, std::slice::from_ref(&stored)), "{body}");
+        }
+    }
+}
+
+#[test]
+fn prefix_match_preserves_nonempty_assistant_content() {
+    let current =
+        to_chat_messages(&request(r#"{"messages":[{"role":"assistant","reasoning_content":"thoughts"}]}"#).messages);
+    for content in [" ", "\n", "answer"] {
+        let body = serde_json::json!({
+            "messages": [
+                {"role": "assistant", "reasoning_content": "thoughts", "content": content},
+                {"role": "user", "content": "again"},
+            ],
+        });
+        let messages = to_chat_messages(&request(&body.to_string()).messages);
+
+        assert_eq!(messages[0].text().as_deref(), Some(content));
+        assert!(!messages_have_prefix(&messages, &current));
+    }
+}
+
+#[test]
+fn prefix_match_preserves_assistant_reasoning_changes() {
+    let current =
+        to_chat_messages(&request(r#"{"messages":[{"role":"assistant","reasoning_content":"thoughts"}]}"#).messages);
+    for reasoning in [None, Some(""), Some(" "), Some("different thoughts")] {
+        let body = serde_json::json!({
+            "messages": [
+                {"role": "assistant", "reasoning_content": reasoning, "content": ""},
+                {"role": "user", "content": "again"},
+            ],
+        });
+        let messages = to_chat_messages(&request(&body.to_string()).messages);
+
+        assert!(!messages_have_prefix(&messages, &current));
+    }
+}
+
+#[test]
+fn non_assistant_empty_content_preserves_text_blocks() {
+    for role in ["user", "system", "developer", "tool", "custom"] {
+        let body = serde_json::json!({"messages": [{"role": role, "content": ""}]});
+        let messages = to_chat_messages(&request(&body.to_string()).messages);
+
+        assert_eq!(messages[0].role.to_string(), role);
+        assert_eq!(
+            messages[0].content,
+            vec![ChatContentBlock::Text {
+                value: String::new()
+            }]
+        );
+    }
+}
+
+#[test]
+fn empty_tool_result_preserves_string_value() {
+    let messages =
+        to_chat_messages(&request(r#"{"messages":[{"role":"tool","tool_call_id":"c1","content":""}]}"#).messages);
+
+    assert_eq!(
+        messages[0].content,
+        vec![ChatContentBlock::ToolCallResult {
+            identifier: Some("c1".to_string()),
+            name: None,
+            value: uzu::types::basic::Value {
+                json: r#""""#.to_string(),
+            },
+        }]
+    );
+}
+
+#[test]
+fn prefix_cache_reset_reason_requires_nonempty_extension() {
+    let current = vec![ChatMessage::user().with_text("hi".to_string())];
+
+    assert_eq!(prefix_cache_reset_reason(&[], &[]), Some("empty_history"));
+    assert_eq!(prefix_cache_reset_reason(&current, &[]), Some("empty_history"));
+    assert_eq!(prefix_cache_reset_reason(&[], &current), Some("not_extension"));
+    assert_eq!(prefix_cache_reset_reason(&current, &current), Some("not_extension"));
+    assert_eq!(
+        prefix_cache_reset_reason(&[ChatMessage::user().with_text("changed".to_string())], &current),
+        Some("not_extension")
+    );
+}
+
+#[test]
+fn prefix_cache_reset_reason_reports_changed_history() {
+    let original = ChatMessage::user().with_text("hi".to_string());
+    let mut changed_metadata = original.clone();
+    changed_metadata.metadata.values.insert("test".to_string(), serde_json::json!(true).into());
+
+    for changed in [
+        ChatMessage::assistant().with_text("hi".to_string()),
+        ChatMessage::user().with_text("changed".to_string()),
+        changed_metadata,
+    ] {
+        let messages = vec![changed, ChatMessage::assistant().with_text("hello".to_string())];
+
+        assert_eq!(prefix_cache_reset_reason(&messages, std::slice::from_ref(&original)), Some("history_mismatch"));
+    }
+}
+
+#[test]
+fn prefix_cache_reset_reason_accepts_matching_extension() {
+    let current = vec![ChatMessage::user().with_text("hi".to_string())];
+    let messages = vec![current[0].clone(), ChatMessage::assistant().with_text("hello".to_string())];
+
+    assert_eq!(prefix_cache_reset_reason(&messages, &current), None);
+}
+
+#[test]
 fn prefix_match_ignores_tool_call_identifiers() {
     let assistant_call = |identifier: &str| {
         ChatMessage::assistant().with_tool_call(uzu::types::basic::ToolCall {
@@ -423,6 +572,7 @@ fn prefix_match_ignores_tool_call_identifiers() {
         ChatMessage::user().with_text("again".to_string()),
     ];
     assert!(messages_have_prefix(&extending, &current));
+    assert_eq!(prefix_cache_reset_reason(&extending, &current), None);
 
     let mut different = assistant_call("nagare-uuid");
     different.content.push(ChatContentBlock::Text {
@@ -450,6 +600,7 @@ fn prefix_match_treats_coerced_arguments_as_equal() {
     let extending =
         vec![assistant_call(r#"{"query":"cats","limit":5}"#), ChatMessage::user().with_text("more".to_string())];
     assert!(messages_have_prefix(&extending, &current));
+    assert_eq!(prefix_cache_reset_reason(&extending, &current), None);
 
     // a genuinely different value is still a mismatch
     let different =

--- a/crates/legacy/hanashi/src/chat/hanashi/continuation.rs
+++ b/crates/legacy/hanashi/src/chat/hanashi/continuation.rs
@@ -1,0 +1,219 @@
+use shoji::types::{
+    basic::TokenId,
+    session::chat::{ChatContentBlock, ChatMessage, ChatRole},
+};
+use token_stream_parser::{Parser as _, reduction::ReductionParserSection};
+use tokenizers::Tokenizer;
+
+use super::{Error, HanashiEncodingImpl, config::HanashiConfig, ordering::Validator};
+use crate::chat::{SynchronizationError, SynchronizationResult};
+
+const MESSAGE_END: &str = "<|im_end|>";
+
+#[derive(Clone, Copy)]
+pub(super) enum ContinuationPolicy {
+    Qwen35 {
+        message_end_id: TokenId,
+    },
+}
+
+impl ContinuationPolicy {
+    pub(super) fn new(
+        config: &HanashiConfig,
+        tokenizer: &Tokenizer,
+    ) -> Option<Self> {
+        if !matches!(config, HanashiConfig::Qwen35) || !tokenizer.get_added_vocabulary().is_special_token(MESSAGE_END) {
+            return None;
+        }
+        let message_end_id = tokenizer.token_to_id(MESSAGE_END)?;
+        if tokenizer.decode(&[message_end_id], false).ok()?.as_str() != MESSAGE_END {
+            return None;
+        }
+        Some(Self::Qwen35 {
+            message_end_id,
+        })
+    }
+}
+
+pub(super) struct CompletedGeneration {
+    canonical_prefix: String,
+}
+
+impl HanashiEncodingImpl {
+    pub fn supports_continuation(&self) -> bool {
+        self.continuation_policy.is_some()
+    }
+
+    /// Record authoritative history only after the owner has finalized a successful backend stream.
+    pub fn record_completion(
+        &mut self,
+        messages: Vec<ChatMessage>,
+    ) -> Result<bool, Error> {
+        self.completed_generation = None;
+        let Some(ContinuationPolicy::Qwen35 {
+            message_end_id,
+        }) = self.continuation_policy
+        else {
+            return Ok(false);
+        };
+        if !self.has_completed_assistant(message_end_id)
+            || !messages.last().is_some_and(|message| matches!(message.role, ChatRole::Assistant {}))
+            || !messages.iter().all(is_supported_message)
+        {
+            return Ok(false);
+        }
+
+        let rendered_messages = self.fill_default_content(&messages)?;
+        let mut canonical_prefix = self.render_messages(&rendered_messages, false)?;
+        if !canonical_prefix.ends_with("<|im_end|>\n") {
+            return Ok(false);
+        }
+        // The stop token was emitted, but the template's following newline has not been consumed.
+        canonical_prefix.pop();
+        self.state.messages = messages;
+        self.completed_generation = Some(CompletedGeneration {
+            canonical_prefix,
+        });
+        Ok(true)
+    }
+
+    /// Append a certified continuation. An error requires the owner to reset encoding and backend state together.
+    pub fn try_append(
+        &mut self,
+        messages: &[ChatMessage],
+    ) -> Result<Option<Vec<TokenId>>, Error> {
+        let previous_len = self.state.messages.len();
+        if self.completed_generation.is_none()
+            || messages.len() <= previous_len
+            || !messages.starts_with(&self.state.messages)
+            || !messages.last().is_some_and(|message| matches!(message.role, ChatRole::User {} | ChatRole::Tool {}))
+            || !messages[previous_len..].iter().all(is_supported_append)
+        {
+            return Ok(None);
+        }
+
+        let rendered_messages = self.fill_default_content(messages)?;
+        let mut validator = Validator::new(self.config.ordering.clone());
+        for message in &rendered_messages {
+            validator.validate_next(&message.role)?;
+        }
+        let rendered = self.render_messages(&rendered_messages, true)?;
+        let Some(completed) = &self.completed_generation else {
+            return Ok(None);
+        };
+        let Some(suffix) = rendered.strip_prefix(&completed.canonical_prefix) else {
+            return Ok(None);
+        };
+        let token_ids = self.tokenize(suffix)?;
+        if token_ids.is_empty() {
+            return Ok(None);
+        }
+
+        // Keep the sampled token ledger and incremental decoder; only new input is staged and parsed.
+        self.completed_generation = None;
+        self.state.messages.extend(rendered_messages.into_iter().skip(previous_len));
+        self.validator = validator;
+        let staged_len = self.state.messages.len();
+        let synchronization = self.push_prompt_tokens(&token_ids)?;
+        if synchronization != SynchronizationResult::Inserted
+            || self.state.messages.len() != staged_len + 1
+            || !self.state.messages.last().is_some_and(|message| matches!(message.role, ChatRole::Assistant {}))
+        {
+            return Err(SynchronizationError::Desynchronization.into());
+        }
+        Ok(Some(token_ids))
+    }
+
+    fn has_completed_assistant(
+        &self,
+        message_end_id: TokenId,
+    ) -> bool {
+        let Some(last_token) = self.state.tokens.last() else {
+            return false;
+        };
+        if last_token.id != message_end_id || !last_token.is_special || last_token.value != MESSAGE_END {
+            return false;
+        }
+        if !self.state.messages.last().is_some_and(|message| {
+            matches!(message.role, ChatRole::Assistant {})
+                && !message.content.iter().any(|block| matches!(block, ChatContentBlock::ToolCallCandidate { .. }))
+        }) {
+            return false;
+        }
+        if self
+            .parser
+            .state()
+            .value
+            .as_array()
+            .and_then(|messages| messages.last())
+            .and_then(|message| message.get("role").and_then(serde_json::Value::as_str))
+            != Some("assistant")
+        {
+            return false;
+        }
+        let Some(ReductionParserSection::Group {
+            name,
+            open: Some(open),
+            close: Some(close),
+            finished: true,
+            sections,
+        }) = self.parser.reduction().state().sections.last()
+        else {
+            return false;
+        };
+        name == "message"
+            && open.value == "<|im_start|>"
+            && open.is_special
+            && close.id == message_end_id
+            && close.value == MESSAGE_END
+            && close.is_special
+            && sections.iter().all(has_closed_bounded_groups)
+    }
+}
+
+fn has_closed_bounded_groups(section: &ReductionParserSection) -> bool {
+    let ReductionParserSection::Group {
+        name,
+        close,
+        finished,
+        sections,
+        ..
+    } = section
+    else {
+        return true;
+    };
+    let expected_close = match name.as_str() {
+        "role" | "content" => None,
+        "reasoning" => Some("</think>"),
+        "tool_call" => Some("</tool_call>"),
+        "tool_call_result" => Some("</tool_response>"),
+        _ => return false,
+    };
+    *finished
+        && expected_close.is_none_or(|expected| close.as_ref().is_some_and(|token| token.value == expected))
+        && sections.iter().all(has_closed_bounded_groups)
+}
+
+fn is_supported_message(message: &ChatMessage) -> bool {
+    !matches!(message.role, ChatRole::Custom { .. })
+        && message.content.iter().all(|block| {
+            matches!(
+                block,
+                ChatContentBlock::Text { .. }
+                    | ChatContentBlock::Reasoning { .. }
+                    | ChatContentBlock::ToolCall { .. }
+                    | ChatContentBlock::ToolCallResult { .. }
+                    | ChatContentBlock::Tools { .. }
+                    | ChatContentBlock::ReasoningEffort { .. }
+            )
+        })
+}
+
+fn is_supported_append(message: &ChatMessage) -> bool {
+    is_supported_message(message)
+        && matches!(message.role, ChatRole::User {} | ChatRole::Assistant {} | ChatRole::Tool {})
+        && !message
+            .content
+            .iter()
+            .any(|block| matches!(block, ChatContentBlock::Tools { .. } | ChatContentBlock::ReasoningEffort { .. }))
+}

--- a/crates/legacy/hanashi/src/chat/hanashi/continuation_test.rs
+++ b/crates/legacy/hanashi/src/chat/hanashi/continuation_test.rs
@@ -1,0 +1,247 @@
+use std::sync::Arc;
+
+use shoji::types::{
+    basic::{ReasoningEffort, Value},
+    session::chat::{ChatContentBlock, ChatMessage, ChatRole},
+};
+use tokenizers::{AddedToken, Tokenizer, models::bpe::BPE, pre_tokenizers::byte_level::ByteLevel};
+
+use super::{HanashiEncodingImpl, config::HanashiConfig};
+use crate::Encoding as _;
+
+fn tokenizer() -> Arc<Tokenizer> {
+    let mut alphabet: Vec<char> = ByteLevel::alphabet().into_iter().collect();
+    alphabet.sort_unstable();
+    let mut vocabulary: Vec<(String, u32)> =
+        alphabet.into_iter().enumerate().map(|(index, character)| (character.to_string(), index as u32)).collect();
+    vocabulary.push(("ab".to_string(), 256));
+    vocabulary.push(("abc".to_string(), 257));
+    let vocabulary: [(String, u32); 258] = vocabulary.try_into().unwrap();
+    let model = BPE::builder()
+        .vocab_and_merges(vocabulary, vec![("a".to_string(), "b".to_string()), ("ab".to_string(), "c".to_string())])
+        .build()
+        .unwrap();
+    let mut tokenizer = Tokenizer::new(model);
+    tokenizer.with_pre_tokenizer(Some(ByteLevel::new(false, false, false)));
+    tokenizer.with_decoder(Some(ByteLevel::new(false, false, false)));
+    tokenizer
+        .add_tokens(&["system", "developer", "user", "assistant", "tool"].map(|value| AddedToken::from(value, false)));
+    tokenizer.add_special_tokens(
+        &[
+            "<|im_start|>",
+            "<|im_end|>",
+            "<think>",
+            "</think>",
+            "<tool_call>",
+            "</tool_call>",
+            "<tool_response>",
+            "</tool_response>",
+        ]
+        .map(|value| AddedToken::from(value, true)),
+    );
+    Arc::new(tokenizer)
+}
+
+fn encoding() -> HanashiEncodingImpl {
+    HanashiEncodingImpl::new(HanashiConfig::Qwen35, tokenizer()).unwrap()
+}
+
+fn prompt() -> Vec<ChatMessage> {
+    vec![
+        ChatMessage::system().with_reasoning_effort(ReasoningEffort::Default),
+        ChatMessage::user().with_text("Inspect the repository.".to_string()),
+    ]
+}
+
+fn decode(
+    encoding: &mut HanashiEncodingImpl,
+    text: &str,
+) {
+    for token_id in encoding.tokenize(text).unwrap() {
+        encoding.decode(vec![token_id]).unwrap();
+    }
+}
+
+fn tool_call(argument: &str) -> String {
+    format!("<tool_call>\n<function=inspect>\n<parameter=options>\n{argument}\n</parameter>\n</function>\n</tool_call>")
+}
+
+fn tool_result(value: &str) -> ChatMessage {
+    ChatMessage::tool().with_block(ChatContentBlock::ToolCallResult {
+        identifier: Some(value.to_string()),
+        name: Some("inspect".to_string()),
+        value: Value {
+            json: serde_json::to_string(value).unwrap(),
+        },
+    })
+}
+
+#[test]
+fn continuation_preserves_sampled_formatting_across_three_turns() {
+    let mut encoding = encoding();
+    let mut history = prompt();
+    encoding.encode(history.clone()).unwrap();
+    let variants = [
+        format!("Ready.\n</think>\n\n{}", tool_call(r#"{"a":1,"b":2}"#)),
+        format!("Ready.\n\n</think>\n\n{}", tool_call(r#"{"html":"<div>"}"#)),
+        format!("Ready.\n</think>\n\nWorking.\n{}\n", tool_call(r#"{"a":1}"#)),
+    ];
+    for generated in variants {
+        decode(&mut encoding, &format!("{generated}<|im_end|>"));
+        assert_eq!(encoding.state().messages.last().unwrap().tool_calls().len(), 1);
+        history.push(encoding.state().messages.last().unwrap().clone());
+        assert!(encoding.record_completion(history.clone()).unwrap());
+        let old_tokens = encoding.state().tokens.clone();
+        let old_messages = history.clone();
+        history.push(tool_result("done"));
+        let suffix = encoding.try_append(&history).unwrap().expect("completed tool turn should append");
+        assert!(!suffix.is_empty());
+        assert_eq!(&encoding.state().tokens[..old_tokens.len()], old_tokens);
+        assert_eq!(&encoding.state().messages[..old_messages.len()], old_messages);
+        assert_eq!(&encoding.state().messages[..history.len()], history);
+        assert_eq!(encoding.state().messages.len(), history.len() + 1);
+        assert_eq!(encoding.state().messages.last().unwrap().role, ChatRole::Assistant {});
+        assert_eq!(
+            encoding.state().tokens[old_tokens.len()..].iter().map(|token| token.id).collect::<Vec<_>>(),
+            suffix
+        );
+    }
+    decode(&mut encoding, "Complete.\n</think>\n\nFinished.<|im_end|>");
+    assert_eq!(encoding.state().messages.last().unwrap().text().as_deref(), Some("Finished."));
+}
+
+#[test]
+fn continuation_preserves_noncanonical_token_ids_and_split_unicode() {
+    let mut encoding = encoding();
+    let mut history = prompt();
+    encoding.encode(history.clone()).unwrap();
+    decode(&mut encoding, "Ready.\n</think>\n\n");
+    let sampled: Vec<_> = ["a", "b", "c"].into_iter().flat_map(|text| encoding.tokenize(text).unwrap()).collect();
+    assert_ne!(sampled, encoding.tokenize("abc").unwrap());
+    for token_id in sampled {
+        encoding.decode(vec![token_id]).unwrap();
+    }
+    decode(&mut encoding, " café 🦀<|im_end|>");
+    history.push(encoding.state().messages.last().unwrap().clone());
+    assert!(encoding.record_completion(history.clone()).unwrap());
+    let old_tokens = encoding.state().tokens.clone();
+    history.push(ChatMessage::user().with_text("Continue café 🦀".to_string()));
+    assert!(encoding.try_append(&history).unwrap().is_some());
+    assert_eq!(&encoding.state().tokens[..old_tokens.len()], old_tokens);
+    decode(&mut encoding, "Ready.\n</think>\n\nVoilà 🦀<|im_end|>");
+    assert_eq!(encoding.state().messages.last().unwrap().text().as_deref(), Some("Voilà 🦀"));
+}
+
+#[test]
+fn continuation_groups_tool_results_without_overwriting_logical_inputs() {
+    let mut encoding = encoding();
+    let mut history = prompt();
+    encoding.encode(history.clone()).unwrap();
+    decode(&mut encoding, &format!("Ready.\n</think>\n\n{}\n{}<|im_end|>", tool_call("one"), tool_call("two")));
+    history.push(encoding.state().messages.last().unwrap().clone());
+    assert!(encoding.record_completion(history.clone()).unwrap());
+    history.extend([tool_result("one"), tool_result("two")]);
+    let suffix = encoding.try_append(&history).unwrap().unwrap();
+    let text = encoding.tokenizer.decode(&suffix, false).unwrap();
+    assert_eq!(text.matches("<|im_start|>user").count(), 1);
+    assert_eq!(text.matches("<tool_response>").count(), 2);
+    assert_eq!(&encoding.state().messages[..history.len()], history);
+}
+
+#[test]
+fn continuation_rejects_logical_edits_and_new_controls_without_mutation() {
+    let mut encoding = encoding();
+    let mut history = prompt();
+    encoding.encode(history.clone()).unwrap();
+    decode(&mut encoding, "Ready.\n</think>\n\nDone.<|im_end|>");
+    history.push(encoding.state().messages.last().unwrap().clone());
+    assert!(encoding.record_completion(history.clone()).unwrap());
+    let original = encoding.state().clone();
+    let mut edited = history.clone();
+    edited[1] = ChatMessage::user().with_text(" Inspect the repository. ".to_string());
+    edited.push(ChatMessage::user().with_text("Next".to_string()));
+    assert!(encoding.try_append(&edited).unwrap().is_none());
+    assert_eq!(encoding.state(), &original);
+    for message in [
+        ChatMessage::system().with_text("changed".to_string()),
+        ChatMessage::developer().with_tool_namespaces(vec![]),
+        ChatMessage::user().with_text("Next".to_string()).with_reasoning_effort(ReasoningEffort::Disabled),
+        ChatMessage::user().with_block(ChatContentBlock::Image {
+            url: "image".to_string(),
+        }),
+        ChatMessage::assistant().with_text("partial".to_string()),
+    ] {
+        let mut next = history.clone();
+        next.push(message);
+        assert!(encoding.try_append(&next).unwrap().is_none());
+        assert_eq!(encoding.state(), &original);
+    }
+    assert!(encoding.try_append(&history).unwrap().is_none());
+    history.push(ChatMessage::user().with_text("Next".to_string()));
+    assert!(encoding.try_append(&history).unwrap().is_some());
+    assert!(encoding.try_append(&history).unwrap().is_none());
+}
+
+#[test]
+fn completion_rejects_implicitly_closed_bounded_sections() {
+    for generated in [
+        "unfinished reasoning<|im_end|>",
+        "Ready.\n</think>\n\n<tool_call>\n<function=inspect>\n<|im_end|>",
+        "Ready.\n</think>\n\nDone.",
+    ] {
+        let mut encoding = encoding();
+        encoding.encode(prompt()).unwrap();
+        decode(&mut encoding, generated);
+        assert!(!encoding.record_completion(encoding.state().messages.clone()).unwrap());
+    }
+}
+
+#[test]
+fn continuation_is_limited_to_bundled_qwen35_and_reset_clears_completion() {
+    let tokenizer = tokenizer();
+    assert_ne!(tokenizer.token_to_id("<|im_end|>"), HanashiConfig::Qwen35.resolve().unwrap().tokens.eos_token_id);
+    assert!(HanashiEncodingImpl::new(HanashiConfig::Qwen35, tokenizer.clone()).unwrap().supports_continuation());
+    for config in [
+        HanashiConfig::Qwen36,
+        HanashiConfig::Custom {
+            config: HanashiConfig::Qwen35.resolve().unwrap(),
+        },
+    ] {
+        assert!(!HanashiEncodingImpl::new(config, tokenizer.clone()).unwrap().supports_continuation());
+    }
+    let mut encoding = encoding();
+    encoding.encode(prompt()).unwrap();
+    decode(&mut encoding, "Ready.\n</think>\n\nDone.<|im_end|>");
+    let mut history = encoding.state().messages.clone();
+    assert!(encoding.record_completion(history.clone()).unwrap());
+    encoding.reset().unwrap();
+    history.push(ChatMessage::user().with_text("Next".to_string()));
+    assert!(encoding.try_append(&history).unwrap().is_none());
+    assert!(encoding.state().tokens.is_empty());
+}
+
+#[test]
+fn continuation_accepts_disabled_thinking_preamble_and_authoritative_call_ids() {
+    let mut encoding = encoding();
+    let mut history = vec![
+        ChatMessage::system().with_reasoning_effort(ReasoningEffort::Disabled),
+        ChatMessage::user().with_text("Inspect the repository.".to_string()),
+    ];
+    encoding.encode(history.clone()).unwrap();
+    decode(&mut encoding, &format!("{}<|im_end|>", tool_call("src")));
+    let mut assistant = encoding.state().messages.last().unwrap().clone();
+    let ChatContentBlock::ToolCall {
+        value,
+    } = assistant.content.last_mut().unwrap()
+    else {
+        panic!("expected parsed tool call");
+    };
+    value.identifier = Some("assigned-by-session".to_string());
+    history.push(assistant);
+    assert!(encoding.record_completion(history.clone()).unwrap());
+    assert_eq!(encoding.state().messages, history);
+    history.push(tool_result("done"));
+    assert!(encoding.try_append(&history).unwrap().is_some());
+    decode(&mut encoding, "Finished.<|im_end|>");
+    assert_eq!(encoding.state().messages.last().unwrap().text().as_deref(), Some("Finished."));
+}

--- a/crates/legacy/hanashi/src/chat/hanashi/mod.rs
+++ b/crates/legacy/hanashi/src/chat/hanashi/mod.rs
@@ -1,9 +1,13 @@
 pub mod config;
+mod continuation;
 mod error;
 pub mod messages;
 mod ordering;
 pub mod renderer;
 mod token;
+
+#[cfg(test)]
+mod continuation_test;
 
 use std::{collections::HashSet, sync::Arc};
 
@@ -17,6 +21,7 @@ use tokenizers::{Tokenizer, step_decode_stream};
 
 use self::{
     config::HanashiResolvedConfig,
+    continuation::{CompletedGeneration, ContinuationPolicy},
     messages::streamed::{Content as StreamedContent, Message as StreamedMessage, Section as StreamedSection},
     ordering::Validator,
 };
@@ -36,6 +41,8 @@ pub struct HanashiEncodingImpl {
     framing_tokens: HashSet<String>,
     renderer: Renderer,
     validator: Validator,
+    continuation_policy: Option<ContinuationPolicy>,
+    completed_generation: Option<CompletedGeneration>,
 
     state: State,
     tokenizer_decode_ids: Vec<u32>,
@@ -53,6 +60,7 @@ impl HanashiEncodingImpl {
         let framing_tokens = resolved_config.parsing.framing_config().tokens.into_iter().collect();
         let renderer = Renderer::new(resolved_config.rendering.clone());
         let validator = Validator::new(resolved_config.ordering.clone());
+        let continuation_policy = ContinuationPolicy::new(&config, &tokenizer);
         Ok(Self {
             capabilities: config.capabilities()?,
             config: resolved_config,
@@ -61,6 +69,8 @@ impl HanashiEncodingImpl {
             framing_tokens,
             renderer,
             validator,
+            continuation_policy,
+            completed_generation: None,
             state: State::default(),
             tokenizer_decode_ids: vec![],
             tokenizer_decode_prefix: "".to_string(),
@@ -81,6 +91,7 @@ impl EncodingTrait for HanashiEncodingImpl {
     }
 
     fn reset(&mut self) -> Result<(), Self::Error> {
+        self.completed_generation = None;
         self.parser.reset();
         self.validator.reset();
         self.state = State::default();
@@ -94,6 +105,7 @@ impl EncodingTrait for HanashiEncodingImpl {
         &mut self,
         messages: Self::Input,
     ) -> Result<(), Self::Error> {
+        self.completed_generation = None;
         let messages = self.fill_default_content(&messages)?;
         for message in &messages {
             self.validator.validate_next(&message.role)?;
@@ -110,17 +122,9 @@ impl EncodingTrait for HanashiEncodingImpl {
             self.parser.set_variable("tools", serde_json::Value::Bool(true));
         }
 
-        let bos_token = self.config.tokens.bos_token_id.and_then(|token_id| self.resolve_token(token_id, false).ok());
-        let eos_token = self.config.tokens.eos_token_id.and_then(|token_id| self.resolve_token(token_id, false).ok());
-        let text = self.renderer.render(&messages, true, bos_token, eos_token, None)?;
+        let text = self.render_messages(&messages, true)?;
         let text_encoding = self.tokenizer.encode(text, false).map_err(|_| Error::UnableToEncodeText)?;
-        for token_id in text_encoding.get_ids() {
-            let token = self.resolve_token(*token_id, true)?;
-            self.push_token_to_parser(&token, true)?;
-            self.state.tokens.push(token);
-        }
-        self.parser.flush_extraction();
-        self.update_messages_from_parser_state()?;
+        self.push_prompt_tokens(text_encoding.get_ids())?;
         Ok(())
     }
 
@@ -128,6 +132,7 @@ impl EncodingTrait for HanashiEncodingImpl {
         &mut self,
         token_ids: Self::Output,
     ) -> Result<(), Self::Error> {
+        self.completed_generation = None;
         for token_id in &token_ids {
             let token = self.resolve_token(*token_id, true)?;
             self.push_token_to_parser(&token, false)?;
@@ -154,6 +159,29 @@ impl HanashiEncodingImpl {
     ) -> Result<Vec<TokenId>, Error> {
         let encoding = self.tokenizer.encode(text, false).map_err(|_| Error::UnableToEncodeText)?;
         Ok(encoding.get_ids().to_vec())
+    }
+
+    fn render_messages(
+        &mut self,
+        messages: &[ChatMessage],
+        should_add_preamble: bool,
+    ) -> Result<String, Error> {
+        let bos_token = self.config.tokens.bos_token_id.and_then(|token_id| self.resolve_token(token_id, false).ok());
+        let eos_token = self.config.tokens.eos_token_id.and_then(|token_id| self.resolve_token(token_id, false).ok());
+        Ok(self.renderer.render(messages, should_add_preamble, bos_token, eos_token, None)?)
+    }
+
+    fn push_prompt_tokens(
+        &mut self,
+        token_ids: &[TokenId],
+    ) -> Result<SynchronizationResult, Error> {
+        for token_id in token_ids {
+            let token = self.resolve_token(*token_id, true)?;
+            self.push_token_to_parser(&token, true)?;
+            self.state.tokens.push(token);
+        }
+        self.parser.flush_extraction();
+        self.update_messages_from_parser_state()
     }
 
     fn push_token_to_parser(
@@ -224,7 +252,7 @@ impl HanashiEncodingImpl {
         })
     }
 
-    fn update_messages_from_parser_state(&mut self) -> Result<(), Error> {
+    fn update_messages_from_parser_state(&mut self) -> Result<SynchronizationResult, Error> {
         let value = self.parser.state().value.clone();
         let messages =
             serde_json::from_value::<Vec<StreamedMessage>>(value).map_err(|_| Error::InvalidStreamedContent)?;
@@ -290,7 +318,7 @@ impl HanashiEncodingImpl {
             self.validator.validate_next(&last_message.role)?;
         }
 
-        Ok(())
+        Ok(result)
     }
 
     fn resolve_token(

--- a/crates/legacy/hanashi/src/chat/mod.rs
+++ b/crates/legacy/hanashi/src/chat/mod.rs
@@ -38,6 +38,33 @@ pub enum Encoding {
 }
 
 impl Encoding {
+    pub fn supports_continuation(&self) -> bool {
+        match self {
+            Self::Hanashi(inner) => inner.supports_continuation(),
+            Self::Harmony(_) => false,
+        }
+    }
+
+    pub fn record_completion(
+        &mut self,
+        messages: Vec<ChatMessage>,
+    ) -> Result<bool, Error> {
+        match self {
+            Self::Hanashi(inner) => inner.record_completion(messages).map_err(Into::into),
+            Self::Harmony(_) => Ok(false),
+        }
+    }
+
+    pub fn try_append(
+        &mut self,
+        messages: &[ChatMessage],
+    ) -> Result<Option<Vec<TokenId>>, Error> {
+        match self {
+            Self::Hanashi(inner) => inner.try_append(messages).map_err(Into::into),
+            Self::Harmony(_) => Ok(None),
+        }
+    }
+
     pub fn tokenize(
         &self,
         text: &str,

--- a/crates/legacy/nagare/src/chat/mod.rs
+++ b/crates/legacy/nagare/src/chat/mod.rs
@@ -292,8 +292,8 @@ impl ChatSession {
 
         let mut instance = self.instance.lock().await;
         let mut stream = match &mut *instance {
-            Instance::Token(session) => session.stream(&all_messages, config, cancel_token).await,
-            Instance::Message(session) => session.stream(&all_messages, config, cancel_token),
+            Instance::Token(session) => session.stream(&all_messages, config, cancel_token.clone()).await,
+            Instance::Message(session) => session.stream(&all_messages, config, cancel_token.clone()),
         };
         while let Some(partial_output) = stream.next().await {
             match partial_output {
@@ -339,6 +339,16 @@ impl ChatSession {
             }
         }
         drop(stream);
+        // The token backend finalizes pending/speculative work in Drop. Only certify its history
+        // after teardown, while the same instance lock still serializes the next request.
+        if !interrupted
+            && !cancel_token.is_cancelled()
+            && !sender.is_closed()
+            && let Instance::Token(session) = &mut *instance
+            && let Some(reply) = outputs.get(&0)
+        {
+            session.finish_turn(all_messages, reply);
+        }
         drop(instance);
 
         // telemetry report result

--- a/crates/legacy/nagare/src/chat/token.rs
+++ b/crates/legacy/nagare/src/chat/token.rs
@@ -26,8 +26,8 @@ use shoji::{
         basic::{SamplingParameters, TokenId},
         model::Model,
         session::chat::{
-            ChatConfig, ChatContentBlock, ChatMessage, ChatReplyConfig, ChatReplyEnergy, ChatReplyFinishReason,
-            ChatReplySpeculatorStats, ChatReplyStats,
+            ChatConfig, ChatContentBlock, ChatMessage, ChatReply, ChatReplyConfig, ChatReplyEnergy,
+            ChatReplyFinishReason, ChatReplySpeculatorStats, ChatReplyStats,
         },
     },
 };
@@ -37,12 +37,16 @@ use tokio_util::sync::CancellationToken;
 use crate::util::power::{EnergyRecorder, Error as EnergyError};
 use crate::{chat::ChatSessionError, util::helpers::error_stream};
 
+#[cfg(test)]
+mod tests;
+
 pub struct Session {
     instance: Arc<dyn ChatTokenBackendInstance>,
     state: Box<dyn State>,
     encoding: Encoding,
     input_tokens: Vec<u64>,
     stop_token_ids: Box<[u64]>,
+    state_is_valid: bool,
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     energy_recorder: EnergyRecorder,
 }
@@ -110,16 +114,19 @@ impl Session {
             encoding,
             input_tokens: Vec::new(),
             stop_token_ids,
+            state_is_valid: true,
             #[cfg(any(target_os = "macos", target_os = "ios"))]
             energy_recorder: EnergyRecorder::new(),
         })
     }
 
     pub async fn reset(&mut self) -> Result<(), ChatSessionError> {
+        self.state_is_valid = false;
         self.encoding.reset().map_err(|error| ChatSessionError::Backend {
             message: error.to_string(),
         })?;
         self.state_reset().await?;
+        self.state_is_valid = true;
         Ok(())
     }
 
@@ -131,47 +138,9 @@ impl Session {
     ) -> Pin<Box<dyn Stream<Item = Result<Output, ChatSessionError>> + Send + 'a>> {
         let time_start = Instant::now();
 
-        let curr_all_tokens = self.encoding.state().tokens.clone();
-        let new_all_tokens = match self.build_input(input) {
-            Ok(input) => input,
-            Err(err) => {
-                return error_stream(ChatSessionError::Backend {
-                    message: err.to_string(),
-                });
-            },
-        };
-
-        // The engine state can only be kept whole or reset, so reuse it whenever the session's
-        // text is a prefix of the newly rendered text — even if tokenizations differ, as sampled
-        // replies are not canonically tokenized — and prefill only the raw-tokenized text suffix.
-        let curr_text = curr_all_tokens.iter().fold(String::new(), |mut text, token| {
-            text.push_str(&token.value);
-            text
-        });
-        let new_text = self.encoding.state().tokens.iter().fold(String::new(), |mut text, token| {
-            text.push_str(&token.value);
-            text
-        });
-        let reset = !new_text.starts_with(&curr_text);
-        let cached_tokens_input = if reset {
-            0
-        } else {
-            curr_all_tokens.len()
-        };
-        self.input_tokens = if reset {
-            if let Err(err) = self.state_reset().await {
-                return error_stream(err);
-            }
-            new_all_tokens
-        } else {
-            match self.encoding.tokenize(&new_text[curr_text.len()..]) {
-                Ok(suffix_tokens) => suffix_tokens.into_iter().map(u64::from).collect(),
-                Err(err) => {
-                    return error_stream(ChatSessionError::Backend {
-                        message: err.to_string(),
-                    });
-                },
-            }
+        let cached_tokens_input = match self.prepare_input(input).await {
+            Ok(cached_tokens) => cached_tokens,
+            Err(error) => return error_stream(error),
         };
 
         let instance = self.instance.as_ref();
@@ -232,6 +201,110 @@ impl Session {
             },
         )
         .boxed()
+    }
+
+    pub(super) fn finish_turn(
+        &mut self,
+        mut messages: Vec<ChatMessage>,
+        reply: &ChatReply,
+    ) {
+        if !self.encoding.supports_continuation()
+            || !matches!(reply.finish_reason, Some(ChatReplyFinishReason::Stop | ChatReplyFinishReason::ToolCalls))
+            || !self
+                .encoding
+                .state()
+                .tokens
+                .last()
+                .is_some_and(|token| self.stop_token_ids.contains(&u64::from(token.id)))
+        {
+            return;
+        }
+
+        messages.push(reply.message.clone());
+        match self.encoding.record_completion(messages) {
+            Ok(complete) => self.state_is_valid = complete,
+            Err(_) => {
+                // The reply has already been delivered. Fall back to a coherent reset on the next input.
+                tracing::debug!(reason = "completion_failed", "Prefix cache unavailable");
+            },
+        }
+    }
+
+    async fn prepare_input(
+        &mut self,
+        input: &[ChatMessage],
+    ) -> Result<usize, ChatSessionError> {
+        if !self.encoding.supports_continuation() {
+            return self.prepare_legacy_input(input).await;
+        }
+
+        let state_is_valid = self.state_is_valid;
+        self.state_is_valid = false;
+        let cached_tokens = self.encoding.state().tokens.len();
+        if state_is_valid
+            && let Some(tokens) = self.encoding.try_append(input).map_err(|error| ChatSessionError::Backend {
+                message: error.to_string(),
+            })?
+        {
+            self.input_tokens = tokens.into_iter().map(u64::from).collect();
+            tracing::debug!(cached_tokens, prefill_tokens = self.input_tokens.len(), "Continuing prefix cache");
+            return Ok(cached_tokens);
+        }
+
+        // An incomplete stream or failed preparation can leave only one side advanced. Reset the pair,
+        // even when the encoding is empty; it does not imply that the backend is empty after an error.
+        let tokens = self.build_input(input)?;
+        if !state_is_valid || cached_tokens != 0 {
+            self.state_reset().await?;
+        }
+        self.input_tokens = tokens;
+        tracing::debug!(
+            discarded_tokens = cached_tokens,
+            prefill_tokens = self.input_tokens.len(),
+            "Prefilling full prompt"
+        );
+        Ok(0)
+    }
+
+    async fn prepare_legacy_input(
+        &mut self,
+        input: &[ChatMessage],
+    ) -> Result<usize, ChatSessionError> {
+        let curr_all_tokens = self.encoding.state().tokens.clone();
+        let new_all_tokens = self.build_input(input)?;
+
+        // The engine state can only be kept whole or reset, so reuse it whenever the session's
+        // text is a prefix of the newly rendered text — even if tokenizations differ, as sampled
+        // replies are not canonically tokenized — and prefill only the raw-tokenized text suffix.
+        let curr_text = curr_all_tokens.iter().fold(String::new(), |mut text, token| {
+            text.push_str(&token.value);
+            text
+        });
+        let new_text = self.encoding.state().tokens.iter().fold(String::new(), |mut text, token| {
+            text.push_str(&token.value);
+            text
+        });
+        let reset = !new_text.starts_with(&curr_text);
+        let cached_tokens_input = if reset {
+            0
+        } else {
+            curr_all_tokens.len()
+        };
+        self.input_tokens = if reset {
+            self.state_reset().await?;
+            new_all_tokens
+        } else {
+            match self.encoding.tokenize(&new_text[curr_text.len()..]) {
+                Ok(suffix_tokens) => suffix_tokens.into_iter().map(u64::from).collect(),
+                Err(err) => {
+                    return Err(ChatSessionError::Backend {
+                        message: err.to_string(),
+                    });
+                },
+            }
+        };
+
+        Ok(cached_tokens_input)
     }
 
     pub fn peak_memory_usage(&self) -> Option<usize> {

--- a/crates/legacy/nagare/src/chat/token/tests.rs
+++ b/crates/legacy/nagare/src/chat/token/tests.rs
@@ -1,0 +1,580 @@
+use std::{
+    any::Any,
+    collections::VecDeque,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task::{Context, Poll},
+};
+
+use futures::Stream;
+use hanashi::{
+    Encoding as _,
+    chat::{
+        Encoding,
+        hanashi::{HanashiEncodingImpl, config::HanashiConfig},
+    },
+};
+use shoji::{
+    traits::{
+        State,
+        backend::{Error, Instance, InstanceStream, chat_token},
+    },
+    types::{
+        basic::{SamplingParameters, ToolDescription, ToolFunction, ToolNamespace, Value},
+        session::chat::{ChatContentBlock, ChatMessage, ChatReply, ChatReplyConfig, ChatReplyFinishReason},
+    },
+};
+use tokenizers::{AddedToken, Tokenizer, decoders::fuse::Fuse, models::bpe::BPE};
+use tokio::sync::{Mutex as AsyncMutex, mpsc};
+use tokio_util::sync::CancellationToken;
+
+use super::Session;
+use crate::{
+    chat::{ChatSession, ChatSessionState, Instance as SessionInstance},
+    telemetry::Telemetry,
+};
+
+const END_TOKEN_ID: u32 = 248046;
+
+#[derive(Default)]
+struct Audit {
+    state_attempts: usize,
+    state_creations: usize,
+    submissions: Vec<(usize, Vec<u64>, Vec<u64>)>,
+    completed: Vec<Vec<u64>>,
+}
+
+struct TestState {
+    identifier: usize,
+    tokens: Vec<u64>,
+}
+
+impl State for TestState {}
+
+struct TestInstance {
+    tokenizer: Arc<Tokenizer>,
+    audit: Arc<Mutex<Audit>>,
+    turns: Mutex<VecDeque<VecDeque<Result<chat_token::StreamOutput, Error>>>>,
+    state_failures: Mutex<usize>,
+    context_limit: Mutex<Option<usize>>,
+}
+
+impl Instance for TestInstance {
+    type StreamConfig = ChatReplyConfig;
+    type StreamInput = chat_token::StreamInput;
+    type StreamOutput = chat_token::StreamOutput;
+    type StreamMetrics = chat_token::StreamMetrics;
+
+    fn state(&self) -> Pin<Box<dyn Future<Output = Result<Box<dyn State>, Error>> + Send + '_>> {
+        Box::pin(async move {
+            let mut audit = self.audit.lock().unwrap();
+            audit.state_attempts += 1;
+            let mut failures = self.state_failures.lock().unwrap();
+            if *failures != 0 {
+                *failures -= 1;
+                return Err("injected state creation error".into());
+            }
+            audit.state_creations += 1;
+            Ok(Box::new(TestState {
+                identifier: audit.state_creations,
+                tokens: Vec::new(),
+            }) as Box<dyn State>)
+        })
+    }
+
+    fn stream<'a>(
+        &'a self,
+        input: &'a Self::StreamInput,
+        state: &'a mut dyn State,
+        _config: Self::StreamConfig,
+        _cancel_token: CancellationToken,
+    ) -> Pin<Box<dyn InstanceStream<Item = Result<Self::StreamOutput, Error>, Metrics = Self::StreamMetrics> + Send + 'a>>
+    {
+        let state = (state as &mut dyn Any).downcast_mut::<TestState>().unwrap();
+        self.audit.lock().unwrap().submissions.push((state.identifier, input.clone(), state.tokens.clone()));
+        state.tokens.extend_from_slice(input);
+        Box::pin(TestStream {
+            state,
+            audit: self.audit.clone(),
+            events: self.turns.lock().unwrap().pop_front().expect("missing test generation"),
+            returned: Vec::new(),
+        })
+    }
+
+    fn peak_memory_usage(&self) -> Option<usize> {
+        None
+    }
+}
+
+impl chat_token::Instance for TestInstance {
+    fn tokenizer(&self) -> Arc<Tokenizer> {
+        self.tokenizer.clone()
+    }
+
+    fn max_context_length(&self) -> Option<usize> {
+        *self.context_limit.lock().unwrap()
+    }
+
+    fn stop_token_ids(&self) -> Option<Box<[u64]>> {
+        Some(Box::new([u64::from(END_TOKEN_ID)]))
+    }
+
+    fn sampling_defaults(&self) -> SamplingParameters {
+        SamplingParameters::default()
+    }
+}
+
+struct TestStream<'a> {
+    state: &'a mut TestState,
+    audit: Arc<Mutex<Audit>>,
+    events: VecDeque<Result<chat_token::StreamOutput, Error>>,
+    returned: Vec<u64>,
+}
+
+impl Stream for TestStream<'_> {
+    type Item = Result<chat_token::StreamOutput, Error>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        _context: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        let event = this.events.pop_front();
+        if let Some(Ok(chat_token::StreamOutput::Token(token))) = &event {
+            this.returned.push(*token);
+        }
+        Poll::Ready(event)
+    }
+}
+
+impl InstanceStream for TestStream<'_> {
+    type Metrics = chat_token::StreamMetrics;
+
+    fn metrics(&self) -> Self::Metrics {
+        None
+    }
+}
+
+impl Drop for TestStream<'_> {
+    fn drop(&mut self) {
+        // Match the backend lifecycle: emitted tokens become durable when its stream is dropped.
+        self.state.tokens.extend_from_slice(&self.returned);
+        self.audit.lock().unwrap().completed.push(self.state.tokens.clone());
+    }
+}
+
+fn tokenizer() -> Arc<Tokenizer> {
+    let mut vocabulary = serde_json::Map::new();
+    for character in 0..128u32 {
+        vocabulary.insert(char::from_u32(character).unwrap().to_string(), serde_json::json!(character));
+    }
+    vocabulary.insert("ab".to_string(), serde_json::json!(128));
+    vocabulary.insert("abc".to_string(), serde_json::json!(129));
+    let framing = [
+        ("<|im_start|>", 130),
+        ("<|im_end|>", END_TOKEN_ID),
+        ("<think>", 131),
+        ("</think>", 132),
+        ("<tool_call>", 133),
+        ("</tool_call>", 134),
+        ("<tool_response>", 135),
+        ("</tool_response>", 136),
+    ];
+    for (token, identifier) in framing {
+        vocabulary.insert(token.to_string(), serde_json::json!(identifier));
+    }
+    let roles = ["system", "developer", "assistant", "user", "tool"];
+    for (index, role) in roles.iter().enumerate() {
+        vocabulary.insert((*role).to_string(), serde_json::json!(137 + index));
+    }
+    let model: BPE = serde_json::from_str(
+        &serde_json::json!({
+            "type": "BPE",
+            "vocab": vocabulary,
+            "merges": [["a", "b"], ["ab", "c"]],
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let mut tokenizer = Tokenizer::new(model);
+    tokenizer.with_decoder(Some(Fuse::new()));
+    tokenizer.add_special_tokens(&framing.map(|(token, _)| AddedToken::from(token, true)));
+    tokenizer.add_tokens(&roles.map(|role| AddedToken::from(role, false)));
+    Arc::new(tokenizer)
+}
+
+fn encode(
+    tokenizer: &Tokenizer,
+    text: &str,
+) -> Vec<u64> {
+    tokenizer.encode(text, false).unwrap().get_ids().iter().copied().map(u64::from).collect()
+}
+
+async fn session(generations: &[&str]) -> (ChatSession, Arc<TestInstance>) {
+    let tokenizer = tokenizer();
+    let instance = Arc::new(TestInstance {
+        tokenizer: tokenizer.clone(),
+        audit: Arc::new(Mutex::new(Audit::default())),
+        turns: Mutex::new(
+            generations
+                .iter()
+                .map(|text| {
+                    encode(&tokenizer, text)
+                        .into_iter()
+                        .map(|token| Ok(chat_token::StreamOutput::Token(token)))
+                        .collect()
+                })
+                .collect(),
+        ),
+        state_failures: Mutex::new(0),
+        context_limit: Mutex::new(None),
+    });
+    let token_session = Session {
+        instance: instance.clone(),
+        state: instance.state().await.unwrap(),
+        encoding: Encoding::Hanashi(HanashiEncodingImpl::new(HanashiConfig::Qwen35, tokenizer).unwrap()),
+        input_tokens: Vec::new(),
+        stop_token_ids: Box::new([u64::from(END_TOKEN_ID)]),
+        state_is_valid: true,
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        energy_recorder: super::EnergyRecorder::new(),
+    };
+    (
+        ChatSession {
+            instance: Arc::new(AsyncMutex::new(SessionInstance::Token(token_session))),
+            state: Arc::new(AsyncMutex::new(ChatSessionState::Idle)),
+            messages: Arc::new(AsyncMutex::new(Vec::new())),
+            model_id: "prefix-cache-test".to_string(),
+            telemetry: Telemetry::disabled(),
+            tool_registry: None,
+        },
+        instance,
+    )
+}
+
+fn tool_prompt() -> Vec<ChatMessage> {
+    vec![
+        ChatMessage::developer().with_tool_namespaces(vec![ToolNamespace {
+            name: "functions".to_string(),
+            description: None,
+            tools: vec![ToolDescription::Function {
+                tool_function: ToolFunction {
+                    name: "write_file".to_string(),
+                    description: "Write a file".to_string(),
+                    parameters: Some(Value {
+                        json: r#"{"type":"object","properties":{"content":{"type":"object"}}}"#.to_string(),
+                    }),
+                    return_definition: None,
+                },
+            }],
+        }]),
+        ChatMessage::user().with_text("Write the config".to_string()),
+    ]
+}
+
+async fn turn(
+    session: &ChatSession,
+    messages: Vec<ChatMessage>,
+    config: ChatReplyConfig,
+    cancel_token: CancellationToken,
+) -> ChatReply {
+    let (sender, _receiver) = mpsc::unbounded_channel();
+    let replies = session.send_input(&sender, messages, config, cancel_token, &mut Vec::new()).await;
+    replies.expect("generation should succeed").pop().expect("generation should produce a reply")
+}
+
+async fn token_ledger(session: &ChatSession) -> Vec<u64> {
+    let instance = session.instance.lock().await;
+    let SessionInstance::Token(session) = &*instance else {
+        panic!("expected token session");
+    };
+    session.encoding.state().tokens.iter().map(|token| u64::from(token.id)).collect()
+}
+
+#[tokio::test]
+async fn compact_json_tool_reply_reuses_actual_tokens_after_stream_drop() {
+    let (session, instance) = session(&[
+        "\n</think>\n\n<tool_call>\n<function=write_file>\n<parameter=content>\n{\"strict\":true}\n</parameter>\n</function>\n</tool_call><|im_end|>",
+        "\n</think>\n\nDone<|im_end|>",
+    ]).await;
+    let first = turn(&session, tool_prompt(), ChatReplyConfig::default(), CancellationToken::new()).await;
+    assert_eq!(first.finish_reason, Some(ChatReplyFinishReason::ToolCalls));
+    let first_tokens = token_ledger(&session).await;
+    assert_eq!(instance.audit.lock().unwrap().completed, vec![first_tokens.clone()]);
+    let result = ChatMessage::tool().with_block(ChatContentBlock::ToolCallResult {
+        identifier: None,
+        name: None,
+        value: Value {
+            json: "\"written\"".to_string(),
+        },
+    });
+    let second = turn(&session, vec![result], ChatReplyConfig::default(), CancellationToken::new()).await;
+    let expected_suffix = encode(
+        &instance.tokenizer,
+        "\n<|im_start|>user\n<tool_response>\nwritten\n</tool_response><|im_end|>\n<|im_start|>assistant\n<think>\n",
+    );
+    let final_tokens = token_ledger(&session).await;
+    let audit = instance.audit.lock().unwrap();
+    assert_eq!(audit.state_creations, 1, "valid tool continuation must not allocate fresh backend state");
+    assert_eq!(audit.submissions[1].0, audit.submissions[0].0);
+    assert_eq!(audit.submissions[1].1, expected_suffix);
+    assert_eq!(audit.submissions[1].2, first_tokens);
+    assert!(final_tokens.starts_with(&first_tokens));
+    assert_eq!(audit.completed[1], final_tokens);
+    assert_eq!(second.stats.tokens_count_input_cached, Some(first_tokens.len() as u32));
+    assert_eq!(second.stats.tokens_count_input, Some(expected_suffix.len() as u32));
+}
+
+#[tokio::test]
+async fn sampled_token_ids_survive_a_text_equivalent_continuation() {
+    let (session, instance) = session(&["\n</think>\n\n", "\n</think>\n\nDone<|im_end|>"]).await;
+    {
+        let mut turns = instance.turns.lock().unwrap();
+        let first = turns.front_mut().unwrap();
+        first.extend(
+            [u64::from(b'a'), u64::from(b'b'), u64::from(b'c'), u64::from(END_TOKEN_ID)]
+                .map(|token| Ok(chat_token::StreamOutput::Token(token))),
+        );
+    }
+    assert_ne!(encode(&instance.tokenizer, "abc"), vec![u64::from(b'a'), u64::from(b'b'), u64::from(b'c')]);
+    turn(
+        &session,
+        vec![ChatMessage::user().with_text("Say abc".to_string())],
+        ChatReplyConfig::default(),
+        CancellationToken::new(),
+    )
+    .await;
+    let first_tokens = token_ledger(&session).await;
+    let second = turn(
+        &session,
+        vec![ChatMessage::user().with_text("Continue".to_string())],
+        ChatReplyConfig::default(),
+        CancellationToken::new(),
+    )
+    .await;
+    let final_tokens = token_ledger(&session).await;
+    let audit = instance.audit.lock().unwrap();
+    assert_eq!(audit.state_creations, 1);
+    assert_eq!(audit.submissions[1].2, first_tokens);
+    assert!(final_tokens.starts_with(&first_tokens), "the codec must retain the IDs that the backend consumed");
+    assert_eq!(audit.completed[1], final_tokens);
+    assert_eq!(second.stats.tokens_count_input_cached, Some(first_tokens.len() as u32));
+}
+
+async fn assert_next_turn_has_fresh_state(
+    session: &ChatSession,
+    instance: &TestInstance,
+) {
+    let reply = turn(
+        session,
+        vec![ChatMessage::user().with_text("Continue".to_string())],
+        ChatReplyConfig::default(),
+        CancellationToken::new(),
+    )
+    .await;
+    let tokens = token_ledger(session).await;
+    let audit = instance.audit.lock().unwrap();
+    assert_eq!(audit.state_creations, 2);
+    assert_eq!(audit.submissions.len(), 2);
+    assert!(audit.submissions[1].2.is_empty(), "recovery must not submit a full prompt to stale backend state");
+    assert_eq!(audit.completed[1], tokens);
+    assert_eq!(reply.stats.tokens_count_input_cached, Some(0));
+}
+
+#[tokio::test]
+async fn invalid_input_cannot_leave_empty_codec_with_reusable_backend_state() {
+    let (session, instance) = session(&["\n</think>\n\nReady<|im_end|>", "\n</think>\n\nDone<|im_end|>"]).await;
+    turn(
+        &session,
+        vec![ChatMessage::user().with_text("Start".to_string())],
+        ChatReplyConfig::default(),
+        CancellationToken::new(),
+    )
+    .await;
+    let history = session.messages.lock().await.clone();
+    let (sender, _receiver) = mpsc::unbounded_channel();
+    let result = session
+        .send_input(
+            &sender,
+            vec![ChatMessage::developer().with_text("Invalid late developer message".to_string())],
+            ChatReplyConfig::default(),
+            CancellationToken::new(),
+            &mut Vec::new(),
+        )
+        .await;
+    assert!(result.is_none());
+    *session.messages.lock().await = history;
+    assert_next_turn_has_fresh_state(&session, &instance).await;
+}
+
+#[tokio::test]
+async fn cancelled_turn_requires_fresh_backend_state() {
+    let (session, instance) = session(&["\n</think>\n\nInterrupted<|im_end|>", "\n</think>\n\nDone<|im_end|>"]).await;
+    let cancellation = CancellationToken::new();
+    cancellation.cancel();
+    let reply = turn(
+        &session,
+        vec![ChatMessage::user().with_text("Start".to_string())],
+        ChatReplyConfig::default(),
+        cancellation,
+    )
+    .await;
+    assert_eq!(reply.finish_reason, Some(ChatReplyFinishReason::Cancelled));
+    assert_next_turn_has_fresh_state(&session, &instance).await;
+}
+
+#[tokio::test]
+async fn length_limited_turn_requires_fresh_backend_state() {
+    let (session, instance) = session(&["\n</think>\n\nInterrupted<|im_end|>", "\n</think>\n\nDone<|im_end|>"]).await;
+    let reply = turn(
+        &session,
+        vec![ChatMessage::user().with_text("Start".to_string())],
+        ChatReplyConfig::default().with_token_limit(Some(1)),
+        CancellationToken::new(),
+    )
+    .await;
+    assert_eq!(reply.finish_reason, Some(ChatReplyFinishReason::Length));
+    assert_next_turn_has_fresh_state(&session, &instance).await;
+}
+
+#[tokio::test]
+async fn backend_error_requires_fresh_backend_state() {
+    let (session, instance) = session(&["\n", "\n</think>\n\nDone<|im_end|>"]).await;
+    instance.turns.lock().unwrap().front_mut().unwrap().push_back(Err("injected backend error".into()));
+    let (sender, _receiver) = mpsc::unbounded_channel();
+    let result = session
+        .send_input(
+            &sender,
+            vec![ChatMessage::user().with_text("Start".to_string())],
+            ChatReplyConfig::default(),
+            CancellationToken::new(),
+            &mut Vec::new(),
+        )
+        .await;
+    assert!(result.is_none());
+    assert_next_turn_has_fresh_state(&session, &instance).await;
+}
+
+#[tokio::test]
+async fn dropped_receiver_requires_fresh_backend_state() {
+    let (session, instance) = session(&["\n</think>\n\nInterrupted<|im_end|>", "\n</think>\n\nDone<|im_end|>"]).await;
+    let (sender, receiver) = mpsc::unbounded_channel();
+    drop(receiver);
+    let result = session
+        .send_input(
+            &sender,
+            vec![ChatMessage::user().with_text("Start".to_string())],
+            ChatReplyConfig::default(),
+            CancellationToken::new(),
+            &mut Vec::new(),
+        )
+        .await;
+    assert!(result.is_none());
+    assert_next_turn_has_fresh_state(&session, &instance).await;
+}
+
+#[tokio::test]
+async fn changed_history_requires_fresh_backend_state() {
+    let (session, instance) = session(&["\n</think>\n\nReady<|im_end|>", "\n</think>\n\nDone<|im_end|>"]).await;
+    turn(
+        &session,
+        vec![ChatMessage::user().with_text("Start".to_string())],
+        ChatReplyConfig::default(),
+        CancellationToken::new(),
+    )
+    .await;
+    session.messages.lock().await[0] = ChatMessage::user().with_text("An edited instruction".to_string());
+    assert_next_turn_has_fresh_state(&session, &instance).await;
+}
+
+#[tokio::test]
+async fn failed_backend_state_creation_retries_before_submitting_input() {
+    let (session, instance) = session(&["\n</think>\n\nReady<|im_end|>", "\n</think>\n\nDone<|im_end|>"]).await;
+    turn(
+        &session,
+        vec![ChatMessage::user().with_text("Start".to_string())],
+        ChatReplyConfig::default(),
+        CancellationToken::new(),
+    )
+    .await;
+    session.messages.lock().await[0] = ChatMessage::user().with_text("An edited instruction".to_string());
+    *instance.state_failures.lock().unwrap() = 1;
+    let (sender, _receiver) = mpsc::unbounded_channel();
+    let result = session
+        .send_input(
+            &sender,
+            vec![ChatMessage::user().with_text("Continue".to_string())],
+            ChatReplyConfig::default(),
+            CancellationToken::new(),
+            &mut Vec::new(),
+        )
+        .await;
+    assert!(result.is_none());
+    assert_eq!(instance.audit.lock().unwrap().submissions.len(), 1);
+
+    let reply = turn(&session, Vec::new(), ChatReplyConfig::default(), CancellationToken::new()).await;
+    let tokens = token_ledger(&session).await;
+    let audit = instance.audit.lock().unwrap();
+    assert_eq!(audit.state_attempts, 3);
+    assert_eq!(audit.state_creations, 2);
+    assert_eq!(audit.submissions.len(), 2);
+    assert!(audit.submissions[1].2.is_empty());
+    assert_eq!(audit.completed[1], tokens);
+    assert_eq!(reply.stats.tokens_count_input_cached, Some(0));
+}
+
+#[tokio::test]
+async fn failed_explicit_reset_cannot_reuse_the_previous_backend_state() {
+    let (session, instance) = session(&["\n</think>\n\nReady<|im_end|>", "\n</think>\n\nDone<|im_end|>"]).await;
+    turn(
+        &session,
+        vec![ChatMessage::user().with_text("Start".to_string())],
+        ChatReplyConfig::default(),
+        CancellationToken::new(),
+    )
+    .await;
+    *instance.state_failures.lock().unwrap() = 1;
+    {
+        let mut instance = session.instance.lock().await;
+        let SessionInstance::Token(session) = &mut *instance else {
+            panic!("expected token session");
+        };
+        assert!(session.reset().await.is_err());
+    }
+    assert_next_turn_has_fresh_state(&session, &instance).await;
+    assert_eq!(instance.audit.lock().unwrap().state_attempts, 3);
+}
+
+#[tokio::test]
+async fn context_limited_turn_requires_fresh_backend_state() {
+    let (session, instance) = session(&["\n</think>\n\nInterrupted<|im_end|>", "\n</think>\n\nDone<|im_end|>"]).await;
+    *instance.context_limit.lock().unwrap() = Some(1);
+    let reply = turn(
+        &session,
+        vec![ChatMessage::user().with_text("Start".to_string())],
+        ChatReplyConfig::default(),
+        CancellationToken::new(),
+    )
+    .await;
+    assert_eq!(reply.finish_reason, Some(ChatReplyFinishReason::ContextLimitReached));
+    *instance.context_limit.lock().unwrap() = None;
+    assert_next_turn_has_fresh_state(&session, &instance).await;
+}
+
+#[tokio::test]
+async fn incomplete_tool_call_at_stop_requires_fresh_backend_state() {
+    let (session, instance) = session(&["\n</think>\n\n<tool_call><|im_end|>", "\n</think>\n\nDone<|im_end|>"]).await;
+    let reply = turn(&session, tool_prompt(), ChatReplyConfig::default(), CancellationToken::new()).await;
+    assert_eq!(reply.finish_reason, Some(ChatReplyFinishReason::ToolCalls));
+    assert!(reply.message.content.iter().any(|block| matches!(block, ChatContentBlock::ToolCallCandidate { .. })));
+    {
+        let instance = session.instance.lock().await;
+        let SessionInstance::Token(session) = &*instance else {
+            panic!("expected token session");
+        };
+        assert!(!session.state_is_valid, "an incomplete tool call must not certify a completed cache");
+    }
+    // The malformed call cannot be rendered as a valid historical tool call. Retry with it removed.
+    session.messages.lock().await.pop();
+    assert_next_turn_has_fresh_state(&session, &instance).await;
+}

--- a/crates/legacy/uzu/tests/test_cache_continuation.rs
+++ b/crates/legacy/uzu/tests/test_cache_continuation.rs
@@ -116,7 +116,7 @@ fn generate_next(
         let token = next.unwrap();
         output.push(token);
         first_token_millis.get_or_insert_with(|| started.elapsed().as_millis());
-        if model.generation_config().stop_token_ids.iter().any(|stop| u64::from(*stop) == token) {
+        if model.generation_config().stop_token_ids.contains(&token) {
             break;
         }
     }

--- a/crates/legacy/uzu/tests/test_cache_continuation.rs
+++ b/crates/legacy/uzu/tests/test_cache_continuation.rs
@@ -1,0 +1,212 @@
+#![cfg(all(target_os = "macos", feature = "backend-metal"))]
+
+use std::{path::PathBuf, sync::Arc, time::Instant};
+
+use hanashi::{
+    Encoding as _,
+    chat::{
+        EncodingConfig,
+        hanashi::{HanashiEncodingImpl, config::HanashiConfig, renderer::Renderer},
+    },
+};
+use shoji::{
+    traits::backend::chat_token::TokenStreamMetrics,
+    types::{
+        basic::{ReasoningEffort, ToolDescription, ToolFunction, ToolNamespace, Value},
+        session::chat::{ChatContentBlock, ChatMessage},
+    },
+};
+use tokenizers::Tokenizer;
+use uzu_engine::{
+    backends::metal::Metal,
+    engine::{
+        Engine,
+        language_model::{LanguageModel, state::LanguageModelState, stream::SamplingMethod},
+    },
+};
+
+fn messages(padding_lines: usize) -> Vec<ChatMessage> {
+    let mut user_text =
+        "Use write_file to create config.json with exactly this one-line content, with no added spaces: \
+        {\"compilerOptions\":{\"strict\":true,\"target\":\"ES2022\"}}"
+            .to_string();
+    if padding_lines != 0 {
+        user_text = format!("Repository context:{}\n\n{user_text}", "\nlet item = 1;".repeat(padding_lines));
+    }
+    vec![
+        ChatMessage::system()
+            .with_text("You are a coding assistant. Use the tool as instructed. Keep responses brief.".to_string())
+            .with_reasoning_effort(ReasoningEffort::Disabled),
+        ChatMessage::developer().with_tool_namespaces(vec![ToolNamespace {
+            name: "functions".to_string(),
+            description: None,
+            tools: vec![ToolDescription::Function {
+                tool_function: ToolFunction {
+                    name: "write_file".to_string(),
+                    description: "Write the exact string content to a file.".to_string(),
+                    parameters: Some(Value {
+                        json: serde_json::json!({
+                            "type": "object",
+                            "properties": {"path": {"type": "string"}, "content": {"type": "string"}},
+                            "required": ["path", "content"],
+                            "additionalProperties": false,
+                        })
+                        .to_string(),
+                    }),
+                    return_definition: None,
+                },
+            }],
+        }]),
+        ChatMessage::user().with_text(user_text),
+    ]
+}
+
+fn token_ids(encoding: &HanashiEncodingImpl) -> Vec<u64> {
+    encoding.state().tokens.iter().map(|token| u64::from(token.id)).collect()
+}
+
+fn generate_tool_call(
+    model: &LanguageModel<Metal>,
+    state: &mut LanguageModelState<Metal>,
+    encoding: &mut HanashiEncodingImpl,
+    end_id: u64,
+) {
+    let input = token_ids(encoding);
+    let mut options = model.default_stream_options();
+    options.sampling_method = SamplingMethod::Greedy;
+    let started = Instant::now();
+    let mut stream = model.stream(&input, state, options).unwrap();
+    let mut completed = false;
+    let mut generated = 0;
+    for output in stream.by_ref().take(512) {
+        let token = output.unwrap();
+        encoding.decode(vec![u32::try_from(token).unwrap()]).unwrap();
+        generated += 1;
+        if token == end_id {
+            completed = true;
+            break;
+        }
+    }
+    let metrics = stream.metrics().clone();
+    drop(stream);
+    assert!(completed, "model must complete the tool call within 512 output tokens");
+    assert_eq!(state.tokens(), token_ids(encoding), "backend teardown must retain exactly the emitted transcript");
+    println!(
+        "initial_input={} generated={generated} elapsed_ms={} metrics={metrics:?}",
+        input.len(),
+        started.elapsed().as_millis(),
+    );
+}
+
+fn generate_next(
+    model: &LanguageModel<Metal>,
+    state: &mut LanguageModelState<Metal>,
+    input: &[u64],
+    label: &str,
+) -> (Vec<u64>, TokenStreamMetrics) {
+    let mut expected_tokens = state.tokens().to_vec();
+    expected_tokens.extend_from_slice(input);
+    let mut options = model.default_stream_options();
+    options.sampling_method = SamplingMethod::Greedy;
+    let started = Instant::now();
+    let mut stream = model.stream(input, state, options).unwrap();
+    let mut output = Vec::new();
+    let mut first_token_millis = None;
+    for next in stream.by_ref().take(32) {
+        let token = next.unwrap();
+        output.push(token);
+        first_token_millis.get_or_insert_with(|| started.elapsed().as_millis());
+        if model.generation_config().stop_token_ids.iter().any(|stop| u64::from(*stop) == token) {
+            break;
+        }
+    }
+    let metrics = stream.metrics().clone();
+    drop(stream);
+    assert!(!output.is_empty());
+    expected_tokens.extend_from_slice(&output);
+    assert_eq!(state.tokens(), expected_tokens, "{label}: backend teardown changed the consumed token ledger");
+    println!(
+        "{label}: input={} output={} ttft_ms={first_token_millis:?} elapsed_ms={} metrics={metrics:?}",
+        input.len(),
+        output.len(),
+        started.elapsed().as_millis(),
+    );
+    (output, metrics)
+}
+
+#[test]
+#[ignore = "requires a local Qwen3.5-encoded model in UZU_CACHE_TEST_MODEL and an idle Metal GPU"]
+fn qwen_continuation_matches_fresh_actual_transcript() {
+    let model_path =
+        PathBuf::from(std::env::var_os("UZU_CACHE_TEST_MODEL").expect(
+            "set UZU_CACHE_TEST_MODEL to the native model directory before explicitly running this ignored test",
+        ));
+    let encodings: Vec<EncodingConfig> =
+        serde_json::from_slice(&std::fs::read(model_path.join("encoding.json")).unwrap()).unwrap();
+    assert!(
+        encodings.iter().any(|encoding| matches!(
+            encoding,
+            EncodingConfig::Hanashi {
+                config: HanashiConfig::Qwen35
+            }
+        )),
+        "this test requires the bundled Qwen3.5 encoding"
+    );
+    let tokenizer = Arc::new(Tokenizer::from_file(model_path.join("tokenizer.json")).unwrap());
+    let end_id = u64::from(tokenizer.token_to_id("<|im_end|>").expect("model tokenizer must declare im_end"));
+    let engine = Engine::<Metal>::new().unwrap();
+    let model = engine.load_language_model(&model_path).unwrap();
+
+    for padding_lines in [0, 800] {
+        let mut encoding = HanashiEncodingImpl::new(HanashiConfig::Qwen35, tokenizer.clone()).unwrap();
+        encoding.encode(messages(padding_lines)).unwrap();
+        if padding_lines != 0 {
+            assert!(encoding.state().tokens.len() >= 5000, "long case must exercise a repository-sized context");
+        }
+        let mut cached_state = model.create_empty_state(Some(16384), 42).unwrap();
+        generate_tool_call(&model, &mut cached_state, &mut encoding, end_id);
+        let actual_tokens = token_ids(&encoding);
+        let actual_text = encoding.state().text();
+        let mut history = encoding.state().messages.clone();
+        let calls = history.last().unwrap().tool_calls();
+        assert_eq!(calls.len(), 1, "fixture must generate one completed write_file call");
+        assert_eq!(calls[0].name, "write_file");
+        assert!(encoding.record_completion(history.clone()).unwrap());
+        history.push(ChatMessage::tool().with_block(ChatContentBlock::ToolCallResult {
+            identifier: calls[0].identifier.clone(),
+            name: Some(calls[0].name.clone()),
+            value: Value {
+                json: "\"Successfully wrote config.json.\"".to_string(),
+            },
+        }));
+        let renderer = Renderer::new(HanashiConfig::Qwen35.resolve().unwrap().rendering);
+        let canonical = renderer.render(&history, true, None, None, None).unwrap();
+        assert!(!canonical.starts_with(&actual_text), "fixture must reproduce a parser/renderer prefix mismatch");
+
+        let suffix: Vec<u64> = encoding
+            .try_append(&history)
+            .unwrap()
+            .expect("completed tool turn should append")
+            .into_iter()
+            .map(u64::from)
+            .collect();
+        assert!(!suffix.is_empty());
+        assert_eq!(
+            &encoding.state().tokens[..actual_tokens.len()].iter().map(|token| u64::from(token.id)).collect::<Vec<_>>(),
+            &actual_tokens
+        );
+        let mut exact_input = actual_tokens.clone();
+        exact_input.extend_from_slice(&suffix);
+        assert_eq!(token_ids(&encoding), exact_input);
+        println!("padding_lines={padding_lines} cached_tokens={} suffix_tokens={}", actual_tokens.len(), suffix.len());
+
+        let (cached_output, cached_metrics) = generate_next(&model, &mut cached_state, &suffix, "cached");
+        assert_eq!(cached_metrics.num_tokens_prefilled, suffix.len());
+        let mut fresh_state = model.create_empty_state(Some(16384), 42).unwrap();
+        // The oracle is the exact sampled transcript plus suffix, never its lossy canonical rerendering.
+        let (fresh_output, fresh_metrics) = generate_next(&model, &mut fresh_state, &exact_input, "fresh");
+        assert_eq!(fresh_metrics.num_tokens_prefilled, exact_input.len());
+        assert_eq!(cached_output, fresh_output, "cached continuation must match fresh inference on identical IDs");
+    }
+    println!("peak_memory_bytes={:?}", engine.peak_memory_usage());
+}


### PR DESCRIPTION
## Problem

Normal Qwen coding turns can discard the entire prefix even when the client echoes unchanged history. Two reproduced cases are a tool-only assistant echoed with `content: ""`, and a generated tool argument whose compact JSON, whitespace, or escaping changes when Hanashi parses and re-renders it. The latter passes the HTTP history comparison but fails Nagare's rendered-text prefix comparison. Re-encoding can also replace sampled token IDs in the encoding ledger while the backend still holds the original IDs.

## Change

- Omit exactly empty assistant text at the HTTP boundary; preserve whitespace, reasoning, other roles, and empty tool results. Log metadata-only reasons when the HTTP history gate resets the cache.
- Add a continuation policy for the bundled `HanashiConfig::Qwen35` encoding, which the tested Qwen3.6-27B package uses. Certify a fully closed assistant boundary only after backend stream teardown. Retain the actual sampled token ledger, parser, and decoder; use the canonical rendering of the authoritative history only to locate the new prompt suffix.
- Require an exact logical-history extension and an unchanged canonical prefix before appending. Invalidate reuse while preparing/generating, and recreate coherent encoding/backend state after incomplete output, cancellation, errors, or genuine edits. Other encodings retain their existing path.

No dependency, serialized configuration, binding, or GPU state-layout change. No rewind or partial truncation of Qwen's recurrent state.

## Validation

- **104 unit tests passed:** 72 CLI, 15 Hanashi, 17 Nagare. New regressions fail on the old behavior and cover empty assistant content, compact JSON, noncanonical sampled IDs, split Unicode, grouped tool results, changed history, incomplete tools, limits, cancellation, receiver drop, and preparation/state-creation failures.
- **Real Metal equivalence test passed** with local Qwen3.6-27B-M on an M3 Ultra: cached and fresh inference emitted identical greedy tokens through the stop token when given the same actual token transcript. Both short and long cases assert backend token identity after stream teardown and exact prefill counts. The test is opt-in via `UZU_CACHE_TEST_MODEL`.
- **31 HTTP requests passed** across blocking and streaming plain, tool, thinking, compact-JSON, empty-content, and interleaved conversations. Hits and expected cold/interleaved misses matched the assertions.
- **Both HTTP disconnect probes passed:** cancel a queued streaming or blocking request while another request is generating, then cancel the active request; verify correct recovery answers and exact cache accounting on the next continuation.
- **60 consecutive warm turns passed**, 20 each after 5,561-, 15,461-, and 31,961-token cold prompts. Every turn returned the required answer, completed its SSE stream, and reused exactly the previous prompt plus completion count. Median first-content latency was 318 / 367 / 452 ms; p95 was 321 / 370 / 455 ms.
- Release build, Rust formatting, formatter-discovery check, locked Cargo metadata, unchanged `Cargo.lock`, and diff whitespace checks passed. The tracked C/Metal formatting check passed for all 136 files using the installed LLVM formatter path.
- Dependency-policy validation (`cargo deny check -D warnings`), generated-file synchronization (`cli-tools sync --check`), and workspace Clippy (`cargo +nightly clippy --release --workspace --all-targets -- -D warnings`) passed. CI is pending on the final revision.

For the long GPU equivalence case, cached inference retained **5,999 tokens**, prefilled **22**, and returned its first token in **184 ms**; fresh inference on the identical 6,021-token input took **14,365 ms**. These are individual paired measurements, not benchmark averages. Separately, the original long HTTP JSON fixture now retains **5,912 tokens** and prefills **22** at **180 ms** TTFT; the earlier diagnostic baseline prefills 5,937 tokens at 14.07 s. The cold canonical prompt and preserved sampled transcript differ, so that HTTP comparison is not an identical-token oracle.

## Scope

This fixes the two reproduced false-miss paths. The server still retains one conversation, so an unrelated title/summary request can evict an active coding conversation; the interleaving probe confirms that limitation. The new continuation policy is deliberately limited to Qwen35, and incomplete/unsupported boundaries fall back to a full reset. The evidence does not identify a specific earlier PR as the introducing regression.

The GPU check exercised ordinary decoding (approximately one token per forward pass); active speculative decoding and other hardware/model packages still need their own validation.
