### PR TITLE
Muse prefill fix

### DIFF
--- a/crates/legacy/hanashi/src/chat/hanashi/messages/streamed/content.rs
+++ b/crates/legacy/hanashi/src/chat/hanashi/messages/streamed/content.rs
@@ -94,17 +94,21 @@ impl Content {
                     }
                 }
 
-                // Keep the parser's text byte-for-byte. Re-rendering this message must reproduce
-                // the sampled prefix so the token backend can retain its KV cache between turns.
+                // Keep reasoning byte-for-byte: Muse-Glimmer emits significant trailing whitespace
+                // that its template does not restore when the message is rendered again.
                 let reasoning = reasoning_parts.concat();
-                let text = text_parts.concat();
+
+                // Text sections may include separators owned by the template rather than the reply
+                // (for example Qwen's newlines around <think>), so keep them out of visible content.
+                let text = text_parts.concat().trim().to_string();
+
                 let mut blocks = Vec::new();
                 if !reasoning.trim().is_empty() {
                     blocks.push(ChatContentBlock::Reasoning {
                         value: reasoning,
                     });
                 }
-                if !text.trim().is_empty() {
+                if !text.is_empty() {
                     blocks.push(ChatContentBlock::Text {
                         value: text,
                     });

--- a/crates/legacy/hanashi/src/chat/hanashi/messages/streamed/content.rs
+++ b/crates/legacy/hanashi/src/chat/hanashi/messages/streamed/content.rs
@@ -94,15 +94,17 @@ impl Content {
                     }
                 }
 
-                let reasoning = reasoning_parts.concat().trim().to_string();
-                let text = text_parts.concat().trim().to_string();
+                // Keep the parser's text byte-for-byte. Re-rendering this message must reproduce
+                // the sampled prefix so the token backend can retain its KV cache between turns.
+                let reasoning = reasoning_parts.concat();
+                let text = text_parts.concat();
                 let mut blocks = Vec::new();
-                if !reasoning.is_empty() {
+                if !reasoning.trim().is_empty() {
                     blocks.push(ChatContentBlock::Reasoning {
                         value: reasoning,
                     });
                 }
-                if !text.is_empty() {
+                if !text.trim().is_empty() {
                     blocks.push(ChatContentBlock::Text {
                         value: text,
                     });
@@ -142,3 +144,7 @@ fn tool_call_result_parts(value: Value) -> (Option<String>, Value) {
         other => (None, other),
     }
 }
+
+#[cfg(test)]
+#[path = "../../../../../unit/chat/hanashi/messages/streamed/content.rs"]
+mod tests;

--- a/crates/legacy/hanashi/unit/chat/hanashi/messages/streamed/content.rs
+++ b/crates/legacy/hanashi/unit/chat/hanashi/messages/streamed/content.rs
@@ -1,0 +1,41 @@
+use super::*;
+
+#[test]
+fn preserves_text_section_whitespace_for_rerendering() {
+    let blocks = Content::Sections(vec![
+        Section::Reasoning {
+            value: Some(" think\n\n".to_string()),
+        },
+        Section::Text {
+            value: Some(" answer \n".to_string()),
+        },
+    ])
+    .blocks(&ChatRole::Assistant {});
+
+    assert_eq!(
+        blocks,
+        vec![
+            ChatContentBlock::Reasoning {
+                value: " think\n\n".to_string(),
+            },
+            ChatContentBlock::Text {
+                value: " answer \n".to_string(),
+            },
+        ]
+    );
+}
+
+#[test]
+fn drops_whitespace_only_text_sections() {
+    let blocks = Content::Sections(vec![
+        Section::Reasoning {
+            value: Some(" \n".to_string()),
+        },
+        Section::Text {
+            value: Some("\t".to_string()),
+        },
+    ])
+    .blocks(&ChatRole::Assistant {});
+
+    assert!(blocks.is_empty());
+}

--- a/crates/legacy/hanashi/unit/chat/hanashi/messages/streamed/content.rs
+++ b/crates/legacy/hanashi/unit/chat/hanashi/messages/streamed/content.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[test]
-fn preserves_text_section_whitespace_for_rerendering() {
+fn preserves_reasoning_whitespace_but_normalizes_text() {
     let blocks = Content::Sections(vec![
         Section::Reasoning {
             value: Some(" think\n\n".to_string()),
@@ -19,7 +19,35 @@ fn preserves_text_section_whitespace_for_rerendering() {
                 value: " think\n\n".to_string(),
             },
             ChatContentBlock::Text {
-                value: " answer \n".to_string(),
+                value: "answer".to_string(),
+            },
+        ]
+    );
+}
+
+#[test]
+fn removes_qwen_template_separators_from_visible_text() {
+    let blocks = Content::Sections(vec![
+        Section::Text {
+            value: Some("\n".to_string()),
+        },
+        Section::Reasoning {
+            value: Some("\nLet me think.\n".to_string()),
+        },
+        Section::Text {
+            value: Some("\n\nHello!".to_string()),
+        },
+    ])
+    .blocks(&ChatRole::Assistant {});
+
+    assert_eq!(
+        blocks,
+        vec![
+            ChatContentBlock::Reasoning {
+                value: "\nLet me think.\n".to_string(),
+            },
+            ChatContentBlock::Text {
+                value: "Hello!".to_string(),
             },
         ]
     );

--- a/crates/legacy/uzu/tests/tool/calls.rs
+++ b/crates/legacy/uzu/tests/tool/calls.rs
@@ -193,49 +193,16 @@ async fn run_tool_calls_test(
 }
 
 #[tokio::test]
-#[ignore]
-async fn functiongemma_270m_it() {
-    // FunctionGemma 270M only handles single-step tool calls out of the box:
-    // for the prompts that require chaining (get_current_location -> get_current_temperature) it invents coordinates or
-    // asks the user for them instead of calling get_current_location first.
-    // Per the model card, multi-step use cases require task-specific fine-tuning.
-    run_tool_calls_test("google/functiongemma-270m-it", false, true, &TEST_CASES[..1]).await;
-}
-
-#[tokio::test]
-#[ignore]
-async fn gpt_oss_20b() {
-    run_tool_calls_test("openai/gpt-oss-20b", true, false, TEST_CASES).await;
-}
-
-#[tokio::test]
-#[ignore]
-async fn lfm2_350m() {
-    run_tool_calls_test("LiquidAI/LFM2-350M", true, false, &TEST_CASES[..1]).await;
-}
-
-#[tokio::test]
-#[ignore]
 async fn lfm2_5_350m() {
-    run_tool_calls_test("LiquidAI/LFM2.5-350M", true, false, &TEST_CASES[..1]).await;
+    run_tool_calls_test("trymirai/LFM2.5-350M-L", true, false, &TEST_CASES[..1]).await;
 }
 
 #[tokio::test]
-#[ignore]
-async fn llama_3_2_1b_instruct() {
-    // Like FunctionGemma, Llama 3.2 1B only handles single-step tool calls: for the prompts that
-    // require chaining (get_current_location -> get_current_temperature) it invents coordinates
-    // (e.g. latitude "37") instead of calling get_current_location first.
-    run_tool_calls_test("meta-llama/Llama-3.2-1B-Instruct", true, false, &TEST_CASES[..1]).await;
-}
-
-#[tokio::test]
-#[ignore]
-async fn qwen3_1_7b() {
-    run_tool_calls_test("Qwen/Qwen3-1.7B", true, false, TEST_CASES).await;
+async fn muse_glimmer_30b_m() {
+    run_tool_calls_test("trymirai/Muse-Glimmer-30B-M", true, false, TEST_CASES).await;
 }
 
 #[tokio::test]
 async fn qwen3_5_0_8b() {
-    run_tool_calls_test("alibaba:qwen3.5:0.8b:mirai:mirai-m:4", true, false, TEST_CASES).await;
+    run_tool_calls_test("trymirai/Qwen3.5-0.8B-M", true, false, TEST_CASES).await;
 }

--- a/crates/legacy/uzu/tests/tool/calls.rs
+++ b/crates/legacy/uzu/tests/tool/calls.rs
@@ -198,6 +198,7 @@ async fn lfm2_5_350m() {
 }
 
 #[tokio::test]
+#[ignore]
 async fn muse_glimmer_30b_m() {
     run_tool_calls_test("trymirai/Muse-Glimmer-30B-M", true, false, TEST_CASES).await;
 }


### PR DESCRIPTION
1. Fixed Muse-Glimmer’s post-tool latency. Cause: trailing reasoning whitespace was trimmed, invalidating the KV-prefix cache
2. Updated uzu tool calls tests