### PR TITLE
matmul: support QTIP trellis (SLOP, don't merge)

### DIFF
--- a/crates/uzu-engine/src/backends/common/gpu_types/gemm.rs
+++ b/crates/uzu-engine/src/backends/common/gpu_types/gemm.rs
@@ -15,6 +15,12 @@ pub enum GemmBPrologueKind {
     ScaleBiasDequant,
     ScaleZeroPointDequant,
     ScaleSymmetricDequant,
+    /// QTIP bitshift-trellis weights: a per-row bit tape decoded by hashing the
+    /// trellis state, with one row scale and no per-group scales or biases.
+    /// See `kernel::matmul::trellis_format`. GEMM only, and only with int8
+    /// activations on the MXU: the decode emits int8 into threadgroup memory
+    /// and the integer schedule reads its fragments from there.
+    Trellis,
 }
 
 bitflags! {

--- a/crates/uzu-engine/src/backends/common/gpu_types/matmul.rs
+++ b/crates/uzu-engine/src/backends/common/gpu_types/matmul.rs
@@ -14,3 +14,26 @@ pub struct GemmParams {
     pub use_morton: bool,
     pub ab_scale: f32,
 }
+
+/// Everything the trellis decode needs that is not already a `GemmParams` field.
+///
+/// `l` and `k_bits` are runtime scalars rather than kernel variants on purpose:
+/// they only pick a mask and a stride, so specializing on them would multiply
+/// PSOs for nothing. `hash_a`/`hash_b` are `trellis_format::hash_params()`,
+/// passed as scalars so the kernel needs no codebook buffer at all. Build one
+/// with `trellis_format::trellis_params`, which is the only place these are
+/// derived.
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct TrellisParams {
+    /// Trellis window width in bits, `1 ..= 32`.
+    pub l: u32,
+    /// Bits injected per trellis step, i.e. `k * V`.
+    pub k_bits_per_step: u32,
+    /// `u32`s between the starts of two consecutive tape rows.
+    pub row_stride_words: u32,
+    pub hash_a: u32,
+    pub hash_b: u32,
+    /// `1 / rms(codebook)`, folded into the per-row scale in the epilogue.
+    pub codebook_scale: f32,
+}

--- a/crates/uzu-engine/src/backends/common/kernel/matmul/matmul_b.rs
+++ b/crates/uzu-engine/src/backends/common/kernel/matmul/matmul_b.rs
@@ -1,3 +1,4 @@
+use super::trellis_format::{TRELLIS_BLOCK_K, TrellisConfig};
 use crate::{
     backends::common::{
         Allocation, Backend, BufferArg,
@@ -33,6 +34,23 @@ pub enum MatmulB<'a, B: Backend, TB: BufferArg<'a, B> = &'a Allocation<B>> {
         group_size: u32,
         signed_codes: bool,
     },
+    /// QTIP bitshift-trellis weights: `b` is one bit tape per row and `scales`
+    /// one scale per row. There are no per-group scales, biases or zero points
+    /// and no stored codes — the weights are hashed out of `config` plus the
+    /// tape, and the decode lands directly in int8.
+    ///
+    /// Packing, codebook construction and the decode oracle live in
+    /// [`trellis_format`](super::trellis_format); the device-side decode lives
+    /// in `metal/kernel/matmul/common/trellis_decode.h`.
+    ///
+    /// Requires int8 activations and the MXU: the GEMM decodes a
+    /// `BLOCK_N x TRELLIS_BLOCK_K` int8 weight block into threadgroup memory and
+    /// feeds the shipped integer schedule from there.
+    Trellis {
+        b: &'a Allocation<B>,
+        scales: &'a Allocation<B>,
+        config: TrellisConfig,
+    },
 }
 
 impl<'a, B: Backend, TB: BufferArg<'a, B>> MatmulB<'a, B, TB> {
@@ -50,6 +68,9 @@ impl<'a, B: Backend, TB: BufferArg<'a, B>> MatmulB<'a, B, TB> {
             Self::ScaleSymmetricDequant {
                 ..
             } => GemmBPrologueKind::ScaleSymmetricDequant,
+            Self::Trellis {
+                ..
+            } => GemmBPrologueKind::Trellis,
         }
     }
 
@@ -70,6 +91,14 @@ impl<'a, B: Backend, TB: BufferArg<'a, B>> MatmulB<'a, B, TB> {
                 mode,
                 ..
             } => Some(DataType::from(*mode).size_in_bits() as u32),
+            // The width of the operand the MXU multiplies, which is what every
+            // consumer of this actually asks about. A trellis tape has no
+            // addressable per-weight code width — the rate is `k + (L - k*V) /
+            // cols` and the states overlap — but the decode's output is int8, so
+            // reporting 8 is what routes this to the int8 MMA path.
+            Self::Trellis {
+                ..
+            } => Some(8),
         }
     }
 
@@ -90,6 +119,13 @@ impl<'a, B: Backend, TB: BufferArg<'a, B>> MatmulB<'a, B, TB> {
                 group_size,
                 ..
             } => Some(*group_size),
+            // Not a quantization group: there is one scale per row. This is the
+            // staging block K, reported here so the shipped integer schedule and
+            // split-K policy — both written against `outer_block_k() ==
+            // GROUP_SIZE` — apply unchanged. See `TRELLIS_BLOCK_K`.
+            Self::Trellis {
+                ..
+            } => Some(TRELLIS_BLOCK_K),
         }
     }
 
@@ -110,6 +146,11 @@ impl<'a, B: Backend, TB: BufferArg<'a, B>> MatmulB<'a, B, TB> {
                 signed_codes,
                 ..
             } => *signed_codes,
+            // The decode emits two's-complement int8; there is no stored code
+            // whose signedness could differ.
+            Self::Trellis {
+                ..
+            } => true,
         }
     }
 }

--- a/crates/uzu-engine/src/backends/common/kernel/matmul/mod.rs
+++ b/crates/uzu-engine/src/backends/common/kernel/matmul/mod.rs
@@ -5,6 +5,7 @@ mod kernel;
 mod matmul_a;
 mod matmul_b;
 pub mod routing;
+pub mod trellis_format;
 
 pub use arguments::MatmulArguments;
 pub use d_ops::MatmulDOps;

--- a/crates/uzu-engine/src/backends/common/kernel/matmul/trellis_format.rs
+++ b/crates/uzu-engine/src/backends/common/kernel/matmul/trellis_format.rs
@@ -1,0 +1,413 @@
+//! QTIP bitshift-trellis weight format: host-side packing and the decode
+//! oracle.
+//!
+//! This module is the definition of the format *and* the oracle the kernels are
+//! tested against; the kernels never call it. The device half is
+//! `metal/kernel/matmul/common/trellis_decode.h`, and the GEMM that consumes it
+//! is the [`GemmBPrologueKind::Trellis`] arm of `gemm.metal`.
+//!
+//! [`GemmBPrologueKind::Trellis`]: crate::backends::common::gpu_types::gemm::GemmBPrologueKind::Trellis
+//!
+//! # Format
+//!
+//! A weight row is one bit tape. With window `L`, [`TRELLIS_V`] weights per step
+//! and `k` bits per weight (`KV = k*V` bits injected per step,
+//! `steps = cols / V`):
+//!
+//! ```text
+//! s_0 = header
+//! s_t = ((s_{t-1} << KV) mod 2**L) | c_t
+//! w[row][t*V + v] = codebook(s_t)[v] * row_scale[row]
+//! ```
+//!
+//! Bit `j` of a row lives in byte `j >> 3` at bit `j & 7`, LSB first; a
+//! width-`n` field at bit `p` is `sum_i bit(p+i) << i`. Layout (packing **v2**,
+//! codes in DESCENDING step order with the header above them):
+//!
+//! ```text
+//! bits [(steps-1-t)*KV, (steps-t)*KV)     c_t,  t = 1 .. steps-1
+//! bits [(steps-1)*KV, (steps-1)*KV + L)   s_0
+//! ```
+//!
+//! The payoff is that `s_t` is then literally one L-bit LSB-first field:
+//!
+//! ```text
+//! s_t = (row_as_integer >> ((steps-1-t)*KV)) & ((1 << L) - 1)
+//! ```
+//!
+//! so a kernel reads a state with one shift and one mask, with no block
+//! reassembly and no special case for the first steps of a row. See the
+//! "WHY DESCENDING" section of `qtip/oracle.py` for the derivation: it is
+//! forced, given that `s_t`'s low `KV` bits are `c_t` and the next `KV` are
+//! `c_{t-1}`.
+//!
+//! Rate is `k + (L - KV) / cols` bits per weight; the `s_0` header is the
+//! overhead term. Dropping it and seeding the window with zero is a real bug —
+//! every recovered state would disagree with the fitted stream — which is why
+//! it is stored explicitly.
+//!
+//! # The codebook
+//!
+//! One hash per STATE, whose four raw bytes become four int8 weights through a
+//! byte-separable map: a quarter of the hashes a per-coordinate codebook would
+//! need, no table, and no dequantization on the way into the MXU. The map is
+//! E8's k = 3 tier A, `8 * pairs(b) + ((3 * (b & 15)) & 15) - 54`, written here
+//! as the CLOSED FORM it was fitted as — the device computes the same values
+//! with a SWAR chain, and the GPU parity tests are what pin the two together.
+use std::sync::LazyLock;
+
+use crate::backends::common::gpu_types::TrellisParams;
+
+/// The seed the shipped configs are fitted with.
+const DEFAULT_SEED: u64 = 1234;
+
+/// Weights produced per trellis step. Fixed: a 32-bit hash has four bytes.
+pub const TRELLIS_V: u32 = 4;
+
+/// Columns of K one threadgroup decodes into shared memory per iteration.
+///
+/// The GEMM reports this as the weight "group size" so that the shipped integer
+/// schedule, its split-K policy and `GemmParams::aligned_inner_iterations` — all
+/// of which are written against `outer_block_k() == GROUP_SIZE` — apply to a
+/// trellis tape unchanged. There is no group of weights sharing a scale here;
+/// there is one scale per row and this is a staging block.
+pub const TRELLIS_BLOCK_K: u32 = 64;
+
+/// The splitmix64 finalizer (Steele/Lea), verbatim from `qtip/codebooks.h`.
+fn splitmix64(
+    x: u64,
+    seed: u64,
+) -> u64 {
+    let mut z = x.wrapping_add(seed);
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+/// The `(a, b)` 32-bit LCG pair the state hash uses, `a` forced odd.
+///
+/// `codebooks.py` derives one pair per coordinate from the seed; this codebook
+/// takes one hash per STATE, so only coordinate 0's pair exists and it is a
+/// constant of the seed rather than of the config.
+pub fn hash_params() -> (u32, u32) {
+    ((splitmix64(0, DEFAULT_SEED) as u32) | 1, splitmix64(1, DEFAULT_SEED) as u32)
+}
+
+/// A `(L, k)` trellis configuration. `V` is [`TRELLIS_V`] everywhere.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TrellisConfig {
+    /// Window width in bits; the state is `L` bits wide, `1 <= L <= 32`.
+    pub l: u32,
+    /// Bits per weight; `k * V` bits are injected per step.
+    pub k: u32,
+}
+
+impl TrellisConfig {
+    pub const fn new(
+        l: u32,
+        k: u32,
+    ) -> Self {
+        Self {
+            l,
+            k,
+        }
+    }
+
+    /// Bits injected per step.
+    pub const fn kv(&self) -> u32 {
+        self.k * TRELLIS_V
+    }
+
+    const fn state_mask(&self) -> u32 {
+        if self.l >= 32 {
+            u32::MAX
+        } else {
+            (1u32 << self.l) - 1
+        }
+    }
+
+    const fn is_valid(&self) -> bool {
+        1 <= self.l && self.l <= 32 && self.k >= 1 && self.kv() <= self.l
+    }
+
+    pub const fn steps(
+        &self,
+        cols: u32,
+    ) -> u32 {
+        cols / TRELLIS_V
+    }
+
+    pub const fn bits_per_row(
+        &self,
+        cols: u32,
+    ) -> u32 {
+        self.l + (self.steps(cols) - 1) * self.kv()
+    }
+
+    pub const fn bytes_per_row(
+        &self,
+        cols: u32,
+    ) -> u32 {
+        self.bits_per_row(cols).div_ceil(8)
+    }
+
+    /// `u32`s per tape row. The window read is a two-word load at a bit offset
+    /// inside the row, so a row needs one word of slack past its last bit;
+    /// four keeps every row 16-byte aligned as well. `trellis_decode.h`'s
+    /// `row_stride_words` is not a second copy of this — the host computes it
+    /// once and passes it down in `TrellisParams`.
+    pub const fn row_stride_words(
+        &self,
+        cols: u32,
+    ) -> u32 {
+        self.bits_per_row(cols).div_ceil(32) + 4
+    }
+
+    /// Bit offset of the L-bit window that spells out `s_t` (packing v2).
+    const fn window_bit_offset(
+        &self,
+        t: u32,
+        steps: u32,
+    ) -> u32 {
+        (steps - 1 - t) * self.kv()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// the codebook: state -> four int8 weights
+// ---------------------------------------------------------------------------
+
+/// `state -> ` the raw 32-bit hash: a 32-bit LCG followed by one fmix32
+/// avalanche round.
+pub fn state_hash(
+    state: u32,
+    a: u32,
+    b: u32,
+) -> u32 {
+    let mut x = state.wrapping_mul(a).wrapping_add(b);
+    x ^= x >> 16;
+    x = x.wrapping_mul(0x85EB_CA6B);
+    x ^ (x >> 16)
+}
+
+/// The induced 256-entry `byte -> int8` map, as E8's closed form rather than as
+/// the SWAR chain `trellis_decode.h` computes it with.
+///
+/// `pairs` is the sum of the byte's four 2-bit fields; 74 levels over
+/// `[-54, 55]`, reaching 2.85 sigma.
+pub fn codebook_table() -> Vec<i8> {
+    (0..256u32)
+        .map(|b| {
+            let pairs = (b & 3) + ((b >> 2) & 3) + ((b >> 4) & 3) + ((b >> 6) & 3);
+            let level = (8 * pairs + (((b & 15) * 3) & 15)) as i32 - 54;
+            i8::try_from(level).expect("trellis level must fit int8")
+        })
+        .collect()
+}
+
+/// `1 / rms(codebook_table())` — the scalar folded into the per-row weight
+/// scale, which makes the decoded codebook unit variance. The four hash bytes
+/// are uniform and independent after the fmix, so the codebook marginal IS the
+/// induced table's.
+pub fn codebook_scale() -> f32 {
+    static SCALE: LazyLock<f32> = LazyLock::new(|| {
+        let table = codebook_table();
+        let mean_square: f64 = table.iter().map(|&v| f64::from(v) * f64::from(v)).sum::<f64>() / table.len() as f64;
+        (1.0 / mean_square.sqrt()) as f32
+    });
+    *SCALE
+}
+
+/// `state -> ` the four int8 codes the kernel stages, in column order.
+pub fn state_codes(
+    state: u32,
+    a: u32,
+    b: u32,
+) -> [i8; 4] {
+    let table = codebook_table();
+    let hash = state_hash(state, a, b);
+    [0u32, 1, 2, 3].map(|j| table[((hash >> (8 * j)) & 255) as usize])
+}
+
+// ---------------------------------------------------------------------------
+// bit tape
+// ---------------------------------------------------------------------------
+
+/// A row-major bit tape: `rows` rows of `config.row_stride_words(cols)` `u32`s.
+/// Little-endian word order makes `words` byte-identical to the reference
+/// `uint8` tape for the first `bytes_per_row` bytes of each row; the remainder
+/// is zero padding.
+#[derive(Debug, Clone)]
+pub struct TrellisTape {
+    pub config: TrellisConfig,
+    pub rows: u32,
+    pub cols: u32,
+    pub words: Vec<u32>,
+}
+
+#[inline]
+fn write_field(
+    row: &mut [u32],
+    bit_offset: u32,
+    width: u32,
+    value: u32,
+) {
+    debug_assert!(width <= 32);
+    let masked = if width == 32 {
+        value
+    } else {
+        value & ((1u32 << width) - 1)
+    };
+    let word = (bit_offset >> 5) as usize;
+    let shift = bit_offset & 31;
+    row[word] |= masked << shift;
+    if shift + width > 32 {
+        row[word + 1] |= masked >> (32 - shift);
+    }
+}
+
+#[inline]
+fn read_field(
+    row: &[u32],
+    bit_offset: u32,
+    width: u32,
+) -> u32 {
+    debug_assert!(width <= 32);
+    let word = (bit_offset >> 5) as usize;
+    let shift = bit_offset & 31;
+    let low = u64::from(row[word]) | (u64::from(row[word + 1]) << 32);
+    let value = (low >> shift) as u32;
+    if width == 32 {
+        value
+    } else {
+        value & ((1u32 << width) - 1)
+    }
+}
+
+impl TrellisTape {
+    /// A deterministic pseudo-random tape, packed the way `qtip/oracle.py`
+    /// packs a fitted one (a fitted tape's statistics are irrelevant to kernel
+    /// correctness or to decode cost).
+    pub fn random(
+        config: TrellisConfig,
+        rows: u32,
+        cols: u32,
+        seed: u64,
+    ) -> Self {
+        assert!(config.is_valid(), "invalid trellis config {config:?}");
+        assert!(cols.is_multiple_of(TRELLIS_V), "cols must be a multiple of V");
+        let steps = config.steps(cols);
+        let stride = config.row_stride_words(cols);
+        let kv = config.kv();
+        let code_mask = (1u64 << kv) - 1;
+        let state_mask = u64::from(config.state_mask());
+        let mut state = seed | 1;
+        let mut next = move || {
+            state = splitmix64(state, 0x9E37_79B9_7F4A_7C15);
+            state
+        };
+
+        let mut words = vec![0u32; (rows * stride) as usize];
+        for row in 0..rows as usize {
+            let destination = &mut words[row * stride as usize..(row + 1) * stride as usize];
+            write_field(destination, (steps - 1) * kv, config.l, (next() & state_mask) as u32);
+            for step in 1..steps {
+                write_field(destination, config.window_bit_offset(step, steps), kv, (next() & code_mask) as u32);
+            }
+        }
+        Self {
+            config,
+            rows,
+            cols,
+            words,
+        }
+    }
+
+    fn row(
+        &self,
+        row: u32,
+    ) -> &[u32] {
+        let stride = self.config.row_stride_words(self.cols) as usize;
+        &self.words[row as usize * stride..(row as usize + 1) * stride]
+    }
+
+    /// `[rows][steps]` states, one window read per step — the same access the
+    /// kernels make (`oracle.py:unpack`).
+    pub fn states(&self) -> Vec<u32> {
+        let steps = self.config.steps(self.cols);
+        let mut out = vec![0u32; (self.rows * steps) as usize];
+        for row in 0..self.rows {
+            let source = self.row(row);
+            for step in 0..steps {
+                out[(row * steps + step) as usize] =
+                    read_field(source, self.config.window_bit_offset(step, steps), self.config.l);
+            }
+        }
+        out
+    }
+
+    /// `[rows][steps]` states obtained by running the trellis recurrence over
+    /// the unpacked code stream. Independent of [`Self::states`], which reads
+    /// windows; the two agreeing is what pins packing v2 down.
+    pub fn states_by_recurrence(&self) -> Vec<u32> {
+        let steps = self.config.steps(self.cols);
+        let kv = self.config.kv();
+        let mask = self.config.state_mask();
+        let mut out = vec![0u32; (self.rows * steps) as usize];
+        for row in 0..self.rows {
+            let source = self.row(row);
+            let mut state = read_field(source, (steps - 1) * kv, self.config.l);
+            out[(row * steps) as usize] = state;
+            for step in 1..steps {
+                let code = read_field(source, self.config.window_bit_offset(step, steps), kv);
+                state = (state.wrapping_shl(kv) & mask) | code;
+                out[(row * steps + step) as usize] = state;
+            }
+        }
+        out
+    }
+
+    /// `[rows][cols]` int8 codes — the weights in the basis the MXU sees, before
+    /// `row_scale * codebook_scale()`.
+    pub fn codes(&self) -> Vec<i8> {
+        let (a, b) = hash_params();
+        let table = codebook_table();
+        let states = self.states();
+        let steps = self.config.steps(self.cols) as usize;
+        let cols = self.cols as usize;
+        let mut out = vec![0i8; (self.rows * self.cols) as usize];
+        for row in 0..self.rows as usize {
+            for step in 0..steps {
+                let hash = state_hash(states[row * steps + step], a, b);
+                for j in 0..4 {
+                    out[row * cols + step * 4 + j] = table[((hash >> (8 * j)) & 255) as usize];
+                }
+            }
+        }
+        out
+    }
+}
+
+/// The device-side constants for `config` over a `k`-column tape, or `None` if
+/// `config` is not one this format can express.
+///
+/// Both kernel paths build their `TrellisParams` here, so the tape stride, the
+/// hash pair and the codebook scale have exactly one definition and no caller
+/// can pass a set that disagrees with the tape it points at.
+pub fn trellis_params(
+    config: TrellisConfig,
+    k: u32,
+) -> Option<TrellisParams> {
+    if !config.is_valid() || !k.is_multiple_of(TRELLIS_V) {
+        return None;
+    }
+    let (hash_a, hash_b) = hash_params();
+    Some(TrellisParams {
+        l: config.l,
+        k_bits_per_step: config.kv(),
+        row_stride_words: config.row_stride_words(k),
+        hash_a,
+        hash_b,
+        codebook_scale: codebook_scale(),
+    })
+}

--- a/crates/uzu-engine/src/backends/cpu/kernel/matmul/reference.rs
+++ b/crates/uzu-engine/src/backends/cpu/kernel/matmul/reference.rs
@@ -105,6 +105,9 @@ impl WeightData {
                 group_size: group_size as usize,
                 signed_codes,
             },
+            MatmulB::Trellis {
+                ..
+            } => unimplemented!("trellis weights have no CPU reference; `trellis_format` is the oracle"),
         }
     }
 }

--- a/crates/uzu-engine/src/backends/metal/kernel/generated/gemm.h
+++ b/crates/uzu-engine/src/backends/metal/kernel/generated/gemm.h
@@ -15,6 +15,7 @@ enum class GemmBPrologueKind : uint32_t {
   ScaleBiasDequant = 1,
   ScaleZeroPointDequant = 2,
   ScaleSymmetricDequant = 3,
+  Trellis = 4,
 };
 
 struct GemmDTransform {

--- a/crates/uzu-engine/src/backends/metal/kernel/generated/matmul.h
+++ b/crates/uzu-engine/src/backends/metal/kernel/generated/matmul.h
@@ -18,4 +18,13 @@ typedef struct {
   bool use_morton;
   float ab_scale;
 } GemmParams;
+
+typedef struct {
+  uint32_t l;
+  uint32_t k_bits_per_step;
+  uint32_t row_stride_words;
+  uint32_t hash_a;
+  uint32_t hash_b;
+  float codebook_scale;
+} TrellisParams;
 } // namespace uzu::matmul

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/common/trellis_decode.h
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/common/trellis_decode.h
@@ -1,0 +1,130 @@
+#pragma once
+
+// QTIP bitshift-trellis weight decode: tape -> state -> four int8 weights.
+//
+// `backends/common/kernel/matmul/trellis_format.rs` is the NORMATIVE definition
+// of the format -- the recurrence, packing v2, the codebook -- and the oracle
+// these kernels are tested against.  What matters on this side is the one
+// consequence packing v2 exists for: `s_t` is the L-bit window at bit offset
+// `(T-1-t)*KV` of the row, so a state costs one shift and one mask at a
+// computed offset.  A gather, not a scan: no per-step reassembly and no special
+// case for the first steps of a row.
+//
+// THE CODEBOOK is one hash per STATE whose four RAW BYTES become the state's
+// four weights through a byte-separable SWAR chain, so a step costs one hash
+// plus ~14 whole-word ALU ops and lands directly in int8 -- no table, no
+// threadgroup codebook, no float dequantization on the way into the MXU.  The
+// alternative that reads a 256-entry Gaussian-quantile table per byte gives the
+// same marginals for fewer ALU ops but four threadgroup gathers, and measured
+// 6.5-13.4% SLOWER at every M: a gather on Apple prices out at ~3.5 ALU ops.
+//
+// Consumed by `gemm/common/trellis_loader.h` and `gemv/common/trellis_slice.h`.
+
+#include <metal_stdlib>
+
+#include "../../common/defines.h"
+
+using namespace metal;
+
+namespace uzu {
+namespace trellis {
+
+/// Weights produced per trellis step. Fixed: a 32-bit hash has four bytes.
+UZU_CONST uint TRELLIS_V = 4;
+
+/// Widest window this header is sized for.
+UZU_CONST uint TRELLIS_MAX_L = 32;
+
+/// `L` is a runtime value everywhere below, so callers hoist its mask once.
+METAL_FUNC uint state_mask(uint l) { return (l >= TRELLIS_MAX_L) ? 0xFFFFFFFFu : ((1u << l) - 1u); }
+
+// ---------------------------------------------------------------------------
+// state -> weights
+// ---------------------------------------------------------------------------
+
+/// `state -> ` the raw 32-bit hash: a 32-bit LCG followed by one fmix32
+/// avalanche round.
+///
+/// The avalanche is what makes the 2**KV successors of a state spread out in
+/// R^V; a bare LCG makes consecutive states nearly collinear.  Both halves of
+/// the round are load bearing: dropping the trailing xorshift saves two ops and
+/// still clears the lag-correlation gate at L=16 V=2 k=3, but fails it at V=4
+/// k=3, where three of the four coordinates land at 0.049..0.072 against a 0.05
+/// bar.
+METAL_FUNC uint state_hash(uint s, uint a, uint b) {
+  // One Murmur3 fmix32 round, verbatim from `qtip/codebooks.h`.
+  uint x = s * a + b;
+  x ^= x >> 16u;
+  x *= 0x85EBCA6Bu;
+  x ^= x >> 16u;
+  return x;
+}
+
+/// The four 2-bit fields of each byte, summed, in 7 whole-word ops.
+///
+/// The standard SWAR pairwise tree, not four masked shifts summed: stage one
+/// leaves `f0 + f1 <= 6` in each low nibble and `f2 + f3 <= 6` in each high one,
+/// so `(s + (s >> 4)) & 0x0f0f0f0f` sums them at `<= 12` -- still a nibble, so
+/// nothing carries out of a byte lane.  `qtip-research/REPORT_E8.md` section 1.
+METAL_FUNC uint byte_pairs(uint x) {
+  const uint s = (x & 0x33333333u) + ((x >> 2u) & 0x33333333u);
+  return (s + (s >> 4u)) & 0x0f0f0f0fu;
+}
+
+/// An already-hashed word -> the step's four int8 weights, packed
+/// little-endian.  E8's k = 3 tier-A map, `w = 8 * pairs + ((3 * n0) & 15) - 54`
+/// in 14 ops: 74 levels reaching 2.85 sigma.
+///
+/// No step can carry out of a byte lane, which is what makes the whole chain one
+/// dependency chain of whole-word ops: `u <= 8 * 12 + 15 = 111`, so the `+ 0x4a`
+/// bias tops out at 185.  `^ 0x80808080` is the `- 128` that turns the
+/// offset-binary composite into its int8 level.  `trellis_format::
+/// codebook_table` is the same map as a closed form, and the GPU parity tests
+/// are what pin the two together.
+METAL_FUNC uint map_bytes(uint x) {
+  const uint p = byte_pairs(x);
+  const uint d = ((x & 0x0f0f0f0fu) * 3u) & 0x0f0f0f0fu;
+  return ((p << 3u) + d + 0x4a4a4a4au) ^ 0x80808080u;
+}
+
+// ---------------------------------------------------------------------------
+// tape -> state
+// ---------------------------------------------------------------------------
+
+/// The L-bit window starting at `p` shifted by `shift` bits.  Two adjacent
+/// 32-bit loads cover it for any shift, since L <= 32 leaves 64 - 31 = 33 valid
+/// bits.  Reads one word past the window, so a row needs a word of slack past
+/// its last bit; `TrellisConfig::row_stride_words` gives four.
+///
+/// Takes a word pointer and a shift rather than a bit offset because one K block
+/// of a staged tile advances the bit offset by a whole number of WORDS, so
+/// consecutive blocks share `shift` and differ by a constant word count.
+/// Callers hoist the shift with [`walk`] and walk the pointer instead of
+/// recomputing `>>5` and `&31` per state.
+METAL_FUNC uint state_at_word(const device uint* p, uint shift, uint state_mask) {
+  const ulong window = (ulong)p[0] | ((ulong)p[1] << 32u);
+  return uint(window >> shift) & state_mask;
+}
+
+/// Where a run of states starts inside a tape row, and how far one block of
+/// `steps_per_block` steps moves it.
+///
+/// The tape DESCENDS -- `s_t` sits at bit `(steps - 1 - t) * KV` -- so a run is
+/// based on its LAST step, and one block is always a whole number of 32-bit
+/// words (V == 4), which is what makes `shift` loop-invariant.
+struct Walk {
+  /// Words from the start of the row to the word holding the run's first state.
+  uint word_offset;
+  /// Bit of that state inside that word.
+  uint shift;
+  /// Words one block of `steps_per_block` steps advances the row pointer by.
+  uint block_words;
+};
+
+METAL_FUNC Walk walk(uint steps, uint last_step, uint steps_per_block, uint kv) {
+  const uint bit_offset = (steps - 1u - last_step) * kv;
+  return Walk{bit_offset >> 5u, bit_offset & 31u, (steps_per_block * kv) / 32u};
+}
+
+} // namespace trellis
+} // namespace uzu

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/common/mxu_mma_core.h
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/common/mxu_mma_core.h
@@ -74,7 +74,9 @@ struct MxuMmaCore {
       const constant uzu::matmul::GemmParams* params,
       GemmAlignment alignment,
       GemmDTransform output_transform,
-      const device RightElementType* output_bias,
+      // Not `RightElementType`: the trellis decode makes that int8, and the
+      // output bias is always in the weight dtype.
+      const device typename Right::DenseElement* output_bias,
       const device int32_t* rht_factors,
       threadgroup RightElementType* b_shared,
       const bool stage_weight_scales,
@@ -125,7 +127,8 @@ struct MxuMmaCore {
     const bool apply_accumulate = output_transform.contains(GemmDTransform::ACCUMULATE);
     const bool apply_bias = output_transform.contains(GemmDTransform::BIAS);
 
-    const device RightElementType* bias_simdgroup = output_bias + size_t(block_col) + size_t(tile_col_offset);
+    const device typename Right::DenseElement* bias_simdgroup =
+        output_bias + size_t(block_col) + size_t(tile_col_offset);
 
     dispatch_bool(
         alignment.contains(GemmAlignment::M) || (simdgroup_limit_m == SIMDGROUP_BLOCK_M),

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/common/operands.h
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/common/operands.h
@@ -3,6 +3,7 @@
 #include <metal_stdlib>
 
 #include "../../../generated/gemm.h"
+#include "../../../generated/matmul.h"
 #include "../../common/mxu_fragment/integer_formats.h"
 
 using namespace metal;
@@ -41,18 +42,26 @@ struct LeftOperand {
 template <GemmBPrologueKind PROLOGUE, ushort BITS_, ushort GROUP_SIZE_, typename Element>
 struct RightOperand {
   UZU_CONST bool QUANTIZED = PROLOGUE != GemmBPrologueKind::FullPrecision;
+  /// The weights are hashed out of a bit tape rather than read as codes, so the
+  /// operand is DECODED INTO THREADGROUP MEMORY once per K block and the K loop
+  /// reads its fragments from there. `GROUP_SIZE` is that staging block, not a
+  /// quantization group: there is one scale per row.
+  UZU_CONST bool STAGED = PROLOGUE == GemmBPrologueKind::Trellis;
   UZU_CONST ushort BITS = QUANTIZED ? BITS_ : 0;
   UZU_CONST ushort GROUP_SIZE = QUANTIZED ? GROUP_SIZE_ : 0;
   UZU_CONST GemmBPrologueKind SCHEME = PROLOGUE;
-  UZU_CONST bool NEEDS_CORRECTION = QUANTIZED && PROLOGUE != GemmBPrologueKind::ScaleSymmetricDequant;
+  UZU_CONST bool NEEDS_CORRECTION = QUANTIZED && !STAGED && PROLOGUE != GemmBPrologueKind::ScaleSymmetricDequant;
 
   static_assert(!QUANTIZED || BITS_ == 4 || BITS_ == 8, "quantized integer weights must use 4 or 8 bits");
   static_assert(!QUANTIZED || PROLOGUE != GemmBPrologueKind::FullPrecision, "quantized weights need a scheme");
+  static_assert(!STAGED || BITS_ == 8, "a staged decode hands the MXU int8");
 
   using CodeElement = int8_t;
   using ScaleElement = Element;
   using DenseElement = Element;
-  using ElementType = DenseElement;
+  /// What the MMA fragments hold. The trellis decode emits int8 directly, so the
+  /// staged tile IS the operand; every other scheme dequantizes into `Element`.
+  using ElementType = metal::conditional_t<STAGED, CodeElement, DenseElement>;
   using Format = metal::conditional_t<
       QUANTIZED,
       uzu::matmul::IntegerFormat<BITS_, uzu::matmul::Signedness::Signed>,
@@ -90,6 +99,10 @@ struct RightStorage {
   const device typename Right::ScaleElement* scales;
   const device typename Right::ScaleElement* biases;
   const device uint8_t* zero_points;
+  /// The bit tape, and the window/hash/scale constants that read it. Both null
+  /// unless `Right::STAGED`; `scales` doubles as the one-scale-per-row vector.
+  const device uint* tape;
+  const constant uzu::matmul::TrellisParams* trellis;
   bool signed_codes;
 
   METAL_FUNC const device typename Right::ScaleElement* bias() const thread {
@@ -126,10 +139,13 @@ METAL_FUNC RightStorage<Right> pack_right(
     const device Element* scales,
     const device Element* biases,
     const device uint8_t* zero_points,
+    const constant uzu::matmul::TrellisParams* trellis,
     const bool signed_codes
 ) {
   if constexpr (!Right::QUANTIZED) {
-    return {dense, nullptr, nullptr, nullptr, nullptr, false};
+    return {dense, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, false};
+  } else if constexpr (Right::STAGED) {
+    return {nullptr, nullptr, scales, nullptr, nullptr, reinterpret_cast<const device uint*>(dense), trellis, true};
   } else {
     return {
         nullptr,
@@ -137,8 +153,25 @@ METAL_FUNC RightStorage<Right> pack_right(
         scales,
         Right::SCHEME == GemmBPrologueKind::ScaleBiasDequant ? biases : nullptr,
         Right::SCHEME == GemmBPrologueKind::ScaleZeroPointDequant ? zero_points : nullptr,
+        nullptr,
+        nullptr,
         signed_codes
     };
+  }
+}
+
+/// The threadgroup block the schedule stages `B` into: the `uint`-typed
+/// allocation for a trellis tile, `b_shared` for every other scheme. See
+/// `GEMM_TRELLIS_TG_WORDS` in `gemm.metal` for why the tile needs its own.
+template <typename Right, typename Element>
+METAL_FUNC threadgroup typename Right::ElementType* stage_block(
+    threadgroup Element* b_shared,
+    threadgroup uint* b_trellis
+) {
+  if constexpr (Right::STAGED) {
+    return reinterpret_cast<threadgroup typename Right::ElementType*>(b_trellis);
+  } else {
+    return b_shared;
   }
 }
 

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/common/quantized/cache.h
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/common/quantized/cache.h
@@ -59,6 +59,11 @@ struct Cache<Residency::Registers, Core, Storage, Operand, ALIGNED> {
   using WeightOperand = typename Core::RightOperand;
   UZU_CONST bool ROWS = metal::is_same<Storage, typename Core::LeftStorage>::value;
   UZU_CONST bool NEEDS_CORRECTION = WeightOperand::NEEDS_CORRECTION;
+  /// A trellis tape has one weight scale per ROW and no K groups at all, so the
+  /// whole cache is loop-invariant: it is filled once, in the constructor, and
+  /// `fill` is a no-op. The codebook's `1 / rms` folds in here rather than in the
+  /// epilogue -- it multiplies the same product.
+  UZU_CONST bool PER_ROW = !ROWS && WeightOperand::STAGED;
 
   UZU_CONST ushort TILES = ROWS ? Fragment::ROW_FRAGMENTS : Fragment::COL_FRAGMENTS;
   UZU_CONST ushort SLOTS = ROWS ? Ops::THREAD_ELEMENT_ROWS : Ops::THREAD_ELEMENT_COLS;
@@ -96,13 +101,19 @@ struct Cache<Residency::Registers, Core, Storage, Operand, ALIGNED> {
       origin = position.x;
       limit = tile.simdgroup_limit_n;
       absolute_base = tile.absolute_column_base();
-      scale_k_groups_per_row = (uint(params->K) + uint(Operand::GROUP_SIZE) - 1) / uint(Operand::GROUP_SIZE);
+      scale_k_groups_per_row =
+          PER_ROW ? 1u : (uint(params->K) + uint(Operand::GROUP_SIZE) - 1) / uint(Operand::GROUP_SIZE);
       first_k_offset = tile.k_offset;
+      if constexpr (PER_ROW) {
+        fill_at_k_offset(0);
+      }
     }
   }
 
   METAL_FUNC void fill(const int k_group_index) thread {
-    fill_at_k_offset(uint(k_group_index) * uint(WeightOperand::GROUP_SIZE));
+    if constexpr (!PER_ROW) {
+      fill_at_k_offset(uint(k_group_index) * uint(WeightOperand::GROUP_SIZE));
+    }
   }
 
   METAL_FUNC void fill_at_k_offset(const uint relative_k_offset) thread {
@@ -116,14 +127,20 @@ struct Cache<Residency::Registers, Core, Storage, Operand, ALIGNED> {
         if (ALIGNED || coordinate < limit) {
           const uint line = absolute_base + uint(coordinate);
           uint scale_index;
-          if constexpr (ROWS) {
+          if constexpr (PER_ROW) {
+            scale_index = line;
+          } else if constexpr (ROWS) {
             const uint scale_k_group = absolute_k_offset / uint(Operand::GROUP_SIZE);
             scale_index = line * scale_k_groups_per_row + scale_k_group;
           } else {
             scale_index = line * scale_k_groups_per_row + absolute_k_group;
           }
           const float group_scale = float(source.scales[scale_index]);
-          scales[tile_index * SLOTS + slot_index] = group_scale;
+          if constexpr (PER_ROW) {
+            scales[tile_index * SLOTS + slot_index] = group_scale * source.trellis->codebook_scale;
+          } else {
+            scales[tile_index * SLOTS + slot_index] = group_scale;
+          }
           if constexpr (NEEDS_CORRECTION) {
             if constexpr (ROWS) {
               corrections[tile_index * SLOTS + slot_index] =

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/common/schedules/integer.h
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/common/schedules/integer.h
@@ -10,6 +10,7 @@
 #include "../operands.h"
 #include "../quantized/cache.h"
 #include "../quantized/cursor.h"
+#include "../trellis_loader.h"
 #include "tile_context.h"
 
 using namespace metal;
@@ -34,6 +35,10 @@ struct IntegerSchedule {
       const thread ThreadContext& thread_context
   ) {
     static_assert(LeftOperand::QUANTIZED && RightOperand::QUANTIZED, "integer schedule requires quantized operands");
+    // A staged right operand owns `shared` for its decoded tile, so the weight
+    // scales cannot also live there. They are one scale per row for that scheme,
+    // which is what registers are for anyway.
+    constexpr bool STAGE_SCALES = STAGE_WEIGHT_SCALES && !RightOperand::STAGED;
     static_assert(LeftOperand::GROUP_SIZE % Core::SIMDGROUP_BLOCK_K == 0, "left groups must contain MMA chunks");
     static_assert(RightOperand::GROUP_SIZE % Core::SIMDGROUP_BLOCK_K == 0, "right groups must contain MMA chunks");
     static_assert(
@@ -51,18 +56,18 @@ struct IntegerSchedule {
             tile,
             thread_context
         );
-    auto right_codes = quantized::
-        make_cursor<quantized::Axis::Columns, HOIST_OPERAND_ADDRESSING, Core, typename RightOperand::Format, ALIGNED_N>(
-            right_storage,
-            params,
-            tile,
-            thread_context
-        );
+    auto right_codes = quantized::make_right_cursor<HOIST_OPERAND_ADDRESSING, Core, RightOperand, ALIGNED_N>(
+        right_storage,
+        shared,
+        params,
+        tile,
+        thread_context
+    );
 
     quantized::Cache<quantized::Residency::Registers, Core, typename Core::LeftStorage, LeftOperand, ALIGNED_M>
         left_scales(left_storage, shared, params, tile, thread_context);
     quantized::Cache<
-        STAGE_WEIGHT_SCALES ? quantized::Residency::Threadgroup : quantized::Residency::Registers,
+        STAGE_SCALES ? quantized::Residency::Threadgroup : quantized::Residency::Registers,
         Core,
         typename Core::RightStorage,
         RightOperand,
@@ -72,7 +77,7 @@ struct IntegerSchedule {
     typename Core::AccumFragment accumulator;
     accumulator.clear();
 
-    if constexpr (STAGE_WEIGHT_SCALES) {
+    if constexpr (STAGE_SCALES) {
       right_scales.prefetch(0);
     }
 
@@ -82,13 +87,16 @@ struct IntegerSchedule {
 
     METAL_PRAGMA_NO_UNROLL
     for (int k_group_index = 0; k_group_index < k_group_count; ++k_group_index) {
-      if constexpr (STAGE_WEIGHT_SCALES) {
+      if constexpr (STAGE_SCALES) {
         threadgroup_barrier(mem_flags::mem_threadgroup);
         if (k_group_index + 1 < k_group_count) {
           right_scales.prefetch(uint(k_group_index + 1));
         }
       }
       right_scales.fill(k_group_index);
+      if constexpr (RightOperand::STAGED) {
+        right_codes.stage();
+      }
 
       for (int span_index = 0; span_index < spans_per_k_group; ++span_index) {
         const uint span_offset = uint(k_group_index * int(RightOperand::GROUP_SIZE)) + uint(span_index * int(SPAN));

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/common/trellis_loader.h
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/common/trellis_loader.h
@@ -1,0 +1,209 @@
+#pragma once
+
+#include <metal_stdlib>
+
+#include "../../../common/thread_context.h"
+#include "../../../generated/matmul.h"
+#include "../../common/fragment.h"
+#include "../../common/trellis_decode.h"
+#include "operands.h"
+#include "quantized/cursor.h"
+#include "schedules/tile_context.h"
+
+using namespace metal;
+
+namespace uzu {
+namespace gemm {
+namespace quantized {
+
+/// The right-hand operand cursor for a trellis tape.
+///
+/// Every other weight scheme reads codes straight out of device memory, so its
+/// cursor is a pointer walk. A tape has no addressable codes: a weight only
+/// exists once its trellis state has been hashed. So this cursor DECODES a
+/// `THREADGROUP_BLOCK_N x THREADGROUP_BLOCK_K` int8 block into threadgroup
+/// memory once per K group, and the K loop then reads MMA fragments out of that
+/// block exactly as it would from device memory. `THREADGROUP_BLOCK_K` is the
+/// `RightOperand::GROUP_SIZE` the integer schedule already steps in, so the
+/// schedule's loop structure, its `aligned_inner_iterations` and the shipped
+/// split-K policy all apply unchanged.
+///
+/// ADDRESS GENERATION is the thing to get right; a naive version recomputes a
+/// 64-bit `row * row_stride_words` product, a `>> 5` and a `& 31` per state and
+/// shows up as an address-generation limiter. Two facts collapse it to one
+/// pointer add per state:
+///
+///   * `THREADS` is a multiple of `STEPS_PER_BLOCK`, so a thread's `SLOTS`
+///     states all sit at the SAME trellis step and differ only by weight ROW.
+///     One shift and one word offset serve all of them, and consecutive slots
+///     are a fixed number of tape words apart.
+///   * one K group advances the step by `STEPS_PER_BLOCK`, i.e. the bit offset
+///     falls by `THREADGROUP_BLOCK_K * k` bits, which for `V == 4` is always a
+///     whole number of 32-bit words. `bit_offset & 31` is therefore
+///     loop-invariant and `bit_offset >> 5` is an induction variable.
+///
+/// so `stage()` never recomputes a shift, a mask, the out-of-range row test or
+/// the threadgroup destination.
+///
+/// N RAGGEDNESS is handled by the `live` mask rather than by the fragment load:
+/// weight rows past `N` stage an exact zero, so the MMA needs no N guard and the
+/// fragment read is always the unbounded one. `live` is derived from `params->N`
+/// alone, so it is the same in every simdgroup of the threadgroup — which
+/// matters, because the two `ALIGNED_N` instantiations of the schedule must
+/// agree on how many barriers they execute.
+template <typename Core>
+struct TrellisCursor {
+  using Ops = typename Core::FragmentOps;
+  using Fragment = uzu::matmul::Fragment<int8_t, Core::TILES_N, Core::TILES_K, Ops, uzu::matmul::ReadDirect, true>;
+
+  UZU_CONST ushort BLOCK_N = Core::THREADGROUP_BLOCK_N;
+  UZU_CONST ushort BLOCK_K = Core::THREADGROUP_BLOCK_K;
+  UZU_CONST ushort THREADS = Core::THREADGROUP_THREADS;
+  UZU_CONST ushort STEPS_PER_BLOCK = BLOCK_K / ushort(uzu::trellis::TRELLIS_V);
+  UZU_CONST ushort SLOTS = (BLOCK_N * STEPS_PER_BLOCK) / THREADS;
+  /// Words per staged weight row. `SHARED_STRIDE_B` already pads the row against
+  /// threadgroup bank conflicts; the decode needs it to be a multiple of four so
+  /// its 32-bit stores stay aligned.
+  UZU_CONST ushort ROW_WORDS = Core::SHARED_STRIDE_B / 4;
+  /// Weight rows between two of this thread's slots.
+  UZU_CONST ushort SLOT_ROWS = THREADS / STEPS_PER_BLOCK;
+  UZU_CONST ushort SLOT_WORDS = SLOT_ROWS * ROW_WORDS;
+  UZU_CONST uint ALL_LIVE = (SLOTS >= 32) ? 0xFFFFFFFFu : ((1u << SLOTS) - 1u);
+
+  static_assert(SLOTS * THREADS == BLOCK_N * STEPS_PER_BLOCK, "weight block must divide evenly across the threadgroup");
+  static_assert(THREADS % STEPS_PER_BLOCK == 0, "a thread's slots must share a trellis step");
+  static_assert(SLOTS <= 32, "the live-row mask is 32 bits");
+  static_assert(Core::SHARED_STRIDE_B % 4 == 0, "the decode stores whole words into the staged row");
+
+  /// The staged block, as words. Its allocation is `uint`-typed for exactly this
+  /// reason; see `operands::stage_block`.
+  threadgroup uint* block;
+  /// Tape word holding the low bits of slot 0's state for the current K group.
+  const device uint* word;
+  /// Bit position of the state inside `word` -- loop-invariant, see above.
+  uint shift;
+  /// Tape words between two slots, and between two K groups.
+  uint slot_words;
+  uint words_per_group;
+  uint state_mask;
+  uint hash_a;
+  uint hash_b;
+  /// Threadgroup word index of slot 0.
+  ushort destination;
+  /// Bit `i` is set when slot `i`'s weight row is inside `N`.
+  uint live;
+  /// This simdgroup's read window into the staged block.
+  uzu::matmul::FragmentSource<threadgroup int8_t*> source;
+  ushort simd_lane_id;
+
+  template <typename Storage>
+  static METAL_FUNC TrellisCursor make(
+      const Storage right,
+      threadgroup int8_t* shared,
+      const constant uzu::matmul::GemmParams* params,
+      const schedules::TileContext tile,
+      const thread ThreadContext& thread_context
+  ) {
+    const uint kv = right.trellis->k_bits_per_step;
+    const uint row_stride_words = right.trellis->row_stride_words;
+    const uint steps = uint(params->K) / uint(uzu::trellis::TRELLIS_V);
+    const uint thread_index = thread_context.simdgroup_index * METAL_SIMD_SIZE + thread_context.simd_lane_id;
+    const ushort step = ushort(thread_index % STEPS_PER_BLOCK);
+    const ushort slot_row = ushort(thread_index / STEPS_PER_BLOCK);
+    const uzu::trellis::Walk tape =
+        uzu::trellis::walk(steps, tile.k_offset / uint(uzu::trellis::TRELLIS_V) + uint(step), STEPS_PER_BLOCK, kv);
+    const uint block_row_base = uint(tile.block_col);
+
+    TrellisCursor cursor;
+    cursor.block = reinterpret_cast<threadgroup uint*>(shared);
+    cursor.word = right.tape + (ulong)(block_row_base + slot_row) * (ulong)row_stride_words + (ulong)tape.word_offset;
+    cursor.shift = tape.shift;
+    cursor.slot_words = uint(SLOT_ROWS) * row_stride_words;
+    cursor.words_per_group = tape.block_words;
+    cursor.state_mask = uzu::trellis::state_mask(right.trellis->l);
+    cursor.hash_a = right.trellis->hash_a;
+    cursor.hash_b = right.trellis->hash_b;
+    cursor.destination = slot_row * ROW_WORDS + step;
+    cursor.live = 0u;
+    METAL_PRAGMA_UNROLL
+    for (ushort i = 0; i < SLOTS; ++i) {
+      if (block_row_base + slot_row + i * SLOT_ROWS < uint(params->N)) {
+        cursor.live |= 1u << i;
+      }
+    }
+    cursor.source =
+        uzu::matmul::fragment_source(shared + tile.tile_col_offset * Core::SHARED_STRIDE_B, int(Core::SHARED_STRIDE_B));
+    cursor.simd_lane_id = ushort(thread_context.simd_lane_id);
+    return cursor;
+  }
+
+  /// Decode this thread's `SLOTS` states into the staged block and step to the
+  /// next K group. The barrier pair is the block's, and it is why this is a
+  /// method rather than something the schedule open-codes: both `ALIGNED_N`
+  /// instantiations must run it the same number of times.
+  METAL_FUNC void stage() thread {
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    // The N guard, hoisted out of the unroll. `live` does not change across K
+    // groups, so the common case -- every slot inside N -- can run the whole
+    // unroll with NO per-slot conditional at all, and only the one ragged N
+    // block per grid pays a test per slot. `integer_and_conditional` is this
+    // kernel's second limiter and SLOTS of it per K group were conditionals.
+    if (live == ALL_LIVE) {
+      METAL_PRAGMA_UNROLL
+      for (ushort i = 0; i < SLOTS; ++i) {
+        const uint state = uzu::trellis::state_at_word(word + i * slot_words, shift, state_mask);
+        block[destination + i * SLOT_WORDS] = uzu::trellis::map_bytes(uzu::trellis::state_hash(state, hash_a, hash_b));
+      }
+    } else {
+      METAL_PRAGMA_UNROLL
+      for (ushort i = 0; i < SLOTS; ++i) {
+        uint packed = 0u;
+        if ((live >> i) & 1u) {
+          const uint state = uzu::trellis::state_at_word(word + i * slot_words, shift, state_mask);
+          packed = uzu::trellis::map_bytes(uzu::trellis::state_hash(state, hash_a, hash_b));
+        }
+        block[destination + i * SLOT_WORDS] = packed;
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    word -= words_per_group;
+  }
+
+  METAL_FUNC Fragment load(const uint chunk_index) const thread {
+    Fragment tile;
+    tile.load_from(simd_lane_id, source.advanced(int(chunk_index) * int(Core::SIMDGROUP_BLOCK_K)));
+    return tile;
+  }
+
+  /// The staged block is re-decoded per K group and read by chunk index, so
+  /// there is no pointer to walk.
+  METAL_FUNC void advance() thread {}
+
+  METAL_FUNC void begin_k_group(const uint) thread {}
+};
+
+/// The right-hand cursor for whichever weight scheme is compiled: a tape decoder
+/// for `Trellis`, the ordinary device-memory code cursor otherwise.
+template <bool HOIST, typename Core, typename RightOperand, bool ALIGNED_N, typename Storage>
+static METAL_FUNC auto make_right_cursor(
+    const Storage right,
+    threadgroup typename Core::RightElementType* shared,
+    const constant uzu::matmul::GemmParams* params,
+    const schedules::TileContext tile,
+    const thread ThreadContext& thread_context
+) {
+  if constexpr (RightOperand::STAGED) {
+    return TrellisCursor<Core>::make(right, shared, params, tile, thread_context);
+  } else {
+    return make_cursor<Axis::Columns, HOIST, Core, typename RightOperand::Format, ALIGNED_N>(
+        right,
+        params,
+        tile,
+        thread_context
+    );
+  }
+}
+
+} // namespace quantized
+} // namespace gemm
+} // namespace uzu

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/gemm.metal
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/gemm.metal
@@ -11,14 +11,24 @@ using namespace metal;
 using namespace uzu::gemm;
 
 #define A_IS_INT8 (A_PROLOGUE == GemmAPrologueKind::Int8Symmetric)
-#define NEEDS_ASYMMETRIC_WEIGHT_CORRECTION (A_IS_INT8 && B_PROLOGUE != GemmBPrologueKind::ScaleSymmetricDequant)
+#define GEMM_TRELLIS (B_PROLOGUE == GemmBPrologueKind::Trellis)
+// Trellis weights are symmetric like ScaleSymmetricDequant: the decode emits
+// signed levels around zero, so there is no zero point to correct for.
+#define NEEDS_ASYMMETRIC_WEIGHT_CORRECTION                                                                             \
+  (A_IS_INT8 && !GEMM_TRELLIS && B_PROLOGUE != GemmBPrologueKind::ScaleSymmetricDequant)
 #define GEMM_MXU_QUANT (USE_MXU && B_PROLOGUE != GemmBPrologueKind::FullPrecision && !A_IS_INT8)
 #define GEMM_TGA_ELEMENTS                                                                                              \
   ((USE_MXU) ? 1 : (gemm_tiling_block_m(GEMM_TILING) * (gemm_tiling_block_k(GEMM_TILING) + 16 / int(sizeof(AT)))))
 #define GEMM_INTEGER_TGB_ELEMENTS                                                                                      \
-  ((B_PROLOGUE == GemmBPrologueKind::ScaleSymmetricDequant)                                                            \
-       ? (2 * gemm_tiling_block_n(GEMM_TILING))                                                                        \
-       : (2 * gemm_tiling_block_n(GEMM_TILING) * (1 + 4 / int(sizeof(BT)))))
+  (GEMM_TRELLIS ? 1                                                                                                    \
+                : ((B_PROLOGUE == GemmBPrologueKind::ScaleSymmetricDequant)                                            \
+                       ? (2 * gemm_tiling_block_n(GEMM_TILING))                                                        \
+                       : (2 * gemm_tiling_block_n(GEMM_TILING) * (1 + 4 / int(sizeof(BT))))))
+// The decoded trellis tile: BLOCK_N int8 rows of GROUP_SIZE columns, padded the
+// way `MxuMmaCore::SHARED_STRIDE_B` pads them, addressed as words because the
+// decode stores four weights at a time. It cannot share `b_shared`: that array
+// is `BT`-typed, so it is only 2-byte aligned and the 32-bit stores would fault.
+#define GEMM_TRELLIS_TG_WORDS (GEMM_TRELLIS ? (gemm_tiling_block_n(GEMM_TILING) * (int(GROUP_SIZE) + 16) / 4) : 1)
 #define GEMM_TGB_ELEMENTS                                                                                              \
   ((USE_MXU) ? (GEMM_MXU_QUANT ? (gemm_tiling_block_n(GEMM_TILING) * (int(GROUP_SIZE) + 16 / int(sizeof(BT))))         \
                                : (A_IS_INT8 ? GEMM_INTEGER_TGB_ELEMENTS : 1))                                          \
@@ -60,7 +70,8 @@ VARIANTS(
     GemmBPrologueKind::FullPrecision,
     GemmBPrologueKind::ScaleBiasDequant,
     GemmBPrologueKind::ScaleZeroPointDequant,
-    GemmBPrologueKind::ScaleSymmetricDequant)
+    GemmBPrologueKind::ScaleSymmetricDequant,
+    GemmBPrologueKind::Trellis)
 VARIANTS(BITS, 0, 4, 8)
 VARIANTS(GROUP_SIZE, 0, 16, 32, 64, 128)
 VARIANTS(
@@ -108,6 +119,23 @@ CONSTRAINT(
 CONSTRAINT(A_PROLOGUE == GemmAPrologueKind::FullPrecision || (AT == "bfloat" && DT == "bfloat"))
 CONSTRAINT((A_PROLOGUE == GemmAPrologueKind::FullPrecision) == (A_GROUP_SIZE == 0))
 CONSTRAINT(A_PROLOGUE == GemmAPrologueKind::FullPrecision || A_GROUP_SIZE >= 32)
+// A trellis tape is decoded into threadgroup memory as int8 and fed to the
+// integer schedule, so it is the a8 path with one substitution: `GROUP_SIZE` is
+// the STAGING block K, not a quantization group, and `BITS` is the width of the
+// decode's output. Only the tiles the a8 policy actually selects are compiled.
+//
+// `GROUP_SIZE == 64` here must match `trellis_format::TRELLIS_BLOCK_K`, which is
+// what the host reports as the weight group size; a mismatch is a missing entry
+// point at dispatch time, not a compile error. `A_GROUP_SIZE == 128` is
+// `ACTIVATION_SCALE_GROUP_SIZE`, the only activation group the a8 route uses.
+CONSTRAINT(
+    B_PROLOGUE != GemmBPrologueKind::Trellis ||
+    (BITS == 8 && GROUP_SIZE == 64 &&
+     A_PROLOGUE == GemmAPrologueKind::Int8Symmetric &&
+     A_GROUP_SIZE == 128 &&
+     (GEMM_TILING == GemmTiling::Tile16x32x256_Simdgroups1x1 ||
+      GEMM_TILING == GemmTiling::Tile32x64x256_Simdgroups2x2 ||
+      GEMM_TILING == GemmTiling::Tile64x64x256_Simdgroups2x2)))
 KERNEL(Gemm)(
     const device AT* a OPTIONAL(A_PROLOGUE == GemmAPrologueKind::FullPrecision),
     const device BT* b,
@@ -125,6 +153,7 @@ KERNEL(Gemm)(
     const device int8_t* a_int8 OPTIONAL(A_IS_INT8),
     const device float* a_scales OPTIONAL(A_IS_INT8),
     const device int32_t* a_group_sums OPTIONAL(NEEDS_ASYMMETRIC_WEIGHT_CORRECTION),
+    const constant uzu::matmul::TrellisParams& trellis OPTIONAL(GEMM_TRELLIS),
     const constant uzu::matmul::GemmParams* params,
     const constant uint& group_count_x,
     const constant uint& group_count_y,
@@ -136,6 +165,7 @@ KERNEL(Gemm)(
     const bool hoist_operand_addressing SPECIALIZE,
     threadgroup AT a_shared[GEMM_TGA_ELEMENTS],
     threadgroup BT b_shared[GEMM_TGB_ELEMENTS],
+    threadgroup uint b_trellis[GEMM_TRELLIS_TG_WORDS],
     const uint group_x GROUPS(group_count_x),
     const uint group_y GROUPS(group_count_y),
     const uint group_z GROUPS(group_count_z),
@@ -158,7 +188,8 @@ KERNEL(Gemm)(
       "kernel bindings and operand correction policy must agree"
   );
   const auto left_storage = operands::pack_left<LeftOperand, AT>(a, a_int8, a_scales, a_group_sums);
-  const auto right_storage = operands::pack_right<RightOperand, BT>(b, scales, biases, zero_points, signed_codes);
+  const auto right_storage =
+      operands::pack_right<RightOperand, BT>(b, scales, biases, zero_points, &trellis, signed_codes);
 
   static_assert(
       !A_IS_INT8 || GEMM_TGB_ELEMENTS >= GEMM_INTEGER_TGB_ELEMENTS,
@@ -176,7 +207,7 @@ KERNEL(Gemm)(
         output_transform,
         output_bias,
         rht_factors,
-        b_shared,
+        operands::stage_block<RightOperand>(b_shared, b_trellis),
         stage_weight_scales,
         hoist_operand_addressing,
         thread_context

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/kernel.rs
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/kernel.rs
@@ -10,12 +10,12 @@ use crate::{
         common::{
             Allocation, BufferArg, Encoder,
             gpu_types::{
-                GemmParams,
+                GemmParams, TrellisParams,
                 gemm::{GemmAPrologueKind, GemmAlignment, GemmBPrologueKind, GemmDTransform},
             },
             kernel::{
                 ActivationTransform, TensorAddBiasKernel,
-                matmul::{MatmulA, MatmulArguments, MatmulB, MatmulError, MatmulShape},
+                matmul::{MatmulA, MatmulArguments, MatmulB, MatmulError, MatmulShape, trellis_format::trellis_params},
             },
         },
         metal::{
@@ -116,6 +116,7 @@ impl GemmKernel {
             self.output_data_type,
             context.supports_mxu,
             context.apple_gpu_family,
+            context.gpu_core_count,
         )
     }
 
@@ -240,6 +241,7 @@ impl GemmKernel {
                         None,
                         None,
                         None,
+                        None,
                         &mut *d,
                         ab_scale,
                         shape,
@@ -292,6 +294,7 @@ impl GemmKernel {
                     None::<&Allocation<Metal>>,
                     None::<&Allocation<Metal>>,
                     None::<&Allocation<Metal>>,
+                    None,
                     std::slice::from_ref(&params),
                     group_count_x,
                     group_count_y,
@@ -307,25 +310,45 @@ impl GemmKernel {
             }
             | MatmulB::ScaleSymmetricDequant {
                 ..
+            }
+            | MatmulB::Trellis {
+                ..
             }) => {
-                let (weights, scales, biases, zero_points) = match quant_b {
+                let (weights, scales, biases, zero_points, trellis) = match quant_b {
                     MatmulB::ScaleBiasDequant {
                         b: w,
                         scales,
                         biases,
                         ..
-                    } => (w, Some(scales), Some(biases), None),
+                    } => (w, Some(scales), Some(biases), None, None),
                     MatmulB::ScaleZeroPointDequant {
                         b: w,
                         scales,
                         zero_points,
                         ..
-                    } => (w, Some(scales), None, Some(zero_points)),
+                    } => (w, Some(scales), None, Some(zero_points), None),
                     MatmulB::ScaleSymmetricDequant {
                         b: w,
                         scales,
                         ..
-                    } => (w, Some(scales), None, None),
+                    } => (w, Some(scales), None, None, None),
+                    // The tape is the `b` buffer and the per-row scales are the
+                    // `scales` buffer, so everything downstream -- alignment,
+                    // params, split-K, the specialization -- is the shipped
+                    // quantized path unchanged; only these constants are new.
+                    MatmulB::Trellis {
+                        b: w,
+                        scales,
+                        config,
+                    } => {
+                        let Some(params) = trellis_params(config, shape.k) else {
+                            return Err(MatmulError::<Metal>::UnsupportedLayout {
+                                path: "Gemm trellis",
+                            }
+                            .into());
+                        };
+                        (w, Some(scales), None, None, Some(params))
+                    },
                     _ => unreachable!(),
                 };
 
@@ -382,6 +405,7 @@ impl GemmKernel {
                         scales,
                         biases,
                         zero_points,
+                        trellis,
                         &mut *d,
                         ab_scale,
                         shape,
@@ -414,6 +438,7 @@ impl GemmKernel {
                         a_int8,
                         a_scales,
                         a_group_sums,
+                        trellis,
                         std::slice::from_ref(&params),
                         group_count_x,
                         group_count_y,
@@ -440,6 +465,7 @@ impl GemmKernel {
         scales: Option<&Allocation<Metal>>,
         biases: Option<&Allocation<Metal>>,
         zero_points: Option<&Allocation<Metal>>,
+        trellis: Option<TrellisParams>,
         d: &mut Allocation<Metal>,
         ab_scale: f32,
         shape: MatmulShape,
@@ -515,6 +541,7 @@ impl GemmKernel {
             a_int8,
             a_scales,
             a_group_sums,
+            trellis,
             std::slice::from_ref(&params),
             base_gx,
             base_gy,
@@ -564,6 +591,7 @@ fn validate_int8_activation_arguments(
             GemmBPrologueKind::ScaleSymmetricDequant
                 | GemmBPrologueKind::ScaleBiasDequant
                 | GemmBPrologueKind::ScaleZeroPointDequant
+                | GemmBPrologueKind::Trellis
         )
         && matches!(bits_per_b, Some(4 | 8))
         && matches!(a_group_size, 32 | 64 | 128)
@@ -605,3 +633,7 @@ fn quant_params(
         ab_scale,
     }
 }
+
+#[cfg(test)]
+#[path = "../../../../../../unit/backends/metal/kernel/matmul/gemm/trellis_test.rs"]
+mod trellis_tests;

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/policy.rs
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/policy.rs
@@ -26,6 +26,23 @@ const SIMDGROUP_QUANT_NARROW_BLOCK_M: u32 = 8;
 const SIMDGROUP_QUANT_LARGE_M_MIN: u32 = 64;
 const SIMDGROUP_QUANT_WIDE_N_MIN: u32 = 6144;
 
+/// Split-K buys threadgroups, and how many threadgroups are worth having is a
+/// property of the machine rather than of a fixed tile count. This is the
+/// production INT4 retune's `SPLIT_K_TARGET_SIMDGROUPS_PER_CORE`, reused
+/// verbatim: the trellis arm feeds the same integer schedule on the same MXU,
+/// so the supply it wants is the same supply.
+const TRELLIS_TARGET_SIMDGROUPS_PER_CORE: u32 = 206;
+
+/// How far a trellis split may go, as `(max M, ceiling)` rungs falling through
+/// to "do not split", measured on a 40-core M5 Max.
+///
+/// A cap on the split-K partial planes as a share of the tape was tried here
+/// and REMOVED: three probe cells that force the uncapped split measured 0.996,
+/// 0.940 and 1.010 against it, so the planes cost nothing the ceiling does not
+/// already bound. Unlike a dequantizing GEMM, splitting a tape multiplies
+/// DECODE work as well as partial traffic, which is what these rungs bound.
+const TRELLIS_SPLIT_K_CEILINGS: [(u32, u32); 2] = [(32, 8), (64, 4)];
+
 const SPLIT_K_TARGET_TILES_FP: u32 = 512;
 const SPLIT_K_TARGET_TILES_A8: u32 = 256;
 const SPLIT_K_TARGET_TILES_A8_TILE16X32: u32 = 4 * SPLIT_K_TARGET_TILES_A8;
@@ -141,4 +158,29 @@ pub(super) fn split_k_target_tiles(
         (true, _, _) => SPLIT_K_TARGET_TILES_A8,
         (false, _, _) => SPLIT_K_TARGET_TILES_FP,
     }
+}
+
+/// The smallest split that lifts a trellis dispatch to
+/// [`TRELLIS_TARGET_SIMDGROUPS_PER_CORE`] simdgroups per GPU core, bounded by
+/// the M ceiling.
+///
+/// Why the trellis arm needs its own rule at all: `split_k_target_tiles` is a
+/// fixed tile count, so a grid at least half as wide as the target answers "do
+/// not split" however little of the machine it fills. `Tile16x32x256` over
+/// N = 16480 is 515 threadgroups of one simdgroup -- 12.9 simdgroups per core
+/// on a 40-core part -- and the a8 tile target still says 1. The A/B that
+/// retired the tile target for this prologue is the round 7 trellis split-K
+/// bench (`scratchpad/round7/draft.md`); the plumbing that measured both rules
+/// in one process has been removed and is recoverable from git history.
+pub(super) fn trellis_split_k(
+    m: u32,
+    base_tiles: u32,
+    tiling: GemmTiling,
+    gpu_core_count: u32,
+) -> u32 {
+    let simdgroups_per_tile = tiling.simdgroups_m().saturating_mul(tiling.simdgroups_n()).max(1);
+    let unsplit_simdgroups = base_tiles.saturating_mul(simdgroups_per_tile).max(1);
+    let target = TRELLIS_TARGET_SIMDGROUPS_PER_CORE.saturating_mul(gpu_core_count.max(1));
+    let ceiling = TRELLIS_SPLIT_K_CEILINGS.iter().find(|(max_m, _)| m <= *max_m).map_or(1, |&(_, c)| c);
+    target.div_ceil(unsplit_simdgroups).clamp(1, ceiling.max(1))
 }

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/selection.rs
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/selection.rs
@@ -17,6 +17,7 @@ pub struct GemmProblem {
     output_data_type: DataType,
     supports_mxu: bool,
     apple_gpu_family: MTLGPUFamily,
+    gpu_core_count: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Error)]
@@ -34,6 +35,7 @@ impl GemmProblem {
         output_data_type: DataType,
         supports_mxu: bool,
         apple_gpu_family: MTLGPUFamily,
+        gpu_core_count: u32,
     ) -> Self {
         Self {
             shape,
@@ -41,6 +43,7 @@ impl GemmProblem {
             output_data_type,
             supports_mxu,
             apple_gpu_family,
+            gpu_core_count,
         }
     }
 
@@ -114,8 +117,18 @@ impl GemmProblem {
             align = align.max(2_u32.saturating_mul(group_size));
         }
         let align = align.max(ACTIVATION_SCALE_GROUP_SIZE).max(group_size);
-        let target_tiles = policy::split_k_target_tiles(!shape.a_full_precision, tiling, shape.b_bits);
-        let mut split_k = (target_tiles / base_tiles).max(1).min((shape.k / align).max(1));
+        // A trellis tape is the one prologue whose `GROUP_SIZE` is a staging
+        // block rather than a quantization group, and the tile target reads it
+        // wrong; it is decided by threadgroup supply instead. See
+        // `policy::trellis_split_k`. Every other prologue keeps the shipped tile
+        // target, byte for byte.
+        let wanted = if shape.b_prologue == GemmBPrologueKind::Trellis {
+            policy::trellis_split_k(shape.m, base_tiles, tiling, self.gpu_core_count)
+        } else {
+            let target_tiles = policy::split_k_target_tiles(!shape.a_full_precision, tiling, shape.b_bits);
+            (target_tiles / base_tiles).max(1)
+        };
+        let mut split_k = wanted.min((shape.k / align).max(1));
         if !shape.a_full_precision && engine == GemmEngine::Mxu && tiling.block_k() != 0 {
             split_k = split_k.min((shape.k / tiling.block_k()).max(1));
         }

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/specialization.rs
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/specialization.rs
@@ -111,6 +111,11 @@ impl GemmPlan {
         self,
         shape: MatmulShape,
     ) -> bool {
+        if shape.b_prologue == GemmBPrologueKind::Trellis {
+            // Threadgroup memory holds the decoded weight tile; the scales are
+            // one per row and stay in registers.
+            return false;
+        }
         if shape.b_bits == Some(4) && shape.b_group_size == Some(32) && self.tiling.block_m() <= 32 {
             return false;
         }

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/common/trellis_b_source.h
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/common/trellis_b_source.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "arguments.h"
+#include "tile.h"
+#include "trellis_slice.h"
+
+namespace uzu {
+namespace gemm {
+
+/// QTIP bitshift-trellis weights as a GEMV B source.
+///
+/// The same shape as `QuantBSource` -- walk K in blocks, load a lane's slice,
+/// accumulate it into `result[INPUT_ROWS][ROWS_PER_LANE]` -- with the two
+/// differences the format forces:
+///
+///   * there is no group loop. One scale covers a row, so the metadata is
+///     loaded once and folded once, and the K loop accumulates the raw integer
+///     dot product (see `TrellisMetadata`).
+///   * a lane's K run is CONTIGUOUS rather than group-strided, because the
+///     states in it then share one tape load (see `TrellisSlice`).
+///
+/// The batch stays in registers exactly as it does for the quantized source,
+/// and that is what pays for the decode: the trellis codebook is ~9 instructions
+/// per weight against a load and a shift for an INT4 code, so it has to be
+/// amortised over the batch rather than repeated per batch row.
+/// The one step width given a compile-time run: `k = 3` over `V = 4`, the
+/// widest the shipped configs use and the one where a compile-time bit offset
+/// turns the lane's four states into four INDEPENDENT extractions. Every other
+/// `k` takes the runtime walk in `TrellisSlice`.
+UZU_CONST uint TRELLIS_STATIC_KV = 12;
+
+template <typename Tile, typename AT, typename BT, typename DT, bool INPUT_ALIGNED, bool FULL_TILE>
+struct TrellisBSource {
+  using U = float;
+  using Metadata = TrellisMetadata<Tile, AT, BT, DT>;
+
+  static_assert(INPUT_ALIGNED, "the trellis GEMV takes only K that is a whole number of blocks");
+  static_assert(Tile::K_SPLIT == 1, "the trellis GEMV does not split K");
+
+  static METAL_FUNC void accumulate(
+      thread U (&result)[Tile::INPUT_ROWS][Tile::ROWS_PER_LANE],
+      const thread GemvOperands<AT, BT, DT>& ops,
+      const thread GemvParams& params,
+      const thread OutputTile<Tile, FULL_TILE>& tile,
+      const constant uzu::matmul::TrellisParams& trellis
+  ) {
+    if (trellis.k_bits_per_step == TRELLIS_STATIC_KV) {
+      run<TRELLIS_STATIC_KV>(result, ops, params, tile, trellis);
+    } else {
+      run<0>(result, ops, params, tile, trellis);
+    }
+  }
+
+private:
+  template <uint KV>
+  static METAL_FUNC void run(
+      thread U (&result)[Tile::INPUT_ROWS][Tile::ROWS_PER_LANE],
+      const thread GemvOperands<AT, BT, DT>& ops,
+      const thread GemvParams& params,
+      const thread OutputTile<Tile, FULL_TILE>& tile,
+      const constant uzu::matmul::TrellisParams& trellis
+  ) {
+    using Slice = TrellisSlice<Tile, AT, BT, DT, FULL_TILE, KV>;
+    uint weight_row_indices[Tile::ROWS_PER_LANE];
+    Tile::for_each_output_row([&](auto output_index) UZU_ALWAYS_INLINE {
+      constexpr uint R = decltype(output_index)::value;
+      weight_row_indices[R] = tile.row0 + R;
+    });
+
+    Metadata metadata;
+    metadata.load(weight_row_indices, ops, trellis);
+
+    Slice current = Slice::make(
+        reinterpret_cast<const device uint*>(ops.b),
+        weight_row_indices,
+        tile.reduction_lane,
+        params.in_vec_size,
+        trellis
+    );
+
+    const uint blocks = params.in_vec_size / Slice::BLOCK_VALUES;
+    const uint batch_remaining = params.batch_size - tile.input_row;
+    float partial[Tile::INPUT_ROWS][Tile::ROWS_PER_LANE] = {{0}};
+    uint column = tile.reduction_lane * Slice::VALUES_PER_LANE;
+    for (uint block = 0; block < blocks; block++) {
+      current.load_weights();
+      current.accumulate(partial, ops, params, tile, column, batch_remaining, trellis);
+      current.advance();
+      column += Slice::BLOCK_VALUES;
+    }
+
+    metadata.fold(result, partial);
+  }
+};
+
+} // namespace gemm
+} // namespace uzu

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/common/trellis_slice.h
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/common/trellis_slice.h
@@ -1,0 +1,257 @@
+#pragma once
+
+#include "../../../common/integral_constant.h"
+#include "../../../generated/matmul.h"
+#include "../../common/trellis_decode.h"
+#include "arguments.h"
+#include "tile.h"
+
+namespace uzu {
+namespace gemm {
+
+/// The trellis GEMV's per-row metadata: ONE scale for the whole row.
+///
+/// Every other B source reloads a scale per quantization group, which is why
+/// `QuantMetadata` is folded once per group. A tape has no groups -- one scale
+/// covers the row -- so this is loaded once before the K loop and folded once
+/// after it, and the K loop accumulates the raw integer dot product.
+/// `codebook_scale` (`1 / rms(codebook)`) rides on the row scale for the same
+/// reason: the decode emits small integers and this keeps the per-weight cost at
+/// one fma.
+template <typename Tile, typename AT, typename BT, typename DT>
+struct TrellisMetadata {
+private:
+  float scale[Tile::ROWS_PER_LANE];
+
+public:
+  METAL_FUNC void load(
+      const thread uint (&weight_rows)[Tile::ROWS_PER_LANE],
+      const thread GemvOperands<AT, BT, DT>& ops,
+      const constant uzu::matmul::TrellisParams& trellis
+  ) thread {
+    Tile::for_each_output_row([&](auto output_index) UZU_ALWAYS_INLINE {
+      constexpr uint R = decltype(output_index)::value;
+      scale[R] = float(ops.scales[weight_rows[R]]) * trellis.codebook_scale;
+    });
+  }
+
+  METAL_FUNC void fold(
+      thread float (&result)[Tile::INPUT_ROWS][Tile::ROWS_PER_LANE],
+      const thread float (&partial)[Tile::INPUT_ROWS][Tile::ROWS_PER_LANE]
+  ) const thread {
+    Tile::for_each_input_row([&](auto input_index) UZU_ALWAYS_INLINE {
+      constexpr uint I = decltype(input_index)::value;
+      Tile::for_each_output_row([&](auto output_index) UZU_ALWAYS_INLINE {
+        constexpr uint R = decltype(output_index)::value;
+        result[I][R] = fma(scale[R], partial[I][R], result[I][R]);
+      });
+    });
+  }
+};
+
+/// One lane's slice of a trellis tape: a CONTIGUOUS run of `STATES_PER_LANE`
+/// trellis states per weight row, read with one load and decoded in registers.
+///
+/// `QuantSlice`'s lane owns a contiguous run of CODES; this lane owns a
+/// contiguous run of STATES, which is the same thing once the tape is the only
+/// addressable form the weights have. Two consequences, both wanted:
+///
+///   * the run spans `(STATES_PER_LANE - 1) * KV + L` bits, so ONE load of
+///     `RAW_WORDS` words and one funnel shift serve every state in it, against
+///     two device loads per state for a lane-strided split;
+///   * the lane's `VALUES_PER_LANE` activations are contiguous, so the slot
+///     loads merge into wide ones, and the simdgroup still covers one contiguous
+///     activation region -- just at a coarser granularity.
+///
+/// THE 128-BIT WINDOW. `TrellisConfig::is_valid` guarantees `KV <= L <= 32`, so
+/// with `STATES_PER_LANE == 4` the run spans at most `3*32 + 32 == 128` bits and
+/// the normalized run always fits in two `ulong`s. That is what lets `L` and
+/// `KV` stay RUNTIME values: the states come out of a 128-bit register pair by
+/// shifting it down `KV` bits at a time, so nothing here needs a compile-time
+/// bit offset, a word index or a branch. A wider run would need one.
+///
+/// ADDRESS ARITHMETIC. One block of `REDUCTION_LANES * STATES_PER_LANE` steps is
+/// `REDUCTION_LANES * STATES_PER_LANE * KV` bits, which for `V == 4` and eight
+/// reduction lanes is always a whole number of words. `bit_offset & 31` is
+/// therefore loop-invariant and the row pointers just walk down, so the K loop
+/// never recomputes a `>> 5`, a `& 31` or a row product.
+/// `KV` is the tape's bits-per-step when the caller knows it at compile time and
+/// 0 when it does not; see the state extraction in `accumulate`.
+template <typename Tile, typename AT, typename BT, typename DT, bool FULL_TILE, uint KV>
+struct TrellisSlice {
+  using U = float;
+
+public:
+  /// Weights per trellis step. Fixed by the codebook: a 32-bit hash has four
+  /// bytes.
+  UZU_CONST uint V = uzu::trellis::TRELLIS_V;
+  /// Trellis states one lane decodes per K block. Four is the widest run that
+  /// still fits a 128-bit window at `KV == L == 32`; see above.
+  UZU_CONST uint STATES_PER_LANE = 4;
+  UZU_CONST uint VALUES_PER_LANE = STATES_PER_LANE * V;
+  /// K values one full reduction step covers.
+  UZU_CONST uint BLOCK_VALUES = Tile::REDUCTION_LANES * VALUES_PER_LANE;
+
+private:
+  /// Bits the run spans, once normalized to bit 0: `STATES_PER_LANE - 1` steps
+  /// of `KV` plus one window. With a compile-time `KV` that is 68 bits at
+  /// `KV == 12`, not the 128 a runtime `KV <= 32` has to be sized for, so the
+  /// run is a word shorter and one device load cheaper as well.
+  UZU_CONST uint STEP_BITS = (KV != 0u) ? KV : uzu::trellis::TRELLIS_MAX_L;
+  UZU_CONST uint SPAN_BITS = (STATES_PER_LANE - 1u) * STEP_BITS + uzu::trellis::TRELLIS_MAX_L;
+  /// Words of the normalized run, and words loaded to produce them: the funnel
+  /// shift reads one word past the last.
+  UZU_CONST uint RUN_WORDS = (SPAN_BITS + 31u) / 32u;
+  UZU_CONST uint RAW_WORDS = RUN_WORDS + 1;
+
+  static_assert(Tile::GROUP_LANES == 1, "a trellis lane owns whole trellis states");
+  // 32 steps of KV bits is KV whole words for any KV, which is what makes
+  // `block_words` exact and `shift` loop-invariant.
+  static_assert((BLOCK_VALUES / V) % 32 == 0, "one K block must advance the tape by whole words");
+
+  /// The run normalized to bit 0, little-endian.
+  uint run[Tile::ROWS_PER_LANE][RUN_WORDS];
+  /// This lane's tape word for each weight row, and the bit of the run's base
+  /// inside it -- loop-invariant, see above.
+  const device uint* head[Tile::ROWS_PER_LANE];
+  uint shift;
+  uint block_words;
+
+public:
+  /// `weight_rows` are the tape rows this lane reduces; `reduction_lane` picks
+  /// its run inside the first K block.
+  static METAL_FUNC TrellisSlice make(
+      const device uint* tape,
+      const thread uint (&weight_rows)[Tile::ROWS_PER_LANE],
+      uint reduction_lane,
+      uint in_vec_size,
+      const constant uzu::matmul::TrellisParams& trellis
+  ) {
+    const uint kv = trellis.k_bits_per_step;
+    const uint steps = in_vec_size / V;
+    const uzu::trellis::Walk run =
+        uzu::trellis::walk(steps, STATES_PER_LANE * (reduction_lane + 1u) - 1u, BLOCK_VALUES / V, kv);
+    const uint stride = trellis.row_stride_words;
+
+    TrellisSlice slice;
+    slice.shift = run.shift;
+    slice.block_words = run.block_words;
+    Tile::for_each_output_row([&](auto output_index) UZU_ALWAYS_INLINE {
+      constexpr uint R = decltype(output_index)::value;
+      slice.head[R] = tape + (ulong)weight_rows[R] * (ulong)stride + (ulong)run.word_offset;
+    });
+    return slice;
+  }
+
+  /// One load per weight row, then one funnel shift that normalizes the run to
+  /// bit 0. Every load is issued before any shift, so the runs arrive together.
+  METAL_FUNC void load_weights() thread {
+    Tile::for_each_output_row([&](auto output_index) UZU_ALWAYS_INLINE {
+      constexpr uint R = decltype(output_index)::value;
+      uint raw[RAW_WORDS];
+      uzu::const_for_loop<0, int(RAW_WORDS), 1>([&](auto i) UZU_ALWAYS_INLINE { raw[i.value] = head[R][i.value]; });
+      uzu::const_for_loop<0, int(RUN_WORDS), 1>([&](auto i) UZU_ALWAYS_INLINE {
+        run[R][i.value] = uint((((ulong)raw[i.value + 1] << 32) | (ulong)raw[i.value]) >> shift);
+      });
+    });
+  }
+
+  /// Step to the next K block. A block is a whole number of tape words, so the
+  /// shift stays put and only the pointers move.
+  METAL_FUNC void advance() thread {
+    Tile::for_each_output_row([&](auto output_index) UZU_ALWAYS_INLINE {
+      constexpr uint R = decltype(output_index)::value;
+      head[R] -= block_words;
+    });
+  }
+
+  /// Decode this lane's run and accumulate it into the batch. `column` is the
+  /// first K column of the run.
+  METAL_FUNC void accumulate(
+      thread U (&partial)[Tile::INPUT_ROWS][Tile::ROWS_PER_LANE],
+      const thread GemvOperands<AT, BT, DT>& ops,
+      const thread GemvParams& params,
+      const thread OutputTile<Tile, FULL_TILE>& tile,
+      uint column,
+      uint batch_remaining,
+      const constant uzu::matmul::TrellisParams& trellis
+  ) const thread {
+    const uint state_mask = uzu::trellis::state_mask(trellis.l);
+
+    // The run's bit offset RISES as the step FALLS, so slot
+    // `STATES_PER_LANE - 1 - i` is the state at bit `i * KV`.
+    //
+    // With a compile-time `KV` that bit is a compile-time word and offset, so
+    // the four states are four INDEPENDENT extractions off the run -- which is
+    // the point, in a kernel whose limiter is latency rather than issue. The
+    // runtime form has to walk a 128-bit register pair down `kv` bits per
+    // state, and each state then waits on the one before it.
+    uint states[Tile::ROWS_PER_LANE][STATES_PER_LANE];
+    Tile::for_each_output_row([&](auto output_index) UZU_ALWAYS_INLINE {
+      constexpr uint R = decltype(output_index)::value;
+      if constexpr (KV != 0u) {
+        uzu::const_for_loop<0, int(STATES_PER_LANE), 1>([&](auto i) UZU_ALWAYS_INLINE {
+          constexpr uint BIT = uint(i.value) * KV;
+          constexpr uint WORD = BIT >> 5u;
+          constexpr uint OFFSET = BIT & 31u;
+          // A window that straddles a word needs the next one, and it always
+          // exists: straddling means `32*(WORD+1) < BIT + L <= SPAN_BITS`.
+          static_assert(OFFSET == 0u || WORD + 1u < RUN_WORDS, "run is too short for its top window");
+          if constexpr (OFFSET == 0u) {
+            states[R][STATES_PER_LANE - 1u - uint(i.value)] = run[R][WORD] & state_mask;
+          } else {
+            states[R][STATES_PER_LANE - 1u - uint(i.value)] =
+                ((run[R][WORD] >> OFFSET) | (run[R][WORD + 1u] << (32u - OFFSET))) & state_mask;
+          }
+        });
+      } else {
+        const uint kv = trellis.k_bits_per_step;
+        // `window` is 64 bits wide, so this is what `spare` has to be lifted by
+        // to refill the bits `window` just shifted out. `KV >= 1`, so it is a
+        // legal shift.
+        const uint refill = 64u - kv;
+        ulong window = (ulong)run[R][0] | ((ulong)run[R][1] << 32);
+        ulong spare = (ulong)run[R][2] | ((ulong)run[R][3] << 32);
+        uzu::const_for_loop<0, int(STATES_PER_LANE), 1>([&](auto i) UZU_ALWAYS_INLINE {
+          states[R][STATES_PER_LANE - 1u - uint(i.value)] = uint(window) & state_mask;
+          window = (window >> kv) | (spare << refill);
+          spare >>= kv;
+        });
+      }
+    });
+
+    uzu::const_for_loop<0, int(STATES_PER_LANE), 1>([&](auto slot) UZU_ALWAYS_INLINE {
+      constexpr uint S = uint(decltype(slot)::value);
+      // One hash per state, then the table-free SWAR level map: four int8
+      // weights whose single scale rides on the row scale, so there is no
+      // per-weight multiply here at all.
+      float weights[Tile::ROWS_PER_LANE][V];
+      Tile::for_each_output_row([&](auto output_index) UZU_ALWAYS_INLINE {
+        constexpr uint R = decltype(output_index)::value;
+        const char4 levels = as_type<char4>(
+            uzu::trellis::map_bytes(uzu::trellis::state_hash(states[R][S], trellis.hash_a, trellis.hash_b))
+        );
+        uzu::const_for_loop<0, int(V), 1>([&](auto c)
+                                              UZU_ALWAYS_INLINE { weights[R][c.value] = float(levels[c.value]); });
+      });
+      Tile::for_each_input_row([&](auto input_index) UZU_ALWAYS_INLINE {
+        constexpr uint I = decltype(input_index)::value;
+        // Padding batch slots read the last real row rather than branching: the
+        // decode above is already paid, so their arithmetic is free and only the
+        // store is guarded.
+        const uint source_row = FULL_TILE ? I : min(I, batch_remaining - 1);
+        const device AT* input = ops.a + (tile.input_row + source_row) * params.in_vec_size + column + S * V;
+        const vec<AT, V> input_values = *reinterpret_cast<const device vec<AT, V>*>(input);
+        Tile::for_each_output_row([&](auto output_index) UZU_ALWAYS_INLINE {
+          constexpr uint R = decltype(output_index)::value;
+          uzu::const_for_loop<0, int(V), 1>([&](auto c) UZU_ALWAYS_INLINE {
+            partial[I][R] = fma(weights[R][c.value], float(input_values[c.value]), partial[I][R]);
+          });
+        });
+      });
+    });
+  }
+};
+
+} // namespace gemm
+} // namespace uzu

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/gemv.metal
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/gemv.metal
@@ -7,10 +7,19 @@
 #include "common/tile.h"
 #include "common/quant_b_source.h"
 #include "common/reduce.h"
+#include "common/trellis_b_source.h"
 
 using namespace metal;
 using namespace uzu;
 using namespace uzu::gemm;
+
+// A trellis tape is neither a dense operand nor a code array: its weights only
+// exist once a state has been hashed, and one scale covers a whole row. It is
+// therefore a third B source, sharing the tile geometry, the reduce and the
+// epilogue with the other two. `BITS` reports the width of what the decode
+// hands the accumulator and `GROUP_SIZE` is 0 because there is no quantization
+// group -- see `select_tile`, which is where those are chosen.
+#define GEMV_TRELLIS (B_PROLOGUE == GemmBPrologueKind::Trellis)
 
 template <
     typename AT,
@@ -35,7 +44,8 @@ VARIANTS(
     GemmBPrologueKind::FullPrecision,
     GemmBPrologueKind::ScaleBiasDequant,
     GemmBPrologueKind::ScaleZeroPointDequant,
-    GemmBPrologueKind::ScaleSymmetricDequant)
+    GemmBPrologueKind::ScaleSymmetricDequant,
+    GemmBPrologueKind::Trellis)
 VARIANTS(GROUP_SIZE, 0, 16, 32, 64, 128)
 VARIANTS(BITS, 0, 4, 8)
 VARIANTS(K_SPLIT, 1, 2, 4, 8)
@@ -47,11 +57,11 @@ VARIANTS(GROUP_LANES, 1, 2, 4, 8, 16)
 VARIANTS(NUM_SIMDGROUPS, 2, 4, 8)
 
 CONSTRAINT((B_PROLOGUE == GemmBPrologueKind::FullPrecision) == (BITS == 0))
-CONSTRAINT((BITS == 0) == (GROUP_SIZE == 0))
+CONSTRAINT(GEMV_TRELLIS || ((BITS == 0) == (GROUP_SIZE == 0)))
 CONSTRAINT(B_PROLOGUE == GemmBPrologueKind::FullPrecision || BT != "float")
 CONSTRAINT(BITS == 0 || K_SPLIT == 1)
 CONSTRAINT(BITS != 0 || (INPUT_ROW_TILE == 1 && REDUCTION_LANES == 32 && NUM_SIMDGROUPS == 8 && GROUP_LANES == 1))
-CONSTRAINT(INPUT_ROW_TILE != 1 || REDUCTION_LANES == 32)
+CONSTRAINT(GEMV_TRELLIS || INPUT_ROW_TILE != 1 || REDUCTION_LANES == 32)
 CONSTRAINT(
     INPUT_ROW_TILE == 1 ||
     (K_SPLIT == 1 && INPUT_ALIGNED && AT == "bfloat" && DT == "bfloat" && GROUP_LANES == 1))
@@ -61,7 +71,7 @@ CONSTRAINT(
 #define INPUT_ROWS(FIRST, LAST) (INPUT_ROW_TILE >= FIRST && INPUT_ROW_TILE <= LAST)
 
 CONSTRAINT(
-    INPUT_ROW_TILE == 1 ||
+    INPUT_ROW_TILE == 1 || GEMV_TRELLIS ||
     (((B_PROLOGUE == GemmBPrologueKind::ScaleSymmetricDequant && BITS == 8) ||
       (B_PROLOGUE == GemmBPrologueKind::ScaleZeroPointDequant && BITS == 4)) &&
      (GROUP_SIZE == 32 || GROUP_SIZE == 64) &&
@@ -75,7 +85,7 @@ CONSTRAINT(
 
 // Keep only selector-reachable geometry families.
 CONSTRAINT(
-    BITS == 0 ||
+    BITS == 0 || GEMV_TRELLIS ||
     (NUM_SIMDGROUPS == 2 &&
      (OUTPUT_ROW_TILE == 2 || OUTPUT_ROW_TILE == 4 || OUTPUT_ROW_TILE == 8 ||
       (INPUT_ROW_TILE > 1 && OUTPUT_ROW_TILE == 16))) ||
@@ -86,7 +96,7 @@ CONSTRAINT(
 CONSTRAINT(
     BITS == 0 || (AT == "bfloat" && DT == "bfloat") ||
     (NUM_SIMDGROUPS == 8 && OUTPUT_ROW_TILE == 32))
-CONSTRAINT(BITS != 8 || (NUM_SIMDGROUPS == 8 && OUTPUT_ROW_TILE == 32) || INPUT_ROW_TILE > 1)
+CONSTRAINT(GEMV_TRELLIS || BITS != 8 || (NUM_SIMDGROUPS == 8 && OUTPUT_ROW_TILE == 32) || INPUT_ROW_TILE > 1)
 CONSTRAINT(INPUT_ALIGNED || K_SPLIT == 1)
 CONSTRAINT(K_SPLIT <= NUM_SIMDGROUPS && NUM_SIMDGROUPS % K_SPLIT == 0)
 CONSTRAINT(OUTPUT_ROW_TILE % (NUM_SIMDGROUPS / K_SPLIT) == 0)
@@ -103,12 +113,26 @@ CONSTRAINT(BITS != 4 || (GROUP_SIZE / GROUP_LANES) % 16 == 0)
 CONSTRAINT(BITS != 8 || (GROUP_SIZE / GROUP_LANES) % 8 == 0)
 CONSTRAINT(BITS != 0 || REDUCTION_LANES == 32)
 CONSTRAINT(
-    BITS == 0 || INPUT_ROW_TILE > 1 || (BITS == 4 &&
+    BITS == 0 || GEMV_TRELLIS || INPUT_ROW_TILE > 1 || (BITS == 4 &&
      ((GROUP_SIZE == 16 && GROUP_LANES == 1) || (GROUP_SIZE == 32 && GROUP_LANES == 2) ||
       (GROUP_SIZE == 64 && GROUP_LANES == 4) || (GROUP_SIZE == 128 && GROUP_LANES == 8))) ||
     (BITS == 8 &&
      ((GROUP_SIZE == 16 && GROUP_LANES == 2) || (GROUP_SIZE == 32 && GROUP_LANES == 4) ||
       (GROUP_SIZE == 64 && GROUP_LANES == 8) || (GROUP_SIZE == 128 && GROUP_LANES == 16))))
+// The trellis family: THREE geometries split on the batch width, at input row
+// tiles 1, 2, 4 and 8 -- routing rounds M up to one of those, so nothing else is
+// reachable.  The exemptions above only remove the quantized families' geometry
+// rules from a prologue they were not written for; this is what pins the family
+// down.  `GemvSpecialization::select_shape`'s trellis arm is where each geometry
+// is CHOSEN and why; this must agree with it, and with `TrellisSlice`'s
+// `GROUP_LANES == 1` and whole-word block assertions.
+CONSTRAINT(
+    !GEMV_TRELLIS ||
+    (AT == "bfloat" && BT == "bfloat" && DT == "bfloat" && BITS == 8 && GROUP_SIZE == 0 && K_SPLIT == 1 &&
+     INPUT_ALIGNED && GROUP_LANES == 1 &&
+     ((GEMV_TILE(8, 32, 8) && (INPUT_ROW_TILE == 1 || INPUT_ROW_TILE == 2)) ||
+      (GEMV_TILE(16, 32, 8) && INPUT_ROW_TILE == 4) ||
+      (GEMV_TILE(16, 8, 2) && (INPUT_ROW_TILE == 1 || INPUT_ROW_TILE == 2 || INPUT_ROW_TILE == 8)))))
 KERNEL(Gemv)(
     const device uint32_t* b,
     const device BT* scales
@@ -131,6 +155,7 @@ KERNEL(Gemv)(
     const constant uint& group_count_x,
     const constant float& soft_cap
         OPTIONAL(output_transform.contains(GemmDTransform::SOFT_CAP)),
+    const constant uzu::matmul::TrellisParams& trellis OPTIONAL(GEMV_TRELLIS),
     const GemmDTransform output_transform SPECIALIZE,
     const bool gathered SPECIALIZE,
     const bool signed_codes SPECIALIZE,
@@ -152,7 +177,9 @@ KERNEL(Gemv)(
         OutputTile<Tile, FullTile>::make(output_tile_idx, input_tile_idx, simd_group, simd_lane, out_vec_size);
     thread float result[Tile::INPUT_ROWS][Tile::ROWS_PER_LANE] = {{0}};
 
-    if constexpr (BITS == 0) {
+    if constexpr (GEMV_TRELLIS) {
+      TrellisBSource<Tile, AT, BT, DT, INPUT_ALIGNED, FullTile>::accumulate(result, ops, params, tile, trellis);
+    } else if constexpr (BITS == 0) {
       FullPrecisionBSource<Tile, AT, BT, DT, INPUT_ALIGNED, FullTile>::accumulate(result, ops, params, tile);
     } else {
       QuantBSource<Tile, AT, BT, DT, B_PROLOGUE, GROUP_SIZE, BITS, INPUT_ALIGNED, FullTile>::accumulate(

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/kernel.rs
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/kernel.rs
@@ -1,6 +1,6 @@
 use metal::MTLGPUFamily;
 
-use super::policy::{self, DEFAULT_RESULTS_PER_SIMDGROUP, FP_K_BLOCK};
+use super::policy::{self, DEFAULT_RESULTS_PER_SIMDGROUP, FP_K_BLOCK, trellis_k_block};
 use crate::{
     backends::{
         common::{
@@ -8,7 +8,7 @@ use crate::{
                 HADAMARD_TRANSFORM_BLOCK_SIZE,
                 gemm::{GemmBPrologueKind, GemmDTransform},
             },
-            kernel::matmul::MatmulShape,
+            kernel::matmul::{MatmulShape, trellis_format::trellis_params},
         },
         metal::{context::MetalContext, error::MetalError, kernel::GemvMetalKernel},
     },
@@ -44,6 +44,59 @@ impl GemvSpecialization {
         gpu_core_count: u32,
         apple_gpu_family: MTLGPUFamily,
     ) -> Option<Self> {
+        // THREE trellis geometries. What the decode is short of below M = 5 is
+        // THREADS -- at M = 1 it issues ~9.5 instructions per weight against an
+        // `instruction_throughput_limiter` of 73% at 25% utilisation, and at
+        // M = 4 the two-simdgroup tile still measures 23% occupancy against a
+        // 33% target with 90 registers and no spill -- so those widths take a
+        // 32-lane, eight-simdgroup tile and only the weight rows per lane move:
+        //
+        //   * M <= 2 -- `(8, 32, 8)`: one output row per simdgroup, so a lane
+        //     owns ONE weight row. Nothing amortises across batch rows here, so
+        //     the narrowest tile that fills the machine wins.
+        //   * M = 3, 4 -- `(16, 32, 8)`: two output rows per simdgroup, so one
+        //     activation vector feeds two rows' worth of decode. Measured
+        //     against `(16, 8, 2)` at M = 4: -15.9% on out_proj and -2.3% on
+        //     in_proj, i.e. 1.104 -> 0.927 and 1.123 -> 1.100 against the
+        //     shipped INT4 route.
+        //   * M >= 5 -- `(16, 8, 2)`: past four batch rows the wide threadgroup
+        //     stops paying. The same A/B measured `(16, 32, 8)` 6% SLOWER at
+        //     M = 6 and M = 8 on in_proj and level on out_proj, so the batch
+        //     arm stays where round 10 left it.
+        //
+        // `(16, 8, 2)` is also the only tile for a K the 32-lane block does not
+        // divide. Must agree with `gemv.metal`'s trellis CONSTRAINT.
+        if shape.b_prologue == GemmBPrologueKind::Trellis {
+            if !(1..=GEMV_MAX_BATCH).contains(&shape.m) {
+                return None;
+            }
+            // Routing rounds M UP to a compiled width rather than compiling one
+            // per M: {1, 2, 4, 8} covers 1..=8 in four tiles instead of eight,
+            // and a padding row costs only its own arithmetic -- `TrellisSlice`
+            // clamps it onto the last real activation row and the epilogue does
+            // not store it.
+            let batch = shape.m.next_power_of_two();
+            // Thirty-two reduction lanes make one K block 512 values wide, so a
+            // K that is a whole number of 128s but not of 512s reaches neither
+            // 32-lane tile.
+            let wide_block = shape.k.is_multiple_of(trellis_k_block(32));
+            let tile = match batch {
+                1 | 2 if wide_block => policy::GemvTile::quantized_output_tile(8, 8, batch, 32, 1),
+                4 if wide_block => policy::GemvTile::quantized_output_tile(8, 16, batch, 32, 1),
+                // The eight-lane family is compiled at input row tiles 1, 2 and
+                // 8, so a batch of four that lands here walks the grid two rows
+                // at a time rather than costing a variant of its own.
+                _ => {
+                    let rows = if batch == GEMV_MAX_BATCH {
+                        batch
+                    } else {
+                        batch.min(2)
+                    };
+                    policy::GemvTile::quantized_output_tile(2, 16, rows, 8, 1)
+                },
+            };
+            return Self::select_tile(shape, weights_data_type, input_data_type, output_data_type, tile);
+        }
         let is_quant = shape.is_quant();
         let bits = shape.b_bits.unwrap_or(0);
         let bf16_io = input_data_type == DataType::BF16 && output_data_type == DataType::BF16;
@@ -102,6 +155,16 @@ impl GemvSpecialization {
         if shape.d_transform.contains(GemmDTransform::ACCUMULATE) && !shape.n.is_multiple_of(32) {
             return None;
         }
+        let trellis = shape.b_prologue == GemmBPrologueKind::Trellis;
+        if trellis
+            && (shape.gathered
+                || shape.m > GEMV_MAX_BATCH
+                || shape.d_transform.contains(GemmDTransform::RHT)
+                || !shape.k.is_multiple_of(trellis_k_block(tile.reduction_lanes))
+                || [weights_data_type, input_data_type, output_data_type] != [DataType::BF16; 3])
+        {
+            return None;
+        }
         let bits = shape.b_bits.unwrap_or(0);
         if !is_quant {
             let mixed_precision = weights_data_type == DataType::F32
@@ -112,6 +175,8 @@ impl GemvSpecialization {
         }
         let block_size = if !is_quant {
             FP_K_BLOCK
+        } else if trellis {
+            trellis_k_block(tile.reduction_lanes)
         } else if bits == 4 {
             512
         } else {
@@ -124,7 +189,14 @@ impl GemvSpecialization {
         }
         let specialization = Self {
             b_prologue: shape.b_prologue,
-            group_size: shape.b_group_size.unwrap_or(0),
+            // A tape has one scale per ROW, so the GEMV has no group at all. The
+            // 64 the host reports is the GEMM's staging block (`TRELLIS_BLOCK_K`),
+            // which this path does not stage.
+            group_size: if trellis {
+                0
+            } else {
+                shape.b_group_size.unwrap_or(0)
+            },
             bits,
             output_transform: shape.d_transform,
             input_aligned,
@@ -143,6 +215,12 @@ impl GemvSpecialization {
 
     pub fn output_row_tile(&self) -> u32 {
         self.output_row_tile
+    }
+
+    /// Only the trellis routing test reads this.
+    #[cfg(test)]
+    pub fn reduction_lanes(&self) -> u32 {
+        self.reduction_lanes
     }
 
     fn create_pipeline(
@@ -277,7 +355,13 @@ impl GemvKernel {
                 zero_points,
                 ..
             } => (Some(*scales), Some(*zero_points), None),
+            // A trellis tape is the `b` buffer and its per-row scales are the
+            // `scales` buffer, so its residency is the symmetric path's.
             MatmulB::ScaleSymmetricDequant {
+                scales,
+                ..
+            }
+            | MatmulB::Trellis {
                 scales,
                 ..
             } => (Some(*scales), None, None),
@@ -305,6 +389,7 @@ impl GemvKernel {
                 ab_scale,
                 output_group_count,
                 soft_cap,
+                None,
                 encoder,
             ),
             MatmulB::ScaleBiasDequant {
@@ -334,10 +419,45 @@ impl GemvKernel {
                 ab_scale,
                 output_group_count,
                 soft_cap,
+                None,
                 encoder,
             ),
+            MatmulB::Trellis {
+                b: weights,
+                config,
+                ..
+            } => {
+                let Some(params) = trellis_params(config, k) else {
+                    return Err(MatmulError::UnsupportedLayout {
+                        path: "Gemv trellis",
+                    });
+                };
+                pipeline.encode(
+                    weights,
+                    scales,
+                    zero_points,
+                    biases,
+                    (a, a_offset),
+                    &mut *d,
+                    output_bias,
+                    rht_factors,
+                    gather_indices,
+                    k,
+                    n,
+                    m,
+                    ab_scale,
+                    output_group_count,
+                    soft_cap,
+                    Some(params),
+                    encoder,
+                )
+            },
         }
 
         Ok(())
     }
 }
+
+#[cfg(test)]
+#[path = "../../../../../../unit/backends/metal/kernel/matmul/gemv/trellis_test.rs"]
+mod trellis_tests;

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/policy.rs
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/policy.rs
@@ -53,6 +53,14 @@ const fn tile(
 
 pub(super) const DEFAULT_TILE: GemvTile = tile(DEFAULT_NUM_SIMDGROUPS, 1, DEFAULT_RESULTS_PER_SIMDGROUP);
 
+/// K values one trellis threadgroup step covers: `reduction_lanes *
+/// states_per_lane(4) * weights_per_state(4)`. `TrellisSlice` assumes K is a
+/// whole number of these, which is also what makes the tape advance by whole
+/// 32-bit words.
+pub(super) const fn trellis_k_block(reduction_lanes: u32) -> u32 {
+    reduction_lanes * 16
+}
+
 impl GemvTile {
     pub const fn quantized(
         num_simdgroups: u32,

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/mod.rs
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/mod.rs
@@ -33,7 +33,11 @@ pub struct MatmulMetalKernel {
     output_data_type: DataType,
 }
 
-enum MatmulDispatch {
+/// What a shape actually routes to. `pub` and `Debug` so the trellis
+/// bench can ASSERT and PRINT the plan a cell takes, rather than deriving it a
+/// second time from the same policy code.
+#[derive(Debug)]
+pub enum MatmulDispatch {
     Gemv(GemvSpecialization),
     Gemm(GemmPlan),
 }
@@ -47,6 +51,14 @@ impl MatmulMetalKernel {
         output_data_type: DataType,
     ) -> bool {
         if shape.gathered || plan.engine != gemm::GemmEngine::Mxu {
+            return false;
+        }
+        // Trellis decode costs ~9 instructions per weight, so the batch widths
+        // below are exactly where keeping the weights in registers pays; the
+        // thresholds here were measured against INT4/INT8 codes and say nothing
+        // about a tape. The GEMM takes over at M > GEMV_MAX_BATCH, where
+        // `GemvSpecialization::select_shape` stops returning a tile.
+        if shape.b_prologue == GemmBPrologueKind::Trellis {
             return false;
         }
         match (shape.m, shape.n == shape.k, (weights_data_type, input_data_type, output_data_type)) {
@@ -98,7 +110,14 @@ impl MatmulMetalKernel {
             gpu_core_count,
             apple_gpu_family,
         );
-        let problem = GemmProblem::new(*shape, weights_data_type, output_data_type, supports_mxu, apple_gpu_family);
+        let problem = GemmProblem::new(
+            *shape,
+            weights_data_type,
+            output_data_type,
+            supports_mxu,
+            apple_gpu_family,
+            gpu_core_count,
+        );
         let plan = problem.select_plan();
         match gemv {
             None => MatmulDispatch::Gemm(plan),
@@ -111,7 +130,7 @@ impl MatmulMetalKernel {
         }
     }
 
-    fn select_dispatch(
+    pub fn select_dispatch(
         &self,
         shape: &MatmulShape,
         context: &MetalContext,
@@ -181,7 +200,8 @@ impl MatmulKernel for MatmulMetalKernel {
         }
 
         let sum_group_size = match shape.b_prologue {
-            GemmBPrologueKind::ScaleSymmetricDequant => None,
+            // Symmetric weights: no zero point, so no group sums to correct with.
+            GemmBPrologueKind::ScaleSymmetricDequant | GemmBPrologueKind::Trellis => None,
             GemmBPrologueKind::ScaleBiasDequant | GemmBPrologueKind::ScaleZeroPointDequant => {
                 Some(weight_group_size.min(activation_group_size))
             },

--- a/crates/uzu-engine/src/backends/metal/mod.rs
+++ b/crates/uzu-engine/src/backends/metal/mod.rs
@@ -4,7 +4,7 @@ mod command_buffer;
 mod context;
 mod dense_buffer;
 mod error;
-mod kernel;
+pub mod kernel;
 mod metal_extensions;
 mod sparse;
 

--- a/crates/uzu-engine/unit/backends/common/kernel/matmul/mod.rs
+++ b/crates/uzu-engine/unit/backends/common/kernel/matmul/mod.rs
@@ -6,3 +6,5 @@ mod quant_dispatch_test;
 mod quant_gemm_bench;
 mod quant_gemv_bench;
 mod qwen3_bench;
+mod trellis_bench;
+mod trellis_format_test;

--- a/crates/uzu-engine/unit/backends/common/kernel/matmul/trellis_bench.rs
+++ b/crates/uzu-engine/unit/backends/common/kernel/matmul/trellis_bench.rs
@@ -1,0 +1,532 @@
+#![cfg(backend = "metal")]
+
+//! `Metal/Kernel/TrellisGemm` and `Metal/Kernel/TrellisGemv` — the trellis
+//! weight format against the INT4 route it would replace, at prefill and at
+//! decode batch widths.
+//!
+//! WHAT IS BEING COMPARED. The INT4 cell is the SHIPPED production dispatch —
+//! g32 `ScaleZeroPoint` weights through `MatmulKernel::encode`, i.e. exactly
+//! what a model runs today at these batch widths — and `trellis` is
+//! `MatmulB::Trellis` through the same entry point. `bf16` is the dense
+//! reference at the same shape. All cells of one `(shape, M)` are adjacent in
+//! time and every conclusion is a within-`(shape, M)` ratio.
+//!
+//! THE GEMM CELLS PAY THE ACTIVATION QUANTIZE, the GEMV cells do not, because
+//! that is what production does: `select_activation_format` keeps `M <= 8` on
+//! bf16 and quantizes above it. `MatmulKernel::encode` does not own that pass,
+//! so each GEMM cell encodes `ActivationTransform::encode_quantize` and then the
+//! GEMM. The two GEMM cells differ in one place the format forces:
+//! `ScaleZeroPoint` weights carry a zero point, so their quantize also emits
+//! activation row sums; a trellis tape is symmetric and does not. The RHT is
+//! excluded from both — trellis weights are fitted on rotated weights, so the
+//! rotation is an upstream dispatch both formats need equally.
+//!
+//! PROTOCOL, because this machine punishes anything looser:
+//!
+//! * the caller leaves the GPU quiet (`ps -Ao comm= | grep -E 'uzu_engine-|gpudebug'`
+//!   empty for >= 150 s) before every pass, and samples it continuously during;
+//! * [`SETTLE`] of untimed dense GPU work before the first timed cell, so the
+//!   clocks are off the post-idle boost. 45 s was not enough: round 7's first
+//!   pass measured its start anchor 4.1% slower than its end anchor ten minutes
+//!   later, i.e. the machine was still speeding up while the first cells ran;
+//! * every weight buffer rotates through a [`ColdPool`], so no tape, weight
+//!   block or dense matrix is cache-resident when a cell reads it;
+//! * a [`CELL_COOLDOWN`] idle after every cell;
+//! * a bf16 dense THERMAL ANCHOR first and last, named `anchor_bf16_start` /
+//!   `anchor_bf16_end` so that a criterion filter listing the variants picks
+//!   them up. If the two medians differ by more than 3% the pass drifted and is
+//!   discarded, not averaged;
+//! * every cell registered through [`cell`], which names its benchmark path so
+//!   `UZU_CAPTURE_BENCH` can capture it.
+//!
+//! ```text
+//! cargo bench -p uzu-engine --lib -- "Metal/Kernel/Trellis"
+//! ```
+
+use std::{
+    sync::Arc,
+    thread::sleep,
+    time::{Duration, Instant},
+};
+
+use criterion::{BenchmarkGroup, BenchmarkId, Criterion, measurement::WallTime};
+use half::bf16;
+use uzu_engine_macros::uzu_bench;
+
+use crate::{
+    array::ArrayElement,
+    backends::{
+        common::{
+            Allocation, Backend, Encoder,
+            gpu_types::QuantizationMethod,
+            kernel::{
+                ActivationTransform, Kernels,
+                activation_transform::ACTIVATION_SCALE_GROUP_SIZE,
+                matmul::{
+                    MatmulA, MatmulArguments, MatmulB, MatmulDOps, MatmulKernel, MatmulShape,
+                    trellis_format::{TrellisConfig, TrellisTape},
+                },
+            },
+        },
+        metal::{Metal, MetalContext, kernel::matmul::MatmulDispatch},
+    },
+    data_type::DataType,
+    tests::{
+        cold_pool::ColdPool,
+        helpers::{alloc_allocation, alloc_allocation_with_data},
+        matmul::{QuantBuffers, QuantInput, iter_encode_loop_named, quant_arguments},
+        util::{shared_metal_context, type_short_name},
+    },
+};
+
+// ---------------------------------------------------------------------------
+// protocol
+// ---------------------------------------------------------------------------
+
+type MetalMatmul = <<Metal as Backend>::Kernels as Kernels>::MatmulKernel;
+/// A weight buffer that rotates through enough copies to stay out of the
+/// system level cache.
+type Pool = ColdPool<Allocation<Metal>, Box<dyn FnMut() -> Allocation<Metal>>>;
+
+const SETTLE: Duration = Duration::from_secs(120);
+const CELL_COOLDOWN: Duration = Duration::from_secs(2);
+
+fn cold_pool<T: ArrayElement>(
+    context: &Arc<MetalContext>,
+    data: Vec<T>,
+) -> Pool {
+    let bytes = size_of_val(data.as_slice());
+    let pool_context = context.clone();
+    ColdPool::new(bytes, Box::new(move || alloc_allocation_with_data::<Metal, T>(&pool_context, &data)))
+}
+
+/// Register one timed cell and cool down after it. `name` becomes both the
+/// criterion parameter and the tail of the capture path.
+fn cell<F>(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    context: &MetalContext,
+    group_path: &str,
+    name: &str,
+    mut body: F,
+) where
+    F: FnMut(&mut Encoder<Metal>),
+{
+    group.bench_function(BenchmarkId::from_parameter(name), |bencher| {
+        let benchmark_path = format!("{group_path}/{name}");
+        iter_encode_loop_named::<Metal, _>(context, bencher, &benchmark_path, |encoder| body(encoder));
+    });
+    sleep(CELL_COOLDOWN);
+}
+
+/// Print, and assert, the dispatch a cell actually takes.
+///
+/// A plan table DERIVED from the same policy code the kernel runs is not
+/// evidence. This reads the plan back through `MatmulKernel::select_dispatch`
+/// for the exact arguments the cell encodes, so the tile, the engine and the
+/// split-K in any report are the ones the GPU ran, and a cell that silently
+/// routes to the other path fails here instead of being reported under the
+/// wrong heading.
+fn report_plan(
+    context: &MetalContext,
+    matmul: &MetalMatmul,
+    label: &str,
+    shape: &MatmulShape,
+    expect_gemm: bool,
+) {
+    let dispatch = matmul.select_dispatch(shape, context);
+    println!("PLAN {label}: {dispatch:?}");
+    assert_eq!(matches!(dispatch, MatmulDispatch::Gemm(_)), expect_gemm, "{label} routed to the wrong path");
+}
+
+fn fill(
+    count: usize,
+    phase: usize,
+) -> Vec<bf16> {
+    (0..count).map(|i| bf16::from_f32((((i + phase) % 13) as f32) * 0.01 - 0.06)).collect()
+}
+
+/// A dense bf16 matmul at one shape, with the weight matrix rotating cold. Used
+/// both as the anchor and as the 16-bits-per-weight reference.
+struct DenseCell {
+    weights: Pool,
+    a: Allocation<Metal>,
+    d: Allocation<Metal>,
+    m: u32,
+    n: u32,
+    k: u32,
+}
+
+impl DenseCell {
+    fn new(
+        context: &Arc<MetalContext>,
+        m: u32,
+        n: u32,
+        k: u32,
+    ) -> Self {
+        Self {
+            weights: cold_pool(context, fill((n * k) as usize, 5)),
+            a: alloc_allocation_with_data::<Metal, bf16>(context, &fill((m * k) as usize, 0)),
+            d: alloc_allocation::<Metal, bf16>(context, (m * n) as usize),
+            m,
+            n,
+            k,
+        }
+    }
+
+    fn arguments(&mut self) -> MatmulArguments<'_, '_, '_, Metal> {
+        MatmulArguments {
+            a: MatmulA::FullPrecision {
+                values: &self.a,
+                offset: 0,
+            },
+            b: MatmulB::FullPrecision {
+                b: self.weights.next_mut(),
+            },
+            b_leading_dimension: None,
+            b_transpose: true,
+            d: &mut self.d,
+            d_transform: MatmulDOps::none(),
+            gather_indices: None,
+            m: self.m,
+            n: self.n,
+            k: self.k,
+        }
+    }
+}
+
+/// The bf16 dense thermal anchor, registered first and last in a pass.
+///
+/// `settle_first` runs [`SETTLE`] of untimed dense work INSIDE the closure that
+/// criterion only calls for a benchmark it actually selected — criterion filters
+/// at the MEASUREMENT, not at the bench function, so a settle in the bench body
+/// would burn two minutes of a shared GPU for a bench nobody asked for. It runs
+/// ONCE: criterion invokes that closure again for every sample
+/// (`iter_encode_loop_named` uses `iter_custom`), so an unguarded settle here
+/// would run 21 times — 42 minutes, not two.
+#[allow(clippy::too_many_arguments)]
+fn anchor_cell(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    context: &Arc<MetalContext>,
+    group_path: &str,
+    name: &str,
+    matmul: &mut MetalMatmul,
+    m: u32,
+    n: u32,
+    k: u32,
+    settle_first: bool,
+) {
+    let mut anchor = DenseCell::new(context, m, n, k);
+    let mut settled = false;
+    group.bench_function(BenchmarkId::from_parameter(name), |bencher| {
+        if settle_first && !settled {
+            settled = true;
+            let mut settle = DenseCell::new(context, 128, n, k);
+            let start = Instant::now();
+            while start.elapsed() < SETTLE {
+                let mut encoder = Encoder::<Metal>::new(context).unwrap();
+                for _ in 0..16 {
+                    matmul.encode(settle.arguments(), &mut encoder).expect("settle encode failed");
+                }
+                encoder.end_encoding().submit().wait_until_completed().unwrap();
+            }
+        }
+        let benchmark_path = format!("{group_path}/{name}");
+        iter_encode_loop_named::<Metal, _>(context, bencher, &benchmark_path, |encoder| {
+            matmul.encode(anchor.arguments(), encoder).expect("bf16 anchor");
+        });
+    });
+    sleep(CELL_COOLDOWN);
+}
+
+// ---------------------------------------------------------------------------
+// the trellis cell
+// ---------------------------------------------------------------------------
+
+/// The config the prototype study benchmarked: `k = 3`, so 3 bits per weight
+/// plus a 32-bit header per row.
+const CONFIG: TrellisConfig = TrellisConfig::new(32, 3);
+
+/// `(label, N, K)`, named after the Qwen3.6-27B matrices they come from: the
+/// two starved N = 5120 matrices, the wide one, and the one the GEMM tile
+/// target leaves completely unsplit.
+const SHAPES: [(&str, u32, u32); 4] = [
+    ("in_proj_16480x5120", 16480, 5120),
+    ("mlp_down_5120x17408", 5120, 17408),
+    ("out_proj_5120x6144", 5120, 6144),
+    ("mlp_up_34816x5120", 34816, 5120),
+];
+
+/// The production INT4 weight group.
+const GROUP_SIZE: u32 = 32;
+
+/// The int8 activation-quantize pass, plus the identity RHT factors it reads.
+struct ActivationQuantize {
+    transform: ActivationTransform<Metal>,
+    factors: Allocation<Metal>,
+}
+
+impl ActivationQuantize {
+    /// `sum_group_size` is `None` for symmetric weights and
+    /// `Some(min(weight_group, ACTIVATION_SCALE_GROUP_SIZE))` for weights
+    /// carrying a zero point, whose GEMM reads activation row sums.
+    fn new(
+        context: &MetalContext,
+        sum_group_size: Option<u32>,
+        k: u32,
+    ) -> Self {
+        Self {
+            transform: ActivationTransform::<Metal>::quantize(
+                context,
+                DataType::BF16,
+                ACTIVATION_SCALE_GROUP_SIZE,
+                sum_group_size,
+            )
+            .expect("activation quantize transform"),
+            factors: alloc_allocation_with_data::<Metal, i32>(context, &vec![1i32; k as usize]),
+        }
+    }
+}
+
+/// The tape, its per-row scales, and the activations.
+///
+/// `quantize` is present exactly when the cell feeds the int8 GEMM; without it
+/// the cell hands the GEMV bf16 activations, which is what production does
+/// below `M = 9`. Only the tape rotates through the cold pool: it is the only
+/// buffer big enough to matter.
+struct TrellisCell {
+    tapes: Pool,
+    row_scales: Allocation<Metal>,
+    quantize: Option<ActivationQuantize>,
+    a_bf16: Allocation<Metal>,
+    a_int8: Allocation<Metal>,
+    a_scales: Allocation<Metal>,
+    d: Allocation<Metal>,
+    m: u32,
+    n: u32,
+    k: u32,
+}
+
+impl TrellisCell {
+    fn new(
+        context: &Arc<MetalContext>,
+        m: u32,
+        n: u32,
+        k: u32,
+        int8_activations: bool,
+    ) -> Self {
+        let words = TrellisTape::random(CONFIG, n, k, 0x1234_5EED).words;
+        let row_scales: Vec<bf16> = (0..n).map(|r| bf16::from_f32(0.002 + 0.001 * ((r % 19) as f32) / 19.0)).collect();
+        Self {
+            tapes: cold_pool(context, words),
+            row_scales: alloc_allocation_with_data::<Metal, bf16>(context, &row_scales),
+            quantize: int8_activations.then(|| ActivationQuantize::new(context, None, k)),
+            a_bf16: alloc_allocation_with_data::<Metal, bf16>(context, &fill((m * k) as usize, 0)),
+            a_int8: alloc_allocation::<Metal, i8>(context, (m * k) as usize),
+            a_scales: alloc_allocation::<Metal, f32>(context, (m * (k / ACTIVATION_SCALE_GROUP_SIZE)) as usize),
+            d: alloc_allocation::<Metal, bf16>(context, (m * n) as usize),
+            m,
+            n,
+            k,
+        }
+    }
+
+    fn arguments(&mut self) -> MatmulArguments<'_, '_, '_, Metal> {
+        let a = if self.quantize.is_some() {
+            MatmulA::Int8Symmetric {
+                values: &self.a_int8,
+                scales: &self.a_scales,
+                group_sums: None,
+                group_size: ACTIVATION_SCALE_GROUP_SIZE,
+            }
+        } else {
+            MatmulA::FullPrecision {
+                values: &self.a_bf16,
+                offset: 0,
+            }
+        };
+        MatmulArguments {
+            a,
+            b: MatmulB::Trellis {
+                b: self.tapes.next_mut(),
+                scales: &self.row_scales,
+                config: CONFIG,
+            },
+            b_leading_dimension: None,
+            b_transpose: true,
+            d: &mut self.d,
+            d_transform: MatmulDOps::none(),
+            gather_indices: None,
+            m: self.m,
+            n: self.n,
+            k: self.k,
+        }
+    }
+
+    fn shape(&mut self) -> MatmulShape {
+        MatmulShape::from_arguments(&self.arguments())
+    }
+
+    /// The whole cell: the activation quantize where production pays one, then
+    /// the matmul.
+    fn encode(
+        &mut self,
+        matmul: &mut MetalMatmul,
+        encoder: &mut Encoder<Metal>,
+    ) {
+        if let Some(quantize) = self.quantize.as_ref() {
+            quantize.transform.encode_quantize(
+                &self.a_bf16,
+                &mut self.a_int8,
+                &mut self.a_scales,
+                None,
+                &quantize.factors,
+                self.m,
+                self.k,
+                encoder,
+            );
+        }
+        matmul.encode(self.arguments(), encoder).expect("trellis matmul");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// the two passes
+// ---------------------------------------------------------------------------
+
+/// Prefill widths: the trellis GEMM against the shipped a8w4 GEMM.
+#[uzu_bench]
+fn bench_trellis_gemm(c: &mut Criterion) {
+    let context = shared_metal_context();
+    if !context.supports_mxu {
+        return;
+    }
+    let group_path = format!("{}/Kernel/TrellisGemm", type_short_name::<Metal>());
+    let mut matmul =
+        MetalMatmul::new(&context, bf16::data_type(), bf16::data_type(), bf16::data_type()).expect("MatmulKernel");
+
+    let mut group = c.benchmark_group(group_path.clone());
+    group.sample_size(20);
+    group.warm_up_time(Duration::from_millis(500));
+    group.measurement_time(Duration::from_secs(2));
+
+    // in_proj at M = 32, the middle of the swept batch widths.
+    let (anchor_label, anchor_n, anchor_k) = SHAPES[0];
+    let anchor_m = 32u32;
+    let anchor = |group: &mut BenchmarkGroup<'_, WallTime>, matmul: &mut MetalMatmul, edge: &str, settle: bool| {
+        let name = format!("anchor_bf16_{edge}/{anchor_label}/M{anchor_m}");
+        anchor_cell(group, &context, &group_path, &name, matmul, anchor_m, anchor_n, anchor_k, settle);
+    };
+    anchor(&mut group, &mut matmul, "start", true);
+
+    for (label, n, k) in SHAPES {
+        for m in [16u32, 32, 64] {
+            {
+                let mut trellis = TrellisCell::new(&context, m, n, k, true);
+                report_plan(&context, &matmul, &format!("trellis/{label}/M{m}"), &trellis.shape(), true);
+                cell(&mut group, &context, &group_path, &format!("trellis/{label}/M{m}"), |encoder| {
+                    trellis.encode(&mut matmul, encoder);
+                });
+            }
+
+            // The shipped INT4 dispatch, routed, with its own activation
+            // quantize. `ScaleZeroPoint` weights read activation row sums, so
+            // this pass emits them; `a8_activation_plan` sizes that group as
+            // `min(weight_group, activation_group)`.
+            {
+                let sum_group_size = GROUP_SIZE.min(ACTIVATION_SCALE_GROUP_SIZE);
+                let input = QuantInput::<bf16>::new(m, k, n, GROUP_SIZE, 4, QuantizationMethod::ScaleZeroPoint, 42)
+                    .with_prepared_a(ACTIVATION_SCALE_GROUP_SIZE, Some(sum_group_size));
+                let quantize = ActivationQuantize::new(&context, Some(sum_group_size), k);
+                let mut pool = ColdPool::new(input.weight_buffer_bytes(), || {
+                    QuantBuffers::<Metal, bf16>::allocate(&context, &input)
+                });
+                report_plan(
+                    &context,
+                    &matmul,
+                    &format!("a8w4/{label}/M{m}"),
+                    &MatmulShape::from_arguments(&quant_arguments(pool.next_mut(), &input)),
+                    true,
+                );
+                cell(&mut group, &context, &group_path, &format!("a8w4/{label}/M{m}"), |encoder| {
+                    let buffers = pool.next_mut();
+                    quantize.transform.encode_quantize(
+                        &buffers.x,
+                        buffers.prepared_a.as_mut().expect("prepared activations"),
+                        buffers.prepared_a_scales.as_mut().expect("prepared activation scales"),
+                        buffers.prepared_a_group_sums.as_mut(),
+                        &quantize.factors,
+                        m,
+                        k,
+                        encoder,
+                    );
+                    matmul.encode(quant_arguments(buffers, &input), encoder).expect("a8w4 GEMM");
+                });
+            }
+
+            {
+                let mut dense = DenseCell::new(&context, m, n, k);
+                cell(&mut group, &context, &group_path, &format!("bf16/{label}/M{m}"), |encoder| {
+                    matmul.encode(dense.arguments(), encoder).expect("bf16 GEMM");
+                });
+            }
+        }
+    }
+
+    anchor(&mut group, &mut matmul, "end", false);
+}
+
+/// Decode widths: the trellis GEMV against the shipped W4 zero-point G32 qmv
+/// route — the one `qmv/routes.rs` is tuned for at these exact shapes, and the
+/// number the trellis GEMV has to beat to be worth its ~9 instructions per
+/// weight. `bf16_dense` is the bandwidth ceiling at 16 bits per weight.
+#[uzu_bench]
+fn bench_trellis_gemv(c: &mut Criterion) {
+    let context = shared_metal_context();
+    let group_path = format!("{}/Kernel/TrellisGemv", type_short_name::<Metal>());
+    let mut matmul =
+        MetalMatmul::new(&context, bf16::data_type(), bf16::data_type(), bf16::data_type()).expect("MatmulKernel");
+
+    let mut group = c.benchmark_group(group_path.clone());
+    group.sample_size(20);
+    group.warm_up_time(Duration::from_millis(500));
+    group.measurement_time(Duration::from_secs(2));
+
+    let (anchor_label, anchor_n, anchor_k) = SHAPES[0];
+    let anchor_m = 1u32;
+    let anchor = |group: &mut BenchmarkGroup<'_, WallTime>, matmul: &mut MetalMatmul, edge: &str, settle: bool| {
+        let name = format!("anchor_bf16_{edge}/{anchor_label}/M{anchor_m}");
+        anchor_cell(group, &context, &group_path, &name, matmul, anchor_m, anchor_n, anchor_k, settle);
+    };
+    anchor(&mut group, &mut matmul, "start", true);
+
+    for (label, n, k) in SHAPES {
+        for m in [1u32, 2, 4, 6, 8] {
+            {
+                let mut trellis = TrellisCell::new(&context, m, n, k, false);
+                report_plan(&context, &matmul, &format!("trellis/{label}/M{m}"), &trellis.shape(), false);
+                cell(&mut group, &context, &group_path, &format!("trellis/{label}/M{m}"), |encoder| {
+                    trellis.encode(&mut matmul, encoder);
+                });
+            }
+
+            {
+                let input = QuantInput::<bf16>::new(m, k, n, GROUP_SIZE, 4, QuantizationMethod::ScaleZeroPoint, 42);
+                let mut pool = ColdPool::new(input.weight_buffer_bytes(), || {
+                    QuantBuffers::<Metal, bf16>::allocate(&context, &input)
+                });
+                cell(&mut group, &context, &group_path, &format!("int4_auto/{label}/M{m}"), |encoder| {
+                    matmul.encode(quant_arguments(pool.next_mut(), &input), encoder).expect("int4 GEMV");
+                });
+            }
+
+            {
+                let mut dense = DenseCell::new(&context, m, n, k);
+                cell(&mut group, &context, &group_path, &format!("bf16_dense/{label}/M{m}"), |encoder| {
+                    matmul.encode(dense.arguments(), encoder).expect("bf16 GEMV");
+                });
+            }
+        }
+    }
+
+    anchor(&mut group, &mut matmul, "end", false);
+}

--- a/crates/uzu-engine/unit/backends/common/kernel/matmul/trellis_format_test.rs
+++ b/crates/uzu-engine/unit/backends/common/kernel/matmul/trellis_format_test.rs
@@ -1,0 +1,198 @@
+//! Cross-checks of the Rust trellis format port against the Python oracle.
+//!
+//! Three things need pinning, and they are pinned separately because they can
+//! drift separately: the TAPE LAYOUT (packing v2 — a change here makes uzu read
+//! an exported model's bytes wrong), the STATE HASH (the codebook was fitted
+//! with it), and the LEVEL MAP (a change here silently stops the codebook being
+//! unit variance).
+
+use uzu_engine_macros::uzu_test;
+
+use crate::backends::common::kernel::matmul::trellis_format::*;
+
+/// One row of `mad1_golden.json`, dumped from `qtip/oracle.py` by
+/// `tools/qtip_dump_golden.py` at the shipped `L = 32, V = 4, k = 3`: the packed
+/// tape bytes and the 17 states Python reads back out of them.
+///
+/// Kept as bytes rather than as a re-packing, because what needs pinning is that
+/// uzu's READ of an exported tape agrees with Python's WRITE of it. uzu never
+/// writes a production tape.
+const GOLDEN_TAPE: &str = "ddaff0c82b87c44e1b5f5b3e1155aa14f1fc7060c927348522e27966";
+const GOLDEN_STATES: [u32; 17] = [
+    0x6679_e222,
+    0x9e22_2853,
+    0x2285_3427,
+    0x5342_7c96,
+    0x27c9_6070,
+    0x9607_0fcf,
+    0x70fc_f114,
+    0xcf11_4aa5,
+    0x14aa_5511,
+    0xa551_13e5,
+    0x113e_5b5f,
+    0xe5b5_f1b4,
+    0x5f1b_4ec4,
+    0xb4ec_4872,
+    0xc487_2bc8,
+    0x72bc_8f0a,
+    0xc8f0_afdd,
+];
+
+#[uzu_test]
+fn tape_layout_matches_python_oracle() {
+    let config = TrellisConfig::new(32, 3);
+    let cols = GOLDEN_STATES.len() as u32 * TRELLIS_V;
+    let bytes: Vec<u8> =
+        (0..GOLDEN_TAPE.len() / 2).map(|i| u8::from_str_radix(&GOLDEN_TAPE[2 * i..2 * i + 2], 16).unwrap()).collect();
+    assert_eq!(config.bytes_per_row(cols) as usize, bytes.len(), "rate formula disagrees with the fixture");
+
+    let stride = config.row_stride_words(cols) as usize;
+    let mut words = vec![0u32; stride];
+    for (index, chunk) in bytes.chunks(4).enumerate() {
+        let mut padded = [0u8; 4];
+        padded[..chunk.len()].copy_from_slice(chunk);
+        words[index] = u32::from_le_bytes(padded);
+    }
+    let tape = TrellisTape {
+        config,
+        rows: 1,
+        cols,
+        words,
+    };
+
+    // The one-shift window read packing v2 exists for, and the trellis
+    // recurrence. Both must reproduce Python, and each other.
+    assert_eq!(tape.states(), GOLDEN_STATES, "window read");
+    assert_eq!(tape.states_by_recurrence(), GOLDEN_STATES, "recurrence");
+}
+
+/// `state_hash` against the Python oracle it was fitted with.
+///
+/// The fixture is dumped from `run_e6.py` driven by OUR hash, as the four bytes
+/// PR #800's `q2dither` map induces — that map is not what uzu ships, so the
+/// four lines that reproduce it live here rather than in the format module, and
+/// what this pins is [`state_hash`], and the `hash_params` pair it is called with. The dump script itself checks all `2**16`
+/// states run_e6 can enumerate; these 85 are what that check leaves behind.
+const STATE_HASH_PYTHON_GOLDEN: [(u32, u32); 85] = [
+    (0, 0xe7ef_0421),
+    (733, 0xeddf_fbf5),
+    (1466, 0xf90c_e50b),
+    (2199, 0xc2f6_1602),
+    (2932, 0x2ee9_0fc7),
+    (3665, 0xfcf5_2df3),
+    (4398, 0x082e_d2f8),
+    (5131, 0xfa03_2d00),
+    (5864, 0x0be3_1cdb),
+    (6597, 0x1700_1dea),
+    (7330, 0x1823_061a),
+    (8063, 0xfefc_f44f),
+    (8796, 0x0cec_fadd),
+    (9529, 0x1704_041b),
+    (10262, 0x39d8_1a04),
+    (10995, 0xeaf1_010c),
+    (11728, 0x26fe_00ea),
+    (12461, 0x1609_d230),
+    (13194, 0x07e6_fbfa),
+    (13927, 0xbce6_fa0b),
+    (14660, 0xfd09_eff7),
+    (15393, 0xd019_01eb),
+    (16126, 0x2828_001a),
+    (16859, 0xd803_13fb),
+    (17592, 0x1408_f012),
+    (18325, 0x1500_ff0a),
+    (19058, 0xfb1d_03e5),
+    (19791, 0xe8fb_05ee),
+    (20524, 0x01e5_f639),
+    (21257, 0xe6da_2306),
+    (21990, 0x1afc_1417),
+    (22723, 0xee2e_17df),
+    (23456, 0x4ffc_fbd2),
+    (24189, 0xfa11_f30d),
+    (24922, 0x1e30_f516),
+    (25655, 0xfded_1814),
+    (26388, 0x04e6_23fe),
+    (27121, 0x04fc_d2f4),
+    (27854, 0x03de_fb23),
+    (28587, 0xf9f6_bc1a),
+    (29320, 0x21d7_e228),
+    (30053, 0x0e30_25ea),
+    (30786, 0xe90d_db17),
+    (31519, 0x1119_e90c),
+    (32252, 0xe6f4_f60a),
+    (32985, 0x0239_ee13),
+    (33718, 0x25e5_3301),
+    (34451, 0x2807_0b16),
+    (35184, 0x2dde_f1b1),
+    (35917, 0xf41a_f908),
+    (36650, 0x1d39_05ed),
+    (37383, 0x2339_fbfa),
+    (38116, 0xe3d3_05f7),
+    (38849, 0x28f5_f021),
+    (39582, 0x44ee_130b),
+    (40315, 0xf50d_2506),
+    (41048, 0x0c2a_d8f9),
+    (41781, 0x07eb_0011),
+    (42514, 0x04d8_061f),
+    (43247, 0x23e6_ecc5),
+    (43980, 0xfc0f_25e7),
+    (44713, 0xe8ee_011a),
+    (45446, 0xe11e_33fe),
+    (46179, 0xf2d6_03dd),
+    (46912, 0x2e18_2214),
+    (47645, 0xd2e5_0109),
+    (48378, 0x4f21_070d),
+    (49111, 0x0b0b_070b),
+    (49844, 0xe9e5_e1f6),
+    (50577, 0x14d2_e5fc),
+    (51310, 0x1401_d223),
+    (52043, 0x2208_131a),
+    (52776, 0x170f_eee3),
+    (53509, 0xf3c5_0117),
+    (54242, 0xf7f8_faed),
+    (54975, 0x3ecd_160a),
+    (55708, 0x1af5_2a07),
+    (56441, 0xe901_17fd),
+    (57174, 0x1410_f806),
+    (57907, 0x13cd_f8ed),
+    (58640, 0x2afa_f123),
+    (59373, 0x04d0_19fe),
+    (60106, 0xe6d8_f4f0),
+    (60839, 0xfa16_3926),
+    (61572, 0xeec7_1f12),
+];
+
+#[uzu_test]
+fn state_hash_matches_python_oracle() {
+    /// PR #800's `11 * pairs + dither - 81` map, as the fixture was dumped
+    /// under. Not what uzu decodes with; it exists to read the fixture.
+    fn q2dither_word(x: u32) -> u32 {
+        const M3: u32 = 0x0303_0303;
+        const MF: u32 = 0x0F0F_0F0F;
+        let pairs = (x & M3).wrapping_add((x >> 2) & M3).wrapping_add((x >> 4) & M3).wrapping_add((x >> 6) & M3);
+        let dither = (((x & MF).wrapping_mul(3).wrapping_add(0x0101_0101)) & MF) << 1;
+        pairs.wrapping_mul(11).wrapping_add(dither).wrapping_add(0x2F2F_2F2F) ^ 0x8080_8080
+    }
+
+    let (a, b) = hash_params();
+    for &(state, want) in STATE_HASH_PYTHON_GOLDEN.iter() {
+        assert_eq!(q2dither_word(state_hash(state, a, b)), want, "state {state:#x}");
+    }
+}
+
+/// The induced level set and the epilogue scale, which are FORMAT rather than
+/// implementation: if either drifts the codebook silently stops being unit
+/// variance and every downstream number is off by a constant nobody would
+/// notice. The counts are E8's, for its k = 3 tier-A map.
+#[uzu_test]
+fn codebook_is_the_fitted_one() {
+    let table = codebook_table();
+    assert_eq!(table.len(), 256);
+    assert_eq!(*table.iter().min().unwrap(), -54);
+    assert_eq!(*table.iter().max().unwrap(), 55);
+    let levels: std::collections::BTreeSet<i8> = table.iter().copied().collect();
+    assert_eq!(levels.len(), 74, "E8's k = 3 tier A induces 74 distinct levels");
+
+    let scale = f64::from(codebook_scale());
+    let variance: f64 = table.iter().map(|&v| (f64::from(v) * scale).powi(2)).sum::<f64>() / table.len() as f64;
+    assert!((variance - 1.0).abs() < 1e-6, "decoded variance {variance}");
+}

--- a/crates/uzu-engine/unit/backends/metal/kernel/matmul/gemm/selection_test.rs
+++ b/crates/uzu-engine/unit/backends/metal/kernel/matmul/gemm/selection_test.rs
@@ -7,6 +7,9 @@ use crate::backends::{
     metal::kernel::matmul::MatmulMetalKernel,
 };
 
+/// The part every number in the trellis split-K table was measured on.
+const REFERENCE_GPU_CORES: u32 = 40;
+
 fn shape(
     m: u32,
     n: u32,
@@ -40,7 +43,7 @@ fn problem(
     shape: MatmulShape,
     output_data_type: DataType,
 ) -> GemmProblem {
-    GemmProblem::new(shape, DataType::BF16, output_data_type, true, MTLGPUFamily::Apple7)
+    GemmProblem::new(shape, DataType::BF16, output_data_type, true, MTLGPUFamily::Apple7, REFERENCE_GPU_CORES)
 }
 
 fn plan(split_k: u32) -> GemmPlan {
@@ -140,7 +143,9 @@ fn selection_fallbacks_and_split_k_are_preserved() {
     biased.a_full_precision = false;
     biased.d_transform = GemmDTransform::BIAS;
     assert_eq!(
-        GemmProblem::new(biased, DataType::BF16, DataType::F32, true, MTLGPUFamily::Apple7).select_plan().split_k,
+        GemmProblem::new(biased, DataType::BF16, DataType::F32, true, MTLGPUFamily::Apple7, REFERENCE_GPU_CORES)
+            .select_plan()
+            .split_k,
         1
     );
 
@@ -154,7 +159,7 @@ fn selection_fallbacks_and_split_k_are_preserved() {
 fn forced_engine_errors_are_preserved() {
     let huge = shape(u32::MAX, u32::MAX, u32::MAX);
     assert_eq!(
-        GemmProblem::new(huge, DataType::BF16, DataType::BF16, false, MTLGPUFamily::Apple7)
+        GemmProblem::new(huge, DataType::BF16, DataType::BF16, false, MTLGPUFamily::Apple7, REFERENCE_GPU_CORES)
             .select_plan_for_engine(GemmEngine::Mxu),
         Err(GemmPlanError::MxuUnavailable)
     );
@@ -200,11 +205,77 @@ fn gemv_gemm_route_boundaries_are_preserved() {
         (shape(3, 4096, 8192), DataType::BF16, false),
         (shape(5, 4096, 8192), DataType::BF16, false),
     ] {
-        let plan = GemmProblem::new(shape, data_type, data_type, true, MTLGPUFamily::Apple7).select_plan();
+        let plan = GemmProblem::new(shape, data_type, data_type, true, MTLGPUFamily::Apple7, REFERENCE_GPU_CORES)
+            .select_plan();
         assert_eq!(MatmulMetalKernel::prefer_gemm_over_gemv(shape, plan, data_type, data_type, data_type), prefer_gemm);
     }
     let mut gathered = shape(4, 4096, 8192);
     gathered.gathered = true;
     let plan = problem(gathered, DataType::BF16).select_plan();
     assert!(!MatmulMetalKernel::prefer_gemm_over_gemv(gathered, plan, DataType::BF16, DataType::BF16, DataType::BF16,));
+}
+
+/// `(label, N, K)` of the eight matrices the trellis study sweeps, and the
+/// batch sizes the trellis GEMM owns.
+const TRELLIS_SHAPES: [(&str, u32, u32); 8] = [
+    ("mlp_up", 34816, 5120),
+    ("in_proj", 16480, 5120),
+    ("qkv", 8192, 5120),
+    ("gate", 6144, 5120),
+    ("mlp_down", 5120, 17408),
+    ("out_proj", 5120, 6144),
+    ("draft_o_proj", 5120, 4096),
+    ("draft_fc", 5120, 25600),
+];
+const TRELLIS_BATCHES: [u32; 3] = [16, 32, 64];
+
+fn trellis(
+    m: u32,
+    n: u32,
+    k: u32,
+) -> MatmulShape {
+    let mut shape = shape(m, n, k);
+    shape.b_prologue = GemmBPrologueKind::Trellis;
+    shape.b_bits = Some(8);
+    shape.b_group_size = Some(crate::backends::common::kernel::matmul::trellis_format::TRELLIS_BLOCK_K);
+    shape.signed_codes = true;
+    shape.a_full_precision = false;
+    shape
+}
+
+/// What the trellis rule dispatches, so it cannot drift silently. 40-core
+/// reference part. Every shape but `mlp_up` is held at the M ceiling; `mlp_up`
+/// is wide enough that supply is met below it at M = 32.
+#[uzu_test]
+fn trellis_split_k_table_for_every_shape() {
+    let expected: [(&str, [u32; 3]); 8] = [
+        ("mlp_up", [8, 4, 4]),
+        ("in_proj", [8, 8, 4]),
+        ("qkv", [8, 8, 4]),
+        ("gate", [8, 8, 4]),
+        ("mlp_down", [8, 8, 4]),
+        ("out_proj", [8, 8, 4]),
+        ("draft_o_proj", [8, 8, 4]),
+        ("draft_fc", [8, 8, 4]),
+    ];
+    for ((label, n, k), (expected_label, splits)) in TRELLIS_SHAPES.into_iter().zip(expected) {
+        assert_eq!(label, expected_label);
+        for (batch, split_k) in splits.into_iter().enumerate() {
+            let m = TRELLIS_BATCHES[batch];
+            assert_eq!(problem(trellis(m, n, k), DataType::BF16).select_plan().split_k, split_k, "{label} M{m}");
+        }
+    }
+}
+
+/// The rule is a property of the machine, not of the shape: the same matrix
+/// wants a different split on a smaller part.
+#[uzu_test]
+fn trellis_split_k_follows_the_core_count() {
+    let plan = |cores| {
+        GemmProblem::new(trellis(16, 34816, 5120), DataType::BF16, DataType::BF16, true, MTLGPUFamily::Apple7, cores)
+            .select_plan()
+            .split_k
+    };
+    assert_eq!(plan(40), 8);
+    assert_eq!(plan(10), 2);
 }

--- a/crates/uzu-engine/unit/backends/metal/kernel/matmul/gemm/trellis_test.rs
+++ b/crates/uzu-engine/unit/backends/metal/kernel/matmul/gemm/trellis_test.rs
@@ -1,0 +1,164 @@
+//! The trellis GEMM on the production `MatmulKernel` dispatch.
+//!
+//! Two checks, and they fail for different reasons: a numeric one against the
+//! shared f64 oracle, swept over the M values that select each of the three
+//! compiled tiles, a ragged `N` and every split-K factor; and the shared
+//! bit-exact probe, which pins the kernel's window read and the tape packing
+//! against the trellis recurrence with no tolerance at all. Both come from
+//! [`crate::tests::matmul::trellis_fixture`].
+//!
+//! TOLERANCE. Int8 activations force a bf16 `D` (`gemm.metal` constrains
+//! `A_PROLOGUE == Int8Symmetric` to `AT == DT == bfloat`). bf16 keeps 7 mantissa
+//! bits, so storing the result costs up to `2^-8 = 3.9e-3` relative on its own,
+//! and split-K rounds each partial to bf16 before the reduce sums them, for one
+//! more of the same. The bar is therefore 8e-3 -- a property of the OUTPUT TYPE,
+//! not of this kernel: the int32 accumulator is exact (`|product| <= 127*127`
+//! and `K <= 8192`, so under 2^27), the probe verifies the decode with no
+//! tolerance at all, and the measured maximum across this sweep is 3.6e-3.
+
+use half::bf16;
+use uzu_engine_macros::uzu_test;
+
+use super::*;
+use crate::{
+    backends::common::kernel::{
+        activation_transform::ACTIVATION_SCALE_GROUP_SIZE,
+        matmul::{MatmulDOps, trellis_format::TRELLIS_BLOCK_K},
+    },
+    tests::{
+        helpers::{alloc_allocation, alloc_allocation_with_data, allocation_to_vec},
+        matmul::trellis_fixture::{
+            CONFIG, Fixture, assert_probe_row, max_relative_error, oracle, probe_points, row_scales,
+        },
+        util::shared_metal_context,
+    },
+};
+
+/// Weight rows and the reduction depth. `N = 130` is ragged against all three
+/// compiled N tiles (32, 64, 64), so both arms of `TrellisCursor::stage`'s
+/// hoisted N guard run; `K` is a multiple of the 128-column activation group and
+/// of the staging block (`TRELLIS_BLOCK_K`).
+const N: u32 = 130;
+const K: u32 = 512;
+
+/// `d = a_codes * weight_codes^T`, scaled the way the epilogue scales it.
+fn run(
+    context: &MetalContext,
+    fixture: &Fixture,
+    a_codes: &[i8],
+    a_scales: &[f32],
+    m: u32,
+    k: u32,
+    split_k: u32,
+) -> Vec<bf16> {
+    let a = alloc_allocation_with_data::<Metal, i8>(context, a_codes);
+    let scales = alloc_allocation_with_data::<Metal, f32>(context, a_scales);
+    let mut d = alloc_allocation::<Metal, bf16>(context, (m * N) as usize);
+
+    let arguments = MatmulArguments {
+        a: MatmulA::Int8Symmetric {
+            values: &a,
+            scales: &scales,
+            group_sums: None,
+            group_size: ACTIVATION_SCALE_GROUP_SIZE,
+        },
+        b: fixture.weights(),
+        b_leading_dimension: None,
+        b_transpose: true,
+        d: &mut d,
+        d_transform: MatmulDOps::none(),
+        gather_indices: None,
+        m,
+        n: N,
+        k,
+    };
+    let shape = MatmulShape::from_arguments(&arguments);
+    let mut plan = GemmProblem::new(
+        shape,
+        DataType::BF16,
+        DataType::BF16,
+        context.supports_mxu,
+        context.apple_gpu_family,
+        context.gpu_core_count,
+    )
+    .select_plan();
+    plan.split_k = split_k;
+
+    let mut kernel = GemmKernel::new(context, DataType::BF16, DataType::BF16, DataType::BF16).expect("GemmKernel");
+    let mut encoder = Encoder::<Metal>::new(context).expect("encoder");
+    kernel.encode_plan(arguments, plan, &mut encoder).expect("trellis GEMM encode failed");
+    encoder.end_encoding().submit().wait_until_completed().unwrap();
+
+    allocation_to_vec::<Metal, bf16>(&d)
+}
+
+/// Deterministic int8 activations plus their per-group f32 scales.
+fn activations(
+    m: u32,
+    k: u32,
+) -> (Vec<i8>, Vec<f32>) {
+    let codes = (0..m * k).map(|i| ((i * 37 + i / 11) % 191) as i32 as i8).collect();
+    let scales = (0..m * (k / ACTIVATION_SCALE_GROUP_SIZE)).map(|i| 0.0009 + 0.0003 * ((i % 7) as f32)).collect();
+    (codes, scales)
+}
+
+#[uzu_test]
+fn trellis_gemm_matches_oracle() {
+    let context = shared_metal_context();
+    if !context.supports_mxu {
+        return;
+    }
+    let fixture = Fixture::new(&context, CONFIG, N, K, row_scales(N));
+
+    // M picks the tile: 16 -> 16x32, 17 and 32 -> 32x64, 64 and 128 -> 64x64.
+    // Split-K is only legal where `M * N` is a multiple of four, which is what
+    // the shipped reduce kernel requires.
+    for m in [16u32, 17, 32, 64, 128] {
+        let (a_codes, a_scales) = activations(m, K);
+        let groups = (K / ACTIVATION_SCALE_GROUP_SIZE) as usize;
+        let expected = oracle(&fixture, m, N, K, |row, index| {
+            f64::from(a_codes[row * K as usize + index])
+                * f64::from(a_scales[row * groups + index / ACTIVATION_SCALE_GROUP_SIZE as usize])
+        });
+        // A forced split has to leave every partition at least one staging
+        // block of K, which the shipped policy guarantees and this test has to
+        // reproduce: `split_k * TRELLIS_BLOCK_K <= K`. Past that, partitions
+        // read off the end of the tape.
+        let max_split = K / TRELLIS_BLOCK_K;
+        let splits: Vec<u32> = if (m * N).is_multiple_of(4) {
+            [1, 4, 8].into_iter().filter(|split_k| *split_k <= max_split).collect()
+        } else {
+            vec![1]
+        };
+        for split_k in splits {
+            let got = run(&context, &fixture, &a_codes, &a_scales, m, K, split_k);
+            let error = max_relative_error(&got[..(m * N) as usize], &expected);
+            assert!(error < 8e-3, "M={m} split_k={split_k}: max relative error {error:e}");
+        }
+    }
+}
+
+#[uzu_test]
+fn trellis_gemm_states_are_bit_exact() {
+    let context = shared_metal_context();
+    if !context.supports_mxu {
+        return;
+    }
+    // A longer row so the probe reaches steps whose window read is misaligned in
+    // every one of the 32 possible ways.
+    let k = 1024u32;
+    let fixture = Fixture::new(&context, CONFIG, N, k, vec![bf16::ONE; N as usize]);
+
+    let probes = probe_points(CONFIG.steps(k));
+    let m = probes.len() as u32;
+    let mut a_codes = vec![0i8; (m * k) as usize];
+    for (row, &(step, coordinate)) in probes.iter().enumerate() {
+        a_codes[row * k as usize + (step * 4 + coordinate) as usize] = 1;
+    }
+    let a_scales = vec![1.0f32; (m * (k / ACTIVATION_SCALE_GROUP_SIZE)) as usize];
+
+    let got = run(&context, &fixture, &a_codes, &a_scales, m, k, 1);
+    for (row, &(step, coordinate)) in probes.iter().enumerate() {
+        assert_probe_row(&fixture, &got[row * N as usize..(row + 1) * N as usize], step, coordinate, "gemm");
+    }
+}

--- a/crates/uzu-engine/unit/backends/metal/kernel/matmul/gemv/trellis_test.rs
+++ b/crates/uzu-engine/unit/backends/metal/kernel/matmul/gemv/trellis_test.rs
@@ -1,0 +1,258 @@
+//! The trellis GEMV on the production `MatmulKernel` dispatch.
+//!
+//! Three checks, and they fail for different reasons: a numeric one against the
+//! shared f64 oracle, swept over every compiled batch width, a ragged `N`, a `K`
+//! that is and is not a power of two, and every window width the format allows;
+//! the shared bit-exact probe, which pins the kernel's 128-bit run read and the
+//! tape packing against the trellis recurrence with no tolerance at all; and
+//! routing, which is visible from outside as the activation format -- the GEMV
+//! takes bf16 activations, the trellis GEMM takes int8 ones.
+//!
+//! `L` and `KV` are runtime scalars, so one config cannot exercise them:
+//! [`trellis_gemv_spans_every_window`] sweeps the narrowest window this kernel
+//! sees up to `KV == L == 32`, where the lane's four-state run spans exactly the
+//! 128 bits `TrellisSlice` holds.
+//!
+//! TOLERANCE. `D` is bf16 (the trellis GEMV family is pinned to bf16 in and
+//! out), and bf16 carries 8 significand bits, so simply STORING a correct result
+//! costs up to `2^-8 = 3.9e-3` relative on its own. The bar below is therefore
+//! set against the oracle ROUNDED TO bf16, where the measured error is exactly
+//! ZERO at every M, K and window width -- the kernel reproduces the oracle's
+//! bf16 bit for bit, which is a strictly stronger statement than any tolerance
+//! against the f64 oracle. The oracle reads the activations as the bf16 values
+//! the GPU read, so activation rounding is not in the number.
+
+use half::bf16;
+use uzu_engine_macros::uzu_test;
+
+use super::*;
+use crate::{
+    backends::{
+        common::{
+            Encoder,
+            kernel::matmul::{
+                ActivationFormat, MatmulA, MatmulArguments, MatmulDOps, MatmulKernel, MatmulShape,
+                trellis_format::{TRELLIS_BLOCK_K, TrellisConfig},
+            },
+        },
+        metal::{Metal, context::MetalContext, kernel::matmul::MatmulMetalKernel},
+    },
+    tests::{
+        helpers::{alloc_allocation, alloc_allocation_with_data, allocation_to_vec},
+        matmul::trellis_fixture::{
+            CONFIG, Fixture, assert_probe_row, max_relative_error, oracle, probe_points, row_scales,
+        },
+        util::shared_metal_context,
+    },
+};
+
+/// Ragged against the 16-row output tile.
+const N: u32 = 130;
+
+/// `d = a * weights^T` through the production dispatch, with bf16 activations.
+fn run(
+    context: &MetalContext,
+    fixture: &Fixture,
+    a: &[bf16],
+    m: u32,
+    n: u32,
+    k: u32,
+) -> Vec<bf16> {
+    let a_buffer = alloc_allocation_with_data::<Metal, bf16>(context, a);
+    let mut d = alloc_allocation::<Metal, bf16>(context, (m * n) as usize);
+
+    let arguments = MatmulArguments {
+        a: MatmulA::FullPrecision {
+            values: &a_buffer,
+            offset: 0,
+        },
+        b: fixture.weights(),
+        b_leading_dimension: None,
+        b_transpose: true,
+        d: &mut d,
+        d_transform: MatmulDOps::none(),
+        gather_indices: None,
+        m,
+        n,
+        k,
+    };
+
+    let mut kernel =
+        MatmulMetalKernel::new(context, DataType::BF16, DataType::BF16, DataType::BF16).expect("MatmulMetalKernel");
+    let mut encoder = Encoder::<Metal>::new(context).expect("encoder");
+    kernel.encode(arguments, &mut encoder).expect("trellis GEMV encode failed");
+    encoder.end_encoding().submit().wait_until_completed().unwrap();
+
+    allocation_to_vec::<Metal, bf16>(&d)
+}
+
+/// Deterministic bf16 activations.
+fn activations(
+    m: u32,
+    k: u32,
+) -> Vec<bf16> {
+    (0..m * k).map(|i| bf16::from_f32(((i % 23) as f32 - 11.0) / 32.0)).collect()
+}
+
+/// The kernel against the oracle's own bf16 rounding; see the TOLERANCE note.
+fn assert_matches_oracle(
+    fixture: &Fixture,
+    got: &[bf16],
+    a: &[bf16],
+    m: u32,
+    n: u32,
+    k: u32,
+    label: &str,
+) {
+    let expected = oracle(fixture, m, n, k, |row, index| f64::from(a[row * k as usize + index].to_f32()));
+    let rounded: Vec<f32> = expected.iter().map(|&value| bf16::from_f32(value).to_f32()).collect();
+    let error = max_relative_error(&got[..(m * n) as usize], &rounded);
+    assert!(error < 1e-3, "{label}: max relative error {error:e} against the bf16-rounded oracle");
+}
+
+#[uzu_test]
+fn trellis_gemv_matches_oracle() {
+    let context = shared_metal_context();
+    // 512 is a power of two; 1152 is nine 128-column blocks and is NOT a
+    // multiple of the 256 the INT8 GEMV calls aligned, which is what the
+    // trellis K block replaces.
+    for k in [512u32, 1152] {
+        let fixture = Fixture::new(&context, CONFIG, N, k, row_scales(N));
+        for m in 1..=8u32 {
+            let a = activations(m, k);
+            let got = run(&context, &fixture, &a, m, N, k);
+            assert_matches_oracle(&fixture, &got, &a, m, N, k, &format!("K={k} M={m}"));
+        }
+    }
+}
+
+/// `L` and `KV` are runtime scalars; this is the sweep that exercises them,
+/// including `KV == L == 32`, where a lane's four-state run spans exactly the
+/// 128 bits the slice holds.
+#[uzu_test]
+fn trellis_gemv_spans_every_window() {
+    let context = shared_metal_context();
+    let k = 512u32;
+    let n = 33u32;
+    for config in [
+        TrellisConfig::new(16, 2),
+        TrellisConfig::new(24, 3),
+        TrellisConfig::new(28, 3),
+        TrellisConfig::new(32, 3),
+        TrellisConfig::new(32, 8),
+    ] {
+        let fixture = Fixture::new(&context, config, n, k, row_scales(n));
+        for m in [1u32, 4, 8] {
+            let a = activations(m, k);
+            let got = run(&context, &fixture, &a, m, n, k);
+            assert_matches_oracle(&fixture, &got, &a, m, n, k, &format!("{config:?} M={m}"));
+        }
+    }
+}
+
+#[uzu_test]
+fn trellis_gemv_states_are_bit_exact() {
+    let context = shared_metal_context();
+    // Long enough that the probe reaches steps whose funnel shift is misaligned
+    // in every one of the 32 possible ways.
+    let k = 1024u32;
+    let fixture = Fixture::new(&context, CONFIG, N, k, vec![bf16::ONE; N as usize]);
+
+    for &(step, coordinate) in probe_points(CONFIG.steps(k)).iter() {
+        let mut a = vec![bf16::ZERO; k as usize];
+        a[(step * 4 + coordinate) as usize] = bf16::ONE;
+        let got = run(&context, &fixture, &a, 1, N, k);
+        assert_probe_row(&fixture, &got[..N as usize], step, coordinate, "gemv");
+    }
+}
+
+#[uzu_test]
+fn trellis_gemv_routes_by_batch() {
+    let context = shared_metal_context();
+    let kernel =
+        MatmulMetalKernel::new(&context, DataType::BF16, DataType::BF16, DataType::BF16).expect("MatmulMetalKernel");
+    let select = |shape: &MatmulShape| {
+        GemvSpecialization::select_shape(
+            shape,
+            DataType::BF16,
+            DataType::BF16,
+            DataType::BF16,
+            context.gpu_core_count,
+            context.apple_gpu_family,
+        )
+    };
+    for m in 1..=8u32 {
+        let shape = trellis_shape(m, 16480, 5120);
+        let specialization = select(&shape).unwrap_or_else(|| panic!("M={m} must reach the trellis GEMV"));
+        // The batch split: eight output rows at M <= 2, sixteen above it, over
+        // eight simdgroups of 32 reduction lanes either way. See
+        // `GemvSpecialization::select_shape`.
+        assert_eq!(
+            specialization.output_row_tile(),
+            if m <= 2 {
+                8
+            } else {
+                16
+            },
+            "M={m}"
+        );
+        // Thirty-two reduction lanes up to M = 4, eight above it.
+        assert_eq!(
+            specialization.reduction_lanes(),
+            if m <= 4 {
+                32
+            } else {
+                8
+            },
+            "M={m}"
+        );
+        assert_eq!(
+            kernel.select_activation_format(&shape, &context),
+            ActivationFormat::Bf16,
+            "M={m} must keep bf16 activations"
+        );
+    }
+    for m in [9u32, 16, 64] {
+        let shape = trellis_shape(m, 16480, 5120);
+        assert!(select(&shape).is_none(), "M={m} must fall to the GEMM");
+        if context.supports_mxu {
+            assert_eq!(
+                kernel.select_activation_format(&shape, &context),
+                ActivationFormat::Int8,
+                "M={m} must reach the int8 trellis GEMM"
+            );
+        }
+    }
+    // K that is not a whole number of trellis K blocks has no GEMV variant.
+    assert!(select(&trellis_shape(4, 16480, 5120 + 64)).is_none());
+    // K that is a whole number of 128s but not of the 32-lane block's 512 falls
+    // back to the eight-lane tile instead of off the GEMV -- at EVERY batch
+    // width, because that tile walks the batch through the grid rather than
+    // compiling an input row tile of its own.
+    for m in 1..=8u32 {
+        let specialization = select(&trellis_shape(m, 16480, 5120 + 128)).expect("eight-lane fallback");
+        assert_eq!(specialization.output_row_tile(), 16, "M={m} K=5248");
+        assert_eq!(specialization.reduction_lanes(), 8, "M={m} K=5248");
+    }
+}
+
+fn trellis_shape(
+    m: u32,
+    n: u32,
+    k: u32,
+) -> MatmulShape {
+    MatmulShape {
+        m,
+        n,
+        k,
+        b_transpose: true,
+        b_leading_dimension: None,
+        b_prologue: GemmBPrologueKind::Trellis,
+        b_bits: Some(8),
+        b_group_size: Some(TRELLIS_BLOCK_K),
+        signed_codes: true,
+        a_full_precision: true,
+        gathered: false,
+        d_transform: GemmDTransform::empty(),
+    }
+}

--- a/crates/uzu-engine/unit/common/matmul/mod.rs
+++ b/crates/uzu-engine/unit/common/matmul/mod.rs
@@ -2,6 +2,8 @@ pub mod bench;
 pub mod harness;
 pub mod quant;
 pub mod shape;
+#[cfg(backend = "metal")]
+pub mod trellis_fixture;
 
 pub use bench::{iter_encode_loop, iter_encode_loop_named};
 pub use harness::{Case, cpu_reference, deterministic_input};

--- a/crates/uzu-engine/unit/common/matmul/trellis_fixture.rs
+++ b/crates/uzu-engine/unit/common/matmul/trellis_fixture.rs
@@ -1,0 +1,145 @@
+//! The fixture both trellis kernel tests are written against.
+//!
+//! One tape, one set of int8 codes derived from it by the host oracle, and one
+//! f64 reference product over those codes — so a rounding difference in the
+//! weight decode can never be mistaken for a matmul bug. The GEMM and the GEMV
+//! differ only in the activation they feed in, which is what [`oracle`] takes as
+//! a closure.
+//!
+//! THE BIT-EXACT PROBE. One-hot activations with unit row scales make each
+//! output exactly one decoded weight, recovered as an integer and compared
+//! against the code the oracle's *recurrence* produces — not its window read.
+//! That pins the kernel's window read and the tape packing against the trellis
+//! definition rather than against another window read. [`probe_points`] covers
+//! both ends of a row, every coordinate of a step, and every alignment of the
+//! two-word window read.
+
+use half::bf16;
+
+use crate::{
+    backends::{
+        common::{
+            Allocation,
+            kernel::matmul::{
+                MatmulB,
+                trellis_format::{TrellisConfig, TrellisTape, codebook_scale, hash_params, state_codes},
+            },
+        },
+        metal::{Metal, MetalContext},
+    },
+    tests::helpers::alloc_allocation_with_data,
+};
+
+/// `L = 32` is the widest window, so the state mask is the one that exercises
+/// the two-word read at every shift.
+pub const CONFIG: TrellisConfig = TrellisConfig::new(32, 3);
+
+pub struct Fixture {
+    pub tape: TrellisTape,
+    /// `[n][k]` int8 codes — the weights in the basis the MXU sees, before
+    /// `row_scale * codebook_scale()`.
+    pub codes: Vec<i8>,
+    pub row_scales: Vec<bf16>,
+    tape_buffer: Allocation<Metal>,
+    scales_buffer: Allocation<Metal>,
+}
+
+impl Fixture {
+    pub fn new(
+        context: &MetalContext,
+        config: TrellisConfig,
+        n: u32,
+        k: u32,
+        row_scales: Vec<bf16>,
+    ) -> Self {
+        let tape = TrellisTape::random(config, n, k, 0x1234_5EED);
+        Self {
+            codes: tape.codes(),
+            tape_buffer: alloc_allocation_with_data::<Metal, u32>(context, &tape.words),
+            scales_buffer: alloc_allocation_with_data::<Metal, bf16>(context, &row_scales),
+            tape,
+            row_scales,
+        }
+    }
+
+    pub fn weights(&self) -> MatmulB<'_, Metal> {
+        MatmulB::Trellis {
+            b: &self.tape_buffer,
+            scales: &self.scales_buffer,
+            config: self.tape.config,
+        }
+    }
+}
+
+/// Per-row weight scales, deterministic and all distinct.
+pub fn row_scales(n: u32) -> Vec<bf16> {
+    (0..n).map(|r| bf16::from_f32(0.002 + 0.001 * ((r * 37 % 19) as f32) / 19.0)).collect()
+}
+
+/// `[m][n]` in f64 over the same int8 codes the GPU decoded. `activation` is the
+/// value the kernel actually consumed at `(row, k index)`, so activation
+/// rounding is not in the result.
+pub fn oracle(
+    fixture: &Fixture,
+    m: u32,
+    n: u32,
+    k: u32,
+    activation: impl Fn(usize, usize) -> f64,
+) -> Vec<f32> {
+    let scale = f64::from(codebook_scale());
+    let mut out = vec![0.0f32; (m * n) as usize];
+    for row in 0..m as usize {
+        for column in 0..n as usize {
+            let mut accumulated = 0.0f64;
+            for index in 0..k as usize {
+                accumulated += activation(row, index) * f64::from(fixture.codes[column * k as usize + index]);
+            }
+            out[row * n as usize + column] =
+                (accumulated * f64::from(fixture.row_scales[column].to_f32()) * scale) as f32;
+        }
+    }
+    out
+}
+
+pub fn max_relative_error(
+    got: &[bf16],
+    expected: &[f32],
+) -> f32 {
+    let scale = expected.iter().fold(0.0f32, |acc, v| acc.max(v.abs())).max(f32::MIN_POSITIVE);
+    got.iter().zip(expected).fold(0.0f32, |acc, (&g, &e)| acc.max((g.to_f32() - e).abs())) / scale
+}
+
+/// `(step, coordinate)` pairs for the bit-exact probe.
+pub fn probe_points(steps: u32) -> Vec<(u32, u32)> {
+    [0, 1, 2, 3, 5, 33, steps / 2, steps - 1].iter().flat_map(|&s| (0..4u32).map(move |j| (s, j))).collect()
+}
+
+/// One probe row: `got` is the kernel's `[n]` output for a one-hot activation at
+/// `(step, coordinate)` with unit row scales, so every element is exactly one
+/// decoded level times `codebook_scale()`.
+///
+/// Dividing that scale back out is exact enough to compare as an integer: the
+/// levels are in `[-54, 55]`, and bf16 carries 8 significand bits, so the
+/// recovered value is within 0.2% of a value that is at most 55.
+pub fn assert_probe_row(
+    fixture: &Fixture,
+    got: &[bf16],
+    step: u32,
+    coordinate: u32,
+    label: &str,
+) {
+    let steps = fixture.tape.config.steps(fixture.tape.cols) as usize;
+    // The recurrence, not the window read: the two agreeing is the check.
+    let states = fixture.tape.states_by_recurrence();
+    let (hash_a, hash_b) = hash_params();
+    let scale = codebook_scale();
+    for (column, &value) in got.iter().enumerate() {
+        let state = states[column * steps + step as usize];
+        let expected = i32::from(state_codes(state, hash_a, hash_b)[coordinate as usize]);
+        assert_eq!(
+            (value.to_f32() / scale).round() as i32,
+            expected,
+            "{label} step={step} coord={coordinate} row={column}: state {state:#x} gave {value}, want {expected}"
+        );
+    }
+}


### PR DESCRIPTION
**Codebook: `p8_md3f`**

The trellis needs a map from a state to 4 Gaussian-distributed weights that looks random across states. The reference stores one (`randn(2^16, 2)`, 512 KiB) and pays a random gather per weight pair. We compute it in two steps:

1. Hash the state: `x = s·a + b`, then one fmix32 round (`x ^= x>>16; x *= 0x85EBCA6B; x ^= x>>16`). The mixing round is required: on a bitshift trellis a state's 2^kV successors are consecutive integers, and a plain LCG (QTIP's 1MAD) has `x(s+d) = x(s) + a·d`, so neighbouring candidates come out 0.5-correlated.
2. Each byte → int8 level: `8·pairs + ((3·n0) & 15)`, where `pairs` is the sum of the byte's four 2-bit fields (7 SWAR ops for all 4 bytes) and `n0` its low nibble. A sum of four uniforms is already bell-shaped; the masked term adds dither between levels and, because it is a mask after a multiply, is not linear in the bits — a linear map cannot reach past 2.83σ, this one reaches 2.9σ.

14 integer ops per 4 weights, no memory access. Cheaper than a 256-entry table because a threadgroup gather costs about 3 ALU ops here, and the table needs four per state. More accurate than the 19-op map in #800 because the fit error tracks the level set's transport distance to N(0,1), and the wider reach plus finer bulk spacing lower it: +1.2% vs an ideal random table at k=3 (vs +1.7%), tie at k=2.

| baseline | M=1 | 2 | 4 | 6 | 8 | 16 | 32 | 64 |
|---|---|---|---|---|---|---|---|---|
| qmv, bf16 activations (out_proj 5120×6144) | 0.81 | 0.98 | 0.93 | 0.75 | 0.79 | — | — | — | 
| a8w4, int8 activations (weighted, 240/272 matrices, 3 passes, 20 samples each) | — | — | — | — | — | **0.80** | **0.80** | **0.81** |