### PR TITLE
Load MXFP4 weight matrices

### DIFF
--- a/crates/uzu-engine/Cargo.toml
+++ b/crates/uzu-engine/Cargo.toml
@@ -84,6 +84,7 @@ xgrammar = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 
 [dev-dependencies]
+tempfile.workspace = true
 test-tag.workspace = true
 proptest.workspace = true
 criterion.workspace = true

--- a/crates/uzu-engine/src/backends/common/kernel/matmul/error.rs
+++ b/crates/uzu-engine/src/backends/common/kernel/matmul/error.rs
@@ -1,7 +1,11 @@
 use thiserror::Error;
 
 use crate::{
-    backends::common::{Backend, gpu_types::gemm::GemmDTransform},
+    backends::common::{
+        Backend,
+        gpu_types::gemm::GemmDTransform,
+        microfloat::{MicrofloatError, MicrofloatFormat},
+    },
     data_type::DataType,
 };
 
@@ -20,6 +24,12 @@ pub enum MatmulError<B: Backend> {
     UnsupportedLayout {
         path: &'static str,
     },
+    #[error("Microfloat storage does not match the requested matrix")]
+    InvalidMicrofloatStorage,
+    #[error(transparent)]
+    InvalidMicrofloat(#[from] MicrofloatError),
+    #[error("Unsupported microfloat weight format: {0:?}")]
+    UnsupportedMicrofloat(MicrofloatFormat),
     #[error("Incompatible A operand for {path}: {reason}")]
     IncompatibleA {
         path: &'static str,

--- a/crates/uzu-engine/src/backends/common/kernel/matmul/matmul_b.rs
+++ b/crates/uzu-engine/src/backends/common/kernel/matmul/matmul_b.rs
@@ -2,6 +2,7 @@ use crate::{
     backends::common::{
         Allocation, Backend, BufferArg,
         gpu_types::{QuantizationMode, gemm::GemmBPrologueKind},
+        microfloat::MicrofloatMetadata,
     },
     data_type::DataType,
 };
@@ -9,6 +10,12 @@ use crate::{
 pub enum MatmulB<'a, B: Backend, TB: BufferArg<'a, B> = &'a Allocation<B>> {
     FullPrecision {
         b: TB,
+    },
+    Microfloat {
+        codes: &'a Allocation<B>,
+        scales: &'a Allocation<B>,
+        outer_scales: &'a Allocation<B>,
+        metadata: MicrofloatMetadata,
     },
     ScaleBiasDequant {
         b: &'a Allocation<B>,
@@ -40,6 +47,9 @@ impl<'a, B: Backend, TB: BufferArg<'a, B>> MatmulB<'a, B, TB> {
         match self {
             Self::FullPrecision {
                 ..
+            }
+            | Self::Microfloat {
+                ..
             } => GemmBPrologueKind::FullPrecision,
             Self::ScaleBiasDequant {
                 ..
@@ -58,6 +68,9 @@ impl<'a, B: Backend, TB: BufferArg<'a, B>> MatmulB<'a, B, TB> {
             Self::FullPrecision {
                 ..
             } => None,
+            Self::Microfloat {
+                ..
+            } => Some(4),
             Self::ScaleBiasDequant {
                 mode,
                 ..
@@ -78,6 +91,10 @@ impl<'a, B: Backend, TB: BufferArg<'a, B>> MatmulB<'a, B, TB> {
             Self::FullPrecision {
                 ..
             } => None,
+            Self::Microfloat {
+                metadata,
+                ..
+            } => Some(metadata.encoding.group_size),
             Self::ScaleBiasDequant {
                 group_size,
                 ..
@@ -96,6 +113,9 @@ impl<'a, B: Backend, TB: BufferArg<'a, B>> MatmulB<'a, B, TB> {
     pub fn signed_codes(&self) -> bool {
         match self {
             Self::FullPrecision {
+                ..
+            }
+            | Self::Microfloat {
                 ..
             } => false,
             Self::ScaleBiasDequant {

--- a/crates/uzu-engine/src/backends/common/microfloat/encoding.rs
+++ b/crates/uzu-engine/src/backends/common/microfloat/encoding.rs
@@ -1,0 +1,42 @@
+use super::{MicrofloatError, MicrofloatFormat};
+
+/// How packed microfloat bytes are interpreted, separate from matrix dimensions.
+///
+/// With MXFP4 group size 16, every 16 values along the input axis occupy eight
+/// packed code bytes and share one E8M0 scale.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MicrofloatEncoding {
+    pub format: MicrofloatFormat,
+    pub group_size: u32,
+}
+
+impl MicrofloatEncoding {
+    pub fn new(
+        format: MicrofloatFormat,
+        bits: u32,
+        group_size: u32,
+    ) -> Result<Self, MicrofloatError> {
+        if bits != 4 {
+            return Err(MicrofloatError::UnsupportedBits {
+                format,
+                bits,
+            });
+        }
+        let encoding = Self {
+            format,
+            group_size,
+        };
+        encoding.validate()?;
+        Ok(encoding)
+    }
+
+    pub fn validate(self) -> Result<(), MicrofloatError> {
+        if !matches!(self.group_size, 16 | 32) {
+            return Err(MicrofloatError::UnsupportedGroupSize {
+                format: self.format,
+                group_size: self.group_size,
+            });
+        }
+        Ok(())
+    }
+}

--- a/crates/uzu-engine/src/backends/common/microfloat/error.rs
+++ b/crates/uzu-engine/src/backends/common/microfloat/error.rs
@@ -1,0 +1,26 @@
+use thiserror::Error;
+
+use super::MicrofloatFormat;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum MicrofloatError {
+    #[error("unsupported {format:?} bit width: {bits}")]
+    UnsupportedBits {
+        format: MicrofloatFormat,
+        bits: u32,
+    },
+    #[error("unsupported {format:?} group size: {group_size}")]
+    UnsupportedGroupSize {
+        format: MicrofloatFormat,
+        group_size: u32,
+    },
+    #[error("microfloat rows and columns must be nonzero")]
+    EmptyShape,
+    #[error("microfloat columns {columns} are not divisible by group size {group_size}")]
+    MisalignedColumns {
+        columns: u32,
+        group_size: u32,
+    },
+    #[error("microfloat storage size overflows usize")]
+    SizeOverflow,
+}

--- a/crates/uzu-engine/src/backends/common/microfloat/format.rs
+++ b/crates/uzu-engine/src/backends/common/microfloat/format.rs
@@ -1,0 +1,8 @@
+use uzu_engine_macros::uzu_config;
+
+#[derive(Copy, Eq)]
+#[uzu_config]
+#[serde(rename_all = "snake_case")]
+pub enum MicrofloatFormat {
+    Mxfp4,
+}

--- a/crates/uzu-engine/src/backends/common/microfloat/metadata.rs
+++ b/crates/uzu-engine/src/backends/common/microfloat/metadata.rs
@@ -1,0 +1,49 @@
+use super::{MicrofloatEncoding, MicrofloatError};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MicrofloatMetadata {
+    pub encoding: MicrofloatEncoding,
+    pub rows: u32,
+    pub columns: u32,
+}
+
+impl MicrofloatMetadata {
+    pub fn new(
+        encoding: MicrofloatEncoding,
+        rows: u32,
+        columns: u32,
+    ) -> Result<Self, MicrofloatError> {
+        let metadata = Self {
+            encoding,
+            rows,
+            columns,
+        };
+        metadata.storage_sizes()?;
+        Ok(metadata)
+    }
+
+    pub fn code_row_stride(self) -> usize {
+        self.columns as usize / 2
+    }
+
+    pub fn scale_row_stride(self) -> usize {
+        self.columns as usize / self.encoding.group_size as usize
+    }
+
+    /// Validate the encoding and shape, then return code and scale byte counts.
+    pub fn storage_sizes(self) -> Result<(usize, usize), MicrofloatError> {
+        self.encoding.validate()?;
+        if self.rows == 0 || self.columns == 0 {
+            return Err(MicrofloatError::EmptyShape);
+        }
+        if !self.columns.is_multiple_of(self.encoding.group_size) {
+            return Err(MicrofloatError::MisalignedColumns {
+                columns: self.columns,
+                group_size: self.encoding.group_size,
+            });
+        }
+        let codes = (self.rows as usize).checked_mul(self.code_row_stride()).ok_or(MicrofloatError::SizeOverflow)?;
+        let scales = (self.rows as usize).checked_mul(self.scale_row_stride()).ok_or(MicrofloatError::SizeOverflow)?;
+        Ok((codes, scales))
+    }
+}

--- a/crates/uzu-engine/src/backends/common/microfloat/mod.rs
+++ b/crates/uzu-engine/src/backends/common/microfloat/mod.rs
@@ -1,0 +1,9 @@
+mod encoding;
+mod error;
+mod format;
+mod metadata;
+
+pub use encoding::MicrofloatEncoding;
+pub use error::MicrofloatError;
+pub use format::MicrofloatFormat;
+pub use metadata::MicrofloatMetadata;

--- a/crates/uzu-engine/src/backends/common/mod.rs
+++ b/crates/uzu-engine/src/backends/common/mod.rs
@@ -8,6 +8,7 @@ mod encoder;
 pub mod gpu_types;
 mod hazard_tracker;
 pub mod kernel;
+pub mod microfloat;
 
 pub use allocator::{Allocation, AllocationPool, AllocationType, Allocator};
 pub use backend::Backend;

--- a/crates/uzu-engine/src/backends/cpu/kernel/matmul/kernel.rs
+++ b/crates/uzu-engine/src/backends/cpu/kernel/matmul/kernel.rs
@@ -1,4 +1,4 @@
-use super::reference::{WeightData, read_f32, write_f32};
+use super::reference::{WeightData, decode_e2m1, decode_e8m0, read_f32, write_f32};
 use crate::{
     backends::{
         common::{
@@ -58,6 +58,27 @@ impl MatmulKernel for MatmulCpuKernel {
         arguments: MatmulArguments<'a, 'b, 'd, Cpu, TB>,
         encoder: &mut Encoder<Cpu>,
     ) -> Result<(), CpuError> {
+        if let MatmulB::Microfloat {
+            codes,
+            scales,
+            outer_scales,
+            metadata,
+        } = &arguments.b
+        {
+            let (code_bytes, scale_bytes) = metadata.storage_sizes().map_err(MatmulError::InvalidMicrofloat)?;
+            let rows_match = arguments.gather_indices.is_some() || metadata.rows == arguments.n;
+            if !arguments.b_transpose
+                || arguments.b_leading_dimension.is_some()
+                || !rows_match
+                || metadata.columns != arguments.k
+                || codes.size() < code_bytes
+                || scales.size() < scale_bytes
+                || outer_scales.size() < self.weights_data_type.size_in_bytes()
+            {
+                return Err(MatmulError::InvalidMicrofloatStorage.into());
+            }
+        }
+
         let output_scale = arguments.d_transform.ab_scale;
         let accumulate = arguments.d_transform.accumulate;
         let bias_alloc = arguments.d_transform.bias;
@@ -183,6 +204,9 @@ impl MatmulKernel for MatmulCpuKernel {
                 },
                 WeightData::FullPrecision {
                     ..
+                }
+                | WeightData::Microfloat {
+                    ..
                 } => None,
             };
 
@@ -272,6 +296,24 @@ impl MatmulKernel for MatmulCpuKernel {
                                         -scale * midpoint
                                     };
                                     scale * quantized_value + bias_term
+                                },
+                                WeightData::Microfloat {
+                                    codes,
+                                    scales,
+                                    outer_scales,
+                                    metadata,
+                                } => {
+                                    let code_index = b_col * metadata.code_row_stride() + inner / 2;
+                                    let packed = *codes.as_ptr().add(code_index);
+                                    let code = packed >> (4 * (inner % 2));
+                                    let scale_index = b_col * metadata.scale_row_stride()
+                                        + inner / metadata.encoding.group_size as usize;
+                                    let exponent = *scales.as_ptr().add(scale_index);
+                                    let outer_scale = read_f32(outer_scales.as_ptr(), weights_data_type, 0);
+                                    // Avoiding intermediate overflow and underflow before the final f32 rounding.
+                                    (f64::from(decode_e2m1(code))
+                                        * f64::from(decode_e8m0(exponent))
+                                        * f64::from(outer_scale)) as f32
                                 },
                             };
                             accumulator += a_value * b_value;

--- a/crates/uzu-engine/src/backends/cpu/kernel/matmul/reference.rs
+++ b/crates/uzu-engine/src/backends/cpu/kernel/matmul/reference.rs
@@ -2,12 +2,30 @@ use half::{bf16, f16};
 
 use crate::{
     backends::{
-        common::{AsBufferRangeRef, BufferArg, gpu_types::QuantizationMode, kernel::matmul::MatmulB},
+        common::{
+            AsBufferRangeRef, BufferArg, gpu_types::QuantizationMode, kernel::matmul::MatmulB,
+            microfloat::MicrofloatMetadata,
+        },
         cpu::Cpu,
     },
     data_type::DataType,
     utils::pointers::SendPtr,
 };
+
+#[inline]
+pub(super) fn decode_e2m1(code: u8) -> f32 {
+    const VALUES: [f32; 16] = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0];
+    VALUES[usize::from(code & 0x0f)]
+}
+
+#[inline]
+pub(super) fn decode_e8m0(exponent: u8) -> f32 {
+    match exponent {
+        0 => f32::from_bits(0x0040_0000),
+        255 => f32::NAN,
+        exponent => f32::from_bits(u32::from(exponent) << 23),
+    }
+}
 
 pub(super) enum WeightData {
     FullPrecision {
@@ -23,6 +41,12 @@ pub(super) enum WeightData {
         bits: usize,
         group_size: usize,
         signed_codes: bool,
+    },
+    Microfloat {
+        codes: SendPtr<u8>,
+        scales: SendPtr<u8>,
+        outer_scales: SendPtr<u8>,
+        metadata: MicrofloatMetadata,
     },
 }
 
@@ -57,6 +81,17 @@ impl WeightData {
                     leading_dimension,
                     transpose: b_transpose,
                 }
+            },
+            MatmulB::Microfloat {
+                codes,
+                scales,
+                outer_scales,
+                metadata,
+            } => WeightData::Microfloat {
+                codes: alloc_ptr(codes),
+                scales: alloc_ptr(scales),
+                outer_scales: alloc_ptr(outer_scales),
+                metadata,
             },
             MatmulB::ScaleBiasDequant {
                 b: weights,
@@ -141,3 +176,7 @@ pub(super) unsafe fn write_f32(
         }
     }
 }
+
+#[cfg(test)]
+#[path = "../../../../../unit/backends/cpu/kernel/matmul/reference_test.rs"]
+mod tests;

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/kernel.rs
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemm/kernel.rs
@@ -191,6 +191,12 @@ impl GemmKernel {
         let use_mxu = plan.engine == GemmEngine::Mxu;
 
         match b {
+            MatmulB::Microfloat {
+                metadata,
+                ..
+            } => {
+                return Err(MatmulError::UnsupportedMicrofloat(metadata.encoding.format).into());
+            },
             MatmulB::FullPrecision {
                 b: weights,
             } => {

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/kernel.rs
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/gemv/kernel.rs
@@ -266,6 +266,9 @@ impl GemvKernel {
         let (scales, zero_points, biases) = match &b {
             MatmulB::FullPrecision {
                 ..
+            }
+            | MatmulB::Microfloat {
+                ..
             } => (None, None, None),
             MatmulB::ScaleBiasDequant {
                 scales,
@@ -287,6 +290,12 @@ impl GemvKernel {
         let context = encoder.context();
         let pipeline = self.get_or_create(context, specialization)?;
         match b {
+            MatmulB::Microfloat {
+                metadata,
+                ..
+            } => {
+                return Err(MatmulError::UnsupportedMicrofloat(metadata.encoding.format));
+            },
             MatmulB::FullPrecision {
                 b: weights,
             } => pipeline.encode(

--- a/crates/uzu-engine/src/backends/metal/kernel/matmul/mod.rs
+++ b/crates/uzu-engine/src/backends/metal/kernel/matmul/mod.rs
@@ -17,7 +17,10 @@ use crate::{
             gpu_types::gemm::{GemmBPrologueKind, GemmTiling},
             kernel::{
                 activation_transform::ACTIVATION_SCALE_GROUP_SIZE,
-                matmul::{A8ActivationPlan, ActivationFormat, MatmulArguments, MatmulError, MatmulKernel, MatmulShape},
+                matmul::{
+                    A8ActivationPlan, ActivationFormat, MatmulArguments, MatmulB, MatmulError, MatmulKernel,
+                    MatmulShape,
+                },
             },
         },
         metal::{Metal, context::MetalContext, error::MetalError},
@@ -217,6 +220,13 @@ impl MatmulKernel for MatmulMetalKernel {
         arguments: MatmulArguments<'a, 'b, 'd, Metal, TB>,
         encoder: &mut Encoder<Metal>,
     ) -> Result<(), MetalError> {
+        if let MatmulB::Microfloat {
+            metadata,
+            ..
+        } = &arguments.b
+        {
+            return Err(MatmulError::UnsupportedMicrofloat(metadata.encoding.format).into());
+        }
         let shape = MatmulShape::from_arguments(&arguments);
         let plan = match self.select_dispatch(&shape, encoder.context()) {
             MatmulDispatch::Gemv(gemv) => {

--- a/crates/uzu-engine/src/config/weight_matrix/microfloat_spec.rs
+++ b/crates/uzu-engine/src/config/weight_matrix/microfloat_spec.rs
@@ -1,0 +1,11 @@
+use uzu_engine_macros::uzu_config;
+
+use crate::{backends::common::microfloat::MicrofloatFormat, config::weight_matrix::Layout};
+
+#[uzu_config(super::WeightMatrixSpec)]
+pub struct MicrofloatSpec {
+    pub bits: u32,
+    pub group_size: u32,
+    pub scale_mode: MicrofloatFormat,
+    pub layout: Layout,
+}

--- a/crates/uzu-engine/src/config/weight_matrix/mod.rs
+++ b/crates/uzu-engine/src/config/weight_matrix/mod.rs
@@ -4,6 +4,7 @@ pub mod full_precision_spec;
 pub mod hybrid_spec;
 pub mod int_spec;
 pub mod low_rank_spec;
+pub mod microfloat_spec;
 pub mod mlx_spec;
 
 #[uzu_config]
@@ -18,6 +19,7 @@ pub enum Layout {
     low_rank_spec::LowRankSpec,
     hybrid_spec::HybridSpec,
     int_spec::IntSpec,
+    microfloat_spec::MicrofloatSpec,
     mlx_spec::MLXSpec
 )]
 pub struct WeightMatrixSpec;

--- a/crates/uzu-engine/src/encodable_block/embedding_table.rs
+++ b/crates/uzu-engine/src/encodable_block/embedding_table.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     config::weight_matrix::{AnyWeightMatrixSpec, Layout},
     data_type::DataType,
-    encodable_block::weight_matrix::{WeightMatrix, WeightMatrixError},
+    encodable_block::weight_matrix::{QuantizationInfo, WeightMatrix, WeightMatrixError},
     parameters::{ParameterLoaderError, ParameterTree},
 };
 
@@ -65,21 +65,32 @@ impl<B: Backend> EmbeddingTable<B> {
         }
 
         let lookup = match matrix.quantization() {
-            None => LookupKernel::FullPrecision(
-                <B::Kernels as Kernels>::FullPrecisionEmbeddingLookupKernel::new(context, data_type)
-                    .map_err(EmbeddingTableError::BackendError)?,
-            ),
-            Some(info) => LookupKernel::Quantized(
-                <B::Kernels as Kernels>::QuantizedEmbeddingLookupKernel::new(
+            None => {
+                let kernel = <B::Kernels as Kernels>::FullPrecisionEmbeddingLookupKernel::new(context, data_type)
+                    .map_err(EmbeddingTableError::BackendError)?;
+                LookupKernel::FullPrecision(kernel)
+            },
+            Some(QuantizationInfo::Microfloat(_)) => {
+                return Err(EmbeddingTableError::UnsupportedConfiguration(
+                    "microfloat embedding tables are not supported".into(),
+                ));
+            },
+            Some(QuantizationInfo::Integer {
+                mode,
+                method,
+                group_size,
+            }) => {
+                let kernel = <B::Kernels as Kernels>::QuantizedEmbeddingLookupKernel::new(
                     context,
                     data_type,
-                    info.group_size,
-                    info.mode,
-                    info.method,
+                    group_size,
+                    mode,
+                    method,
                     output_hadamard_factors.is_some(),
                 )
-                .map_err(EmbeddingTableError::BackendError)?,
-            ),
+                .map_err(EmbeddingTableError::BackendError)?;
+                LookupKernel::Quantized(kernel)
+            },
         };
 
         Ok(Self {

--- a/crates/uzu-engine/src/encodable_block/linear/matmul.rs
+++ b/crates/uzu-engine/src/encodable_block/linear/matmul.rs
@@ -8,8 +8,7 @@ use crate::{
         kernel::{
             Kernels,
             matmul::{
-                A8ActivationPlan, ActivationFormat, MatmulA, MatmulArguments, MatmulB, MatmulDOps, MatmulKernel,
-                MatmulShape,
+                A8ActivationPlan, ActivationFormat, MatmulA, MatmulArguments, MatmulDOps, MatmulKernel, MatmulShape,
             },
         },
     },
@@ -63,8 +62,6 @@ fn load_biases<B: Backend>(
 }
 
 impl<B: Backend> LinearMatmul<B> {
-    /// Loads a linear over any parsed spec — full precision, MLX or Int. Hybrid
-    /// compositions live in the wrappers, not here.
     pub fn load(
         context: &B::Context,
         spec: AnyWeightMatrixSpec,
@@ -77,8 +74,9 @@ impl<B: Backend> LinearMatmul<B> {
         bias_tree: Option<&ParameterTree<B>>,
         output_hadamard_factors: Option<Allocation<B>>,
     ) -> Result<Self, LinearMatmulError<B>> {
+        let microfloat = matches!(spec, AnyWeightMatrixSpec::MicrofloatSpec(_));
         for data_type in [weights_data_type, input_data_type, output_data_type] {
-            if !matches!(data_type, DataType::BF16 | DataType::F32) {
+            if !matches!(data_type, DataType::BF16 | DataType::F32) && !(microfloat && data_type == DataType::F16) {
                 return Err(LinearMatmulError::UnsupportedDataType(data_type));
             }
         }
@@ -131,7 +129,7 @@ impl<B: Backend> LinearMatmul<B> {
         self.kernel.lock().encode(
             MatmulArguments {
                 a,
-                b: self.matmul_b(),
+                b: self.matrix.matmul_b(),
                 b_leading_dimension: None,
                 b_transpose: true,
                 d: &mut output,
@@ -152,7 +150,7 @@ impl<B: Backend> LinearMatmul<B> {
         batch_dim: u32,
         a_full_precision: bool,
     ) -> MatmulShape {
-        let b = self.matmul_b();
+        let b = self.matrix.matmul_b();
         MatmulShape {
             m: batch_dim,
             n: self.output_dim,
@@ -174,15 +172,11 @@ impl<B: Backend> LinearMatmul<B> {
         batch_dim: u32,
         context: &B::Context,
     ) -> ActivationFormat {
-        if !self.matmul_b().signed_codes() {
+        if !self.matrix.matmul_b().signed_codes() {
             return ActivationFormat::Bf16;
         }
         let bf16_shape = self.matmul_shape(batch_dim, true);
         self.kernel.lock().select_activation_format(&bf16_shape, context)
-    }
-
-    fn matmul_b(&self) -> MatmulB<'_, B> {
-        self.matrix.matmul_b()
     }
 
     fn d_ops(&self) -> MatmulDOps<'_, B> {

--- a/crates/uzu-engine/src/encodable_block/linear/mod.rs
+++ b/crates/uzu-engine/src/encodable_block/linear/mod.rs
@@ -100,7 +100,8 @@ impl<B: Backend> dyn Linear<B> {
         match spec {
             spec @ (AnyWeightMatrixSpec::FullPrecisionSpec(_)
             | AnyWeightMatrixSpec::MLXSpec(_)
-            | AnyWeightMatrixSpec::IntSpec(_)) => {
+            | AnyWeightMatrixSpec::IntSpec(_)
+            | AnyWeightMatrixSpec::MicrofloatSpec(_)) => {
                 let block = LinearMatmul::load(
                     context,
                     spec,

--- a/crates/uzu-engine/src/encodable_block/weight_matrix.rs
+++ b/crates/uzu-engine/src/encodable_block/weight_matrix.rs
@@ -5,6 +5,7 @@ use crate::{
         Allocation, Backend,
         gpu_types::{QuantizationMethod, QuantizationMode},
         kernel::matmul::MatmulB,
+        microfloat::{MicrofloatEncoding, MicrofloatError, MicrofloatMetadata},
     },
     config::weight_matrix::{AnyWeightMatrixSpec, Layout},
     data_type::DataType,
@@ -15,15 +16,20 @@ use crate::{
 pub enum WeightMatrixError<B: Backend> {
     #[error("Parameter loading error: {0}")]
     ParameterError(#[from] ParameterLoaderError<B>),
+    #[error("Microfloat error: {0}")]
+    MicrofloatError(#[from] MicrofloatError),
     #[error("Unsupported weight matrix configuration: {0}")]
     UnsupportedConfiguration(String),
 }
 
-#[derive(Clone, Copy)]
-pub struct QuantizationInfo {
-    pub mode: QuantizationMode,
-    pub method: QuantizationMethod,
-    pub group_size: u32,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuantizationInfo {
+    Integer {
+        mode: QuantizationMode,
+        method: QuantizationMethod,
+        group_size: u32,
+    },
+    Microfloat(MicrofloatEncoding),
 }
 
 pub struct ParsedWeightSpec {
@@ -32,50 +38,60 @@ pub struct ParsedWeightSpec {
 }
 
 pub fn parse_spec<B: Backend>(spec: &AnyWeightMatrixSpec) -> Result<ParsedWeightSpec, WeightMatrixError<B>> {
-    let (layout, quantized) = match spec {
+    let (layout, quantization) = match spec {
         AnyWeightMatrixSpec::FullPrecisionSpec(spec) => (spec.layout.clone(), None),
         AnyWeightMatrixSpec::MLXSpec(spec) => {
-            (spec.layout.clone(), Some((spec.bits, spec.group_size, QuantizationMethod::ScaleBias)))
+            let quantization = integer_quantization::<B>(spec.bits, spec.group_size, QuantizationMethod::ScaleBias)?;
+            (spec.layout.clone(), Some(quantization))
         },
-        AnyWeightMatrixSpec::IntSpec(spec) => (
-            spec.layout.clone(),
-            Some((
-                spec.bits,
-                spec.group_size,
-                if spec.is_symmetric {
-                    QuantizationMethod::ScaleSymmetric
-                } else {
-                    QuantizationMethod::ScaleZeroPoint
-                },
-            )),
-        ),
-        spec => return Err(WeightMatrixError::UnsupportedConfiguration(format!("{spec:?}"))),
-    };
-    let quantization = match quantized {
-        None => None,
-        Some((bits, group_size, method)) => {
-            let mode = match bits {
-                4 => QuantizationMode::U4,
-                8 => QuantizationMode::U8,
-                _ => {
-                    return Err(WeightMatrixError::UnsupportedConfiguration(format!(
-                        "{method} bits={bits}, group_size={group_size}"
-                    )));
-                },
+        AnyWeightMatrixSpec::IntSpec(spec) => {
+            let method = if spec.is_symmetric {
+                QuantizationMethod::ScaleSymmetric
+            } else {
+                QuantizationMethod::ScaleZeroPoint
             };
-            if group_size == 0 {
-                return Err(WeightMatrixError::UnsupportedConfiguration("group size must be non-zero".into()));
-            }
-            Some(QuantizationInfo {
-                mode,
-                method,
-                group_size,
-            })
+            let quantization = integer_quantization::<B>(spec.bits, spec.group_size, method)?;
+            (spec.layout.clone(), Some(quantization))
         },
+        AnyWeightMatrixSpec::MicrofloatSpec(spec) => {
+            if spec.layout != Layout::OutputInput {
+                return Err(WeightMatrixError::UnsupportedConfiguration(format!(
+                    "microfloat matrices require output-input layout, got {:?}",
+                    spec.layout,
+                )));
+            }
+            let encoding = MicrofloatEncoding::new(spec.scale_mode, spec.bits, spec.group_size)?;
+            (spec.layout.clone(), Some(QuantizationInfo::Microfloat(encoding)))
+        },
+        spec => return Err(WeightMatrixError::UnsupportedConfiguration(format!("{spec:?}"))),
     };
     Ok(ParsedWeightSpec {
         layout,
         quantization,
+    })
+}
+
+fn integer_quantization<B: Backend>(
+    bits: u32,
+    group_size: u32,
+    method: QuantizationMethod,
+) -> Result<QuantizationInfo, WeightMatrixError<B>> {
+    let mode = match bits {
+        4 => QuantizationMode::U4,
+        8 => QuantizationMode::U8,
+        _ => {
+            return Err(WeightMatrixError::UnsupportedConfiguration(format!(
+                "{method} bits={bits}, group_size={group_size}"
+            )));
+        },
+    };
+    if group_size == 0 {
+        return Err(WeightMatrixError::UnsupportedConfiguration("group size must be non-zero".into()));
+    }
+    Ok(QuantizationInfo::Integer {
+        mode,
+        method,
+        group_size,
     })
 }
 
@@ -85,11 +101,19 @@ enum QuantizedCorrection<B: Backend> {
     ZeroPoints(Allocation<B>),
 }
 
-struct Quantized<B: Backend> {
-    scales: Allocation<B>,
-    correction: QuantizedCorrection<B>,
-    info: QuantizationInfo,
-    signed_codes: bool,
+enum Quantized<B: Backend> {
+    Integer {
+        scales: Allocation<B>,
+        correction: QuantizedCorrection<B>,
+        mode: QuantizationMode,
+        group_size: u32,
+        signed_codes: bool,
+    },
+    Microfloat {
+        scales: Allocation<B>,
+        outer_scales: Allocation<B>,
+        metadata: MicrofloatMetadata,
+    },
 }
 
 pub struct WeightMatrix<B: Backend> {
@@ -117,7 +141,7 @@ impl<B: Backend> WeightMatrix<B> {
         }
         let (rows, columns) = physical_shape(&layout, output_dim, input_dim);
 
-        let Some(info) = quantization else {
+        let Some(quantization) = quantization else {
             let values = tree.leaf("weights")?.validate(&[rows, columns], data_type)?.read_allocation()?;
             return Ok(Self {
                 values,
@@ -125,20 +149,43 @@ impl<B: Backend> WeightMatrix<B> {
             });
         };
 
-        let group_size = info.group_size;
-        let packing_divisor = info.mode.packing_divisor();
-        let storage_data_type = info.mode.storage_type();
+        let (mode, method, group_size) = match quantization {
+            QuantizationInfo::Microfloat(encoding) => {
+                let metadata = MicrofloatMetadata::new(encoding, rows, columns)?;
+                let values = tree.leaf("weights")?.validate(&[rows, columns / 2], DataType::U8)?.read_allocation()?;
+                let scales = tree
+                    .leaf("scales")?
+                    .validate(&[rows, columns / encoding.group_size], DataType::U8)?
+                    .read_allocation()?;
+                let outer_scales = tree.leaf("global_scale")?.validate(&[1], data_type)?.read_allocation()?;
+                return Ok(Self {
+                    values,
+                    quantized: Some(Quantized::Microfloat {
+                        scales,
+                        outer_scales,
+                        metadata,
+                    }),
+                });
+            },
+            QuantizationInfo::Integer {
+                mode,
+                method,
+                group_size,
+            } => (mode, method, group_size),
+        };
+
+        let packing_divisor = mode.packing_divisor();
+        let storage_data_type = mode.storage_type();
         if !columns.is_multiple_of(packing_divisor) {
             return Err(WeightMatrixError::UnsupportedConfiguration(format!(
                 "stored columns {columns} are not divisible by packing divisor {packing_divisor}"
             )));
         }
         let groups = columns.div_ceil(group_size);
-
         let values =
             tree.leaf("weights")?.validate(&[rows, columns / packing_divisor], storage_data_type)?.read_allocation()?;
         let scales = tree.leaf("scales")?.validate(&[rows, groups], data_type)?.read_allocation()?;
-        let correction = match info.method {
+        let correction = match method {
             QuantizationMethod::ScaleBias => QuantizedCorrection::Biases(
                 tree.leaf("biases")?.validate(&[rows, groups], data_type)?.read_allocation()?,
             ),
@@ -149,57 +196,117 @@ impl<B: Backend> WeightMatrix<B> {
             ),
             QuantizationMethod::ScaleSymmetric => QuantizedCorrection::Symmetric,
         };
-
         Ok(Self {
             values,
-            quantized: Some(Quantized {
+            quantized: Some(Quantized::Integer {
                 scales,
                 correction,
-                info,
+                mode,
+                group_size,
                 signed_codes: false,
             }),
         })
     }
 
+    /// Borrow weights; code mutation must also update the signed-code state.
     pub fn values(&self) -> &Allocation<B> {
         &self.values
     }
 
     pub fn quantization(&self) -> Option<QuantizationInfo> {
-        self.quantized.as_ref().map(|quantized| quantized.info)
+        match &self.quantized {
+            None => None,
+            Some(Quantized::Microfloat {
+                metadata,
+                ..
+            }) => Some(QuantizationInfo::Microfloat(metadata.encoding)),
+            Some(Quantized::Integer {
+                mode,
+                correction,
+                group_size,
+                ..
+            }) => {
+                let method = match correction {
+                    QuantizedCorrection::Symmetric => QuantizationMethod::ScaleSymmetric,
+                    QuantizedCorrection::Biases(_) => QuantizationMethod::ScaleBias,
+                    QuantizedCorrection::ZeroPoints(_) => QuantizationMethod::ScaleZeroPoint,
+                };
+                Some(QuantizationInfo::Integer {
+                    mode: *mode,
+                    method,
+                    group_size: *group_size,
+                })
+            },
+        }
     }
 
     pub fn scales(&self) -> Option<&Allocation<B>> {
-        self.quantized.as_ref().map(|quantized| &quantized.scales)
+        match &self.quantized {
+            None => None,
+            Some(
+                Quantized::Integer {
+                    scales,
+                    ..
+                }
+                | Quantized::Microfloat {
+                    scales,
+                    ..
+                },
+            ) => Some(scales),
+        }
     }
 
     pub fn zero_points(&self) -> Option<&Allocation<B>> {
-        match &self.quantized.as_ref()?.correction {
-            QuantizedCorrection::ZeroPoints(zero_points) => Some(zero_points),
-            QuantizedCorrection::Biases(_) | QuantizedCorrection::Symmetric => None,
+        match &self.quantized {
+            Some(Quantized::Integer {
+                correction: QuantizedCorrection::ZeroPoints(zero_points),
+                ..
+            }) => Some(zero_points),
+            _ => None,
         }
     }
 
     pub fn biases(&self) -> Option<&Allocation<B>> {
-        match &self.quantized.as_ref()?.correction {
-            QuantizedCorrection::Biases(biases) => Some(biases),
-            QuantizedCorrection::ZeroPoints(_) | QuantizedCorrection::Symmetric => None,
+        match &self.quantized {
+            Some(Quantized::Integer {
+                correction: QuantizedCorrection::Biases(biases),
+                ..
+            }) => Some(biases),
+            _ => None,
         }
     }
 
     pub fn matmul_b(&self) -> MatmulB<'_, B> {
-        let Some(quantized) = self.quantized.as_ref() else {
-            return MatmulB::FullPrecision {
-                b: &self.values,
-            };
+        let (scales, correction, mode, group_size, signed_codes) = match &self.quantized {
+            None => {
+                return MatmulB::FullPrecision {
+                    b: &self.values,
+                };
+            },
+            Some(Quantized::Microfloat {
+                scales,
+                outer_scales,
+                metadata,
+            }) => {
+                return MatmulB::Microfloat {
+                    codes: &self.values,
+                    scales,
+                    outer_scales,
+                    metadata: *metadata,
+                };
+            },
+            Some(Quantized::Integer {
+                scales,
+                correction,
+                mode,
+                group_size,
+                signed_codes,
+            }) => (scales, correction, *mode, *group_size, *signed_codes),
         };
-        let mode = quantized.info.mode;
-        let group_size = quantized.info.group_size;
-        let signed_codes = quantized.signed_codes;
-        match &quantized.correction {
+        match correction {
             QuantizedCorrection::Biases(biases) => MatmulB::ScaleBiasDequant {
                 b: &self.values,
-                scales: &quantized.scales,
+                scales,
                 biases,
                 mode,
                 group_size,
@@ -207,7 +314,7 @@ impl<B: Backend> WeightMatrix<B> {
             },
             QuantizedCorrection::ZeroPoints(zero_points) => MatmulB::ScaleZeroPointDequant {
                 b: &self.values,
-                scales: &quantized.scales,
+                scales,
                 zero_points,
                 mode,
                 group_size,
@@ -215,7 +322,7 @@ impl<B: Backend> WeightMatrix<B> {
             },
             QuantizedCorrection::Symmetric => MatmulB::ScaleSymmetricDequant {
                 b: &self.values,
-                scales: &quantized.scales,
+                scales,
                 mode,
                 group_size,
                 signed_codes,
@@ -224,20 +331,25 @@ impl<B: Backend> WeightMatrix<B> {
     }
 
     pub fn make_codes_signed(&mut self) {
-        let Some(quantized) = self.quantized.as_mut() else {
+        let Some(Quantized::Integer {
+            mode,
+            signed_codes,
+            ..
+        }) = &mut self.quantized
+        else {
             return;
         };
-        if quantized.signed_codes {
+        if *signed_codes {
             return;
         }
-        let Some(sign_flip_mask) = quantized.info.mode.weight_codes_sign_flip_mask() else {
+        let Some(sign_flip_mask) = mode.weight_codes_sign_flip_mask() else {
             return;
         };
         let broadcast_mask = u64::from(sign_flip_mask) * 0x0101_0101_0101_0101;
         let (prefix, words, suffix) = bytemuck::pod_align_to_mut::<u8, u64>(self.values.as_slice_mut());
         words.iter_mut().for_each(|word| *word ^= broadcast_mask);
         prefix.iter_mut().chain(suffix.iter_mut()).for_each(|code| *code ^= sign_flip_mask);
-        quantized.signed_codes = true;
+        *signed_codes = true;
     }
 }
 
@@ -251,3 +363,7 @@ fn physical_shape(
         Layout::InputOutput => (input_dim, output_dim),
     }
 }
+
+#[cfg(test)]
+#[path = "../../unit/encodable_block/weight_matrix/microfloat_test.rs"]
+mod microfloat_test;

--- a/crates/uzu-engine/unit/backends/common/kernel/matmul/microfloat_test.rs
+++ b/crates/uzu-engine/unit/backends/common/kernel/matmul/microfloat_test.rs
@@ -1,0 +1,261 @@
+use half::{bf16, f16};
+use uzu_engine_macros::uzu_test;
+
+use crate::{
+    array::ArrayElement,
+    backends::{
+        common::{
+            Backend, Encoder, Kernels,
+            kernel::matmul::{MatmulA, MatmulArguments, MatmulB, MatmulDOps, MatmulError, MatmulKernel},
+            microfloat::{MicrofloatEncoding, MicrofloatError, MicrofloatFormat, MicrofloatMetadata},
+        },
+        cpu::Cpu,
+    },
+    data_type::DataType,
+    tests::{
+        assert::assert_eq_float,
+        helpers::{alloc_allocation_with_data, allocation_to_vec, create_context, submit_encoder},
+    },
+};
+
+fn check_dense_mxfp4<T: ArrayElement>(
+    row_count: usize,
+    group_size: usize,
+    wide_scale: bool,
+) {
+    const K: usize = 32;
+    const N: usize = 4;
+    const E2M1: [f32; 16] = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0];
+
+    let encoding =
+        MicrofloatEncoding::new(MicrofloatFormat::Mxfp4, 4, group_size as u32).expect("valid MXFP4 encoding");
+    let metadata = MicrofloatMetadata::new(encoding, N as u32, K as u32).expect("valid dense MXFP4 metadata");
+    let context = create_context::<Cpu>();
+    let input: Vec<f32> = (0..row_count * K)
+        .map(|index| {
+            if wide_scale {
+                if index % K == 0 {
+                    1.0 / 1024.0
+                } else {
+                    0.0
+                }
+            } else {
+                (index % 13) as f32 * 0.125 - 0.5
+            }
+        })
+        .collect();
+    let codes: Vec<u8> = (0..N * K / 2)
+        .map(|index| {
+            if wide_scale {
+                return 0x77;
+            }
+            let low = ((index * 5 + 1) % 16) as u8;
+            let high = ((index * 7 + 3) % 16) as u8;
+            low | (high << 4)
+        })
+        .collect();
+    let scales: Vec<u8> = (0..N * K / group_size)
+        .map(|index| {
+            if wide_scale {
+                254
+            } else {
+                126 + (index % 3) as u8
+            }
+        })
+        .collect();
+    let outer_scale: f32 = if wide_scale {
+        0.25
+    } else {
+        1.25
+    };
+    let mut expected = vec![0.0; row_count * N];
+    for row in 0..row_count {
+        for output_row in 0..N {
+            for inner in 0..K {
+                let packed = codes[output_row * K / 2 + inner / 2];
+                let code = (packed >> (4 * (inner % 2))) & 0x0f;
+                let exponent = scales[output_row * K / group_size + inner / group_size];
+                let weight = (f64::from(E2M1[code as usize])
+                    * 2.0f64.powi(i32::from(exponent) - 127)
+                    * f64::from(outer_scale)) as f32;
+                expected[row * N + output_row] += input[row * K + inner] * weight;
+            }
+        }
+    }
+    let biases = [0.5, -1.0, 1.5, -2.0];
+    if wide_scale {
+        // The unscaled weight exceeds f32, but the outer scale makes it representable.
+        assert_eq!(expected, vec![3.0 * 2.0f32.powi(116); row_count * N]);
+    } else {
+        for (index, value) in expected.iter_mut().enumerate() {
+            *value = ((*value * 0.5 + biases[index % N]) / 16.0).tanh() * 16.0;
+        }
+    }
+
+    let input: Vec<T> = input.into_iter().map(|value| T::from(value).expect("representable input")).collect();
+    let outer_scale = T::from(outer_scale).expect("representable outer scale");
+    let input = alloc_allocation_with_data::<Cpu, T>(context.as_ref(), &input);
+    let codes = alloc_allocation_with_data::<Cpu, u8>(context.as_ref(), &codes);
+    let scales = alloc_allocation_with_data::<Cpu, u8>(context.as_ref(), &scales);
+    let outer_scales = alloc_allocation_with_data::<Cpu, T>(context.as_ref(), &[outer_scale]);
+    let biases = biases.map(|value| T::from(value).expect("representable bias"));
+    let biases = alloc_allocation_with_data::<Cpu, T>(context.as_ref(), &biases);
+    let mut output = alloc_allocation_with_data::<Cpu, f32>(context.as_ref(), &vec![f32::NAN; row_count * N]);
+    let d_transform = if wide_scale {
+        MatmulDOps::none()
+    } else {
+        MatmulDOps {
+            ab_scale: 0.5,
+            bias: Some(&biases),
+            soft_cap: Some(16.0),
+            ..MatmulDOps::none()
+        }
+    };
+    let mut kernel = <<Cpu as Backend>::Kernels as Kernels>::MatmulKernel::new(
+        context.as_ref(),
+        T::data_type(),
+        T::data_type(),
+        DataType::F32,
+    )
+    .expect("create matmul kernel");
+    let mut encoder = Encoder::<Cpu>::new(context.as_ref()).expect("create encoder");
+    kernel
+        .encode(
+            MatmulArguments {
+                a: MatmulA::FullPrecision {
+                    values: &input,
+                    offset: 0,
+                },
+                b: MatmulB::<Cpu>::Microfloat {
+                    codes: &codes,
+                    scales: &scales,
+                    outer_scales: &outer_scales,
+                    metadata,
+                },
+                b_leading_dimension: None,
+                b_transpose: true,
+                d: &mut output,
+                d_transform,
+                gather_indices: None,
+                m: row_count as u32,
+                n: N as u32,
+                k: K as u32,
+            },
+            &mut encoder,
+        )
+        .expect("encode MXFP4 matmul");
+    submit_encoder(encoder);
+    let actual = allocation_to_vec::<Cpu, f32>(&output);
+    assert_eq_float(&expected, &actual, 1e-5, &format!("CPU {:?} M={row_count} group={group_size}", T::data_type()));
+}
+
+#[uzu_test]
+fn cpu_dense_mxfp4_matches_scalar_reference() {
+    for row_count in [1, 9, 33] {
+        for group_size in [16, 32] {
+            check_dense_mxfp4::<f16>(row_count, group_size, false);
+            check_dense_mxfp4::<bf16>(row_count, group_size, false);
+            check_dense_mxfp4::<f32>(row_count, group_size, false);
+            check_dense_mxfp4::<f16>(row_count, group_size, true);
+        }
+    }
+}
+
+#[uzu_test]
+fn cpu_rejects_invalid_mxfp4_operands_before_dispatch() {
+    let context = create_context::<Cpu>();
+    let encoding = MicrofloatEncoding::new(MicrofloatFormat::Mxfp4, 4, 16).expect("valid MXFP4 encoding");
+    let metadata = MicrofloatMetadata::new(encoding, 4, 32).expect("valid MXFP4 metadata");
+    let input = alloc_allocation_with_data::<Cpu, f32>(context.as_ref(), &[1.0; 32]);
+    let mut output = alloc_allocation_with_data::<Cpu, f32>(context.as_ref(), &[f32::NAN; 4]);
+    let mut kernel = <<Cpu as Backend>::Kernels as Kernels>::MatmulKernel::new(
+        context.as_ref(),
+        DataType::F32,
+        DataType::F32,
+        DataType::F32,
+    )
+    .expect("create CPU matmul kernel");
+
+    for (metadata, code_bytes, scale_bytes, outer_bytes, invalid_metadata) in [
+        (
+            MicrofloatMetadata {
+                rows: 0,
+                ..metadata
+            },
+            64,
+            8,
+            4,
+            Some(MicrofloatError::EmptyShape),
+        ),
+        (
+            MicrofloatMetadata {
+                columns: 33,
+                ..metadata
+            },
+            64,
+            8,
+            4,
+            Some(MicrofloatError::MisalignedColumns {
+                columns: 33,
+                group_size: 16,
+            }),
+        ),
+        (
+            MicrofloatMetadata {
+                encoding: MicrofloatEncoding {
+                    group_size: 0,
+                    ..encoding
+                },
+                ..metadata
+            },
+            64,
+            8,
+            4,
+            Some(MicrofloatError::UnsupportedGroupSize {
+                format: MicrofloatFormat::Mxfp4,
+                group_size: 0,
+            }),
+        ),
+        (metadata, 63, 8, 4, None),
+        (metadata, 64, 7, 4, None),
+        (metadata, 64, 8, 3, None),
+    ] {
+        let codes = alloc_allocation_with_data::<Cpu, u8>(context.as_ref(), &vec![0x22; code_bytes]);
+        let scales = alloc_allocation_with_data::<Cpu, u8>(context.as_ref(), &vec![127; scale_bytes]);
+        let outer_scales = alloc_allocation_with_data::<Cpu, u8>(context.as_ref(), &vec![0; outer_bytes]);
+        let mut encoder = Encoder::<Cpu>::new(context.as_ref()).expect("create CPU encoder");
+        let result = kernel.encode(
+            MatmulArguments {
+                a: MatmulA::FullPrecision {
+                    values: &input,
+                    offset: 0,
+                },
+                b: MatmulB::<Cpu>::Microfloat {
+                    codes: &codes,
+                    scales: &scales,
+                    outer_scales: &outer_scales,
+                    metadata,
+                },
+                b_leading_dimension: None,
+                b_transpose: true,
+                d: &mut output,
+                d_transform: MatmulDOps::none(),
+                gather_indices: None,
+                m: 1,
+                n: 4,
+                k: 32,
+            },
+            &mut encoder,
+        );
+        let error = result.expect_err("reject invalid MXFP4 operand during encoding");
+        let error = (&error as &dyn std::error::Error)
+            .source()
+            .and_then(|source| source.downcast_ref::<MatmulError<Cpu>>())
+            .expect("preserve matmul error");
+        match (invalid_metadata, error) {
+            (Some(expected), MatmulError::InvalidMicrofloat(actual)) => assert_eq!(*actual, expected),
+            (None, MatmulError::InvalidMicrofloatStorage) => {},
+            (expected, actual) => panic!("expected metadata error {expected:?}, got {actual:?}"),
+        }
+    }
+}

--- a/crates/uzu-engine/unit/backends/common/kernel/matmul/mod.rs
+++ b/crates/uzu-engine/unit/backends/common/kernel/matmul/mod.rs
@@ -2,6 +2,7 @@ mod a8w_bench;
 mod dispatch_paths_test;
 mod gemm_bench;
 mod gemv_test;
+mod microfloat_test;
 mod quant_dispatch_test;
 mod quant_gemm_bench;
 mod quant_gemv_bench;

--- a/crates/uzu-engine/unit/backends/cpu/kernel/matmul/reference_test.rs
+++ b/crates/uzu-engine/unit/backends/cpu/kernel/matmul/reference_test.rs
@@ -1,0 +1,20 @@
+use uzu_engine_macros::uzu_test;
+
+use super::{decode_e2m1, decode_e8m0};
+
+#[uzu_test]
+fn decodes_e2m1_and_e8m0_edges() {
+    let expected = [0.0f32, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0];
+
+    for (code, value) in expected.into_iter().enumerate() {
+        assert_eq!(decode_e2m1(code as u8), value);
+        assert_eq!(decode_e2m1(code as u8 | 0b1000), -value);
+    }
+    assert_eq!(decode_e2m1(0).to_bits(), 0.0f32.to_bits());
+    assert_eq!(decode_e2m1(8).to_bits(), (-0.0f32).to_bits());
+    assert_eq!(decode_e8m0(0).to_bits(), 0x0040_0000);
+    assert_eq!(decode_e8m0(1), 2.0f32.powi(-126));
+    assert_eq!(decode_e8m0(127), 1.0);
+    assert_eq!(decode_e8m0(254), 2.0f32.powi(127));
+    assert!(decode_e8m0(255).is_nan());
+}

--- a/crates/uzu-engine/unit/encodable_block/weight_matrix/microfloat_test.rs
+++ b/crates/uzu-engine/unit/encodable_block/weight_matrix/microfloat_test.rs
@@ -1,0 +1,189 @@
+use std::{fmt::Debug, fs::File, io::Write};
+
+use half::{bf16, f16};
+use serde_json::{Map, Value, json};
+use tempfile::tempfile;
+use uzu_engine_macros::uzu_test;
+
+use crate::{
+    array::ArrayElement,
+    backends::{common::Encoder, cpu::Cpu},
+    data_type::DataType,
+    encodable_block::{
+        linear::{Linear, LinearBlockError, LinearMatmulError},
+        weight_matrix::WeightMatrixError,
+    },
+    parameters::{ParameterLoader, ParameterLoaderError},
+    tests::helpers::{alloc_allocation_with_data, allocation_to_vec, create_context},
+};
+
+fn add_tensor(
+    header: &mut Map<String, Value>,
+    payload: &mut Vec<u8>,
+    name: &str,
+    shape: &[u32],
+    data_type: &str,
+    data: &[u8],
+) {
+    let begin = payload.len();
+    payload.extend_from_slice(data);
+    header.insert(
+        name.into(),
+        json!({
+            "dtype": data_type,
+            "shape": shape,
+            "data_offsets": [begin, payload.len()]
+        }),
+    );
+}
+
+fn dense_microfloat_parameter_file<T: ArrayElement>(edit_header: impl FnOnce(&mut Map<String, Value>)) -> File {
+    const ROWS: u32 = 2;
+    const COLUMNS: u32 = 32;
+    const GROUP_SIZE: u32 = 16;
+
+    let mut header = Map::new();
+    header.insert(
+        "__metadata__".into(),
+        json!({
+            "weights.spec": json!({
+                "type": "MicrofloatSpec",
+                "bits": 4,
+                "group_size": GROUP_SIZE,
+                "scale_mode": "mxfp4",
+                "layout": "output_input"
+            }).to_string()
+        }),
+    );
+    let mut payload = Vec::new();
+    let codes: Vec<u8> = [0x21, 0xbc, 0x76, 0x09].into_iter().flat_map(|code| [code; 8]).collect();
+    let scales = [126, 128, 127, 125];
+    let global_scale = T::from(0.75).expect("representable outer scale");
+    let biases = [T::from(1.5).unwrap(), T::from(-0.75).unwrap()];
+    let data_type = match T::data_type() {
+        DataType::F16 => "F16",
+        DataType::BF16 => "BF16",
+        DataType::F32 => "F32",
+        _ => unreachable!(),
+    };
+    add_tensor(&mut header, &mut payload, "weights.weights", &[ROWS, COLUMNS / 2], "U8", &codes);
+    add_tensor(&mut header, &mut payload, "weights.scales", &[ROWS, COLUMNS / GROUP_SIZE], "U8", &scales);
+    add_tensor(&mut header, &mut payload, "weights.global_scale", &[1], data_type, bytemuck::bytes_of(&global_scale));
+    add_tensor(&mut header, &mut payload, "biases", &[ROWS], data_type, bytemuck::cast_slice(&biases));
+
+    edit_header(&mut header);
+    let mut header = serde_json::to_vec(&Value::Object(header)).expect("serialize safetensors header");
+    header.extend(std::iter::repeat_n(b' ', (8 - header.len() % 8) % 8));
+    let mut file = tempfile().expect("create dense MXFP4 fixture");
+    file.write_all(&(header.len() as u64).to_le_bytes()).expect("write safetensors header length");
+    file.write_all(&header).expect("write safetensors header");
+    file.write_all(&payload).expect("write safetensors payload");
+    file
+}
+
+fn execute_loaded_projection<T: ArrayElement + PartialEq + Debug>(batch_dim: u32) {
+    let context = create_context::<Cpu>();
+    let file = dense_microfloat_parameter_file::<T>(|_| {});
+    let loader = ParameterLoader::<Cpu>::new(&file, context.as_ref()).expect("load dense MXFP4 fixture");
+    let tree = loader.tree();
+    let projection = <dyn Linear<Cpu>>::new(32, [2], true, context.as_ref(), T::data_type(), &tree)
+        .expect("load dense MXFP4 projection");
+    tree.assert_all_tensors_validated().expect("validate dense MXFP4 tensors");
+
+    let input: Vec<T> = (0..batch_dim)
+        .flat_map(|row| {
+            (0..32).map(move |column| {
+                let value = match (row % 2, column) {
+                    (1, 16..) => 0.5,
+                    (1, column) if column % 2 == 1 => -1.0,
+                    _ => 1.0,
+                };
+                T::from(value).expect("representable input")
+            })
+        })
+        .collect();
+    let input = alloc_allocation_with_data::<Cpu, T>(context.as_ref(), &input);
+    let mut encoder = Encoder::<Cpu>::new(context.as_ref()).expect("create encoder");
+    let output = projection.encode(input, batch_dim, &mut encoder).expect("encode MXFP4 projection");
+    let command_buffer = encoder.end_encoding();
+    let command_buffer = command_buffer.submit();
+    let completed = command_buffer.wait_until_completed().expect("execute MXFP4 projection");
+    let values = allocation_to_vec::<Cpu, T>(&output);
+    // Releasing scratch before the completion handle returns its allocation pool.
+    drop(output);
+    drop(completed);
+    let expected: Vec<T> = (0..batch_dim)
+        .flat_map(|row| {
+            if row % 2 == 0 {
+                [-36.0, 58.5]
+            } else {
+                [-21.0, -13.125]
+            }
+        })
+        .map(|value| T::from(value).expect("representable expected output"))
+        .collect();
+    assert_eq!(values, expected, "CPU {:?} batch={batch_dim}", T::data_type());
+}
+
+#[uzu_test]
+fn loads_and_executes_dense_mxfp4_projection() {
+    for batch_dim in [1, 9] {
+        execute_loaded_projection::<bf16>(batch_dim);
+        execute_loaded_projection::<f16>(batch_dim);
+        execute_loaded_projection::<f32>(batch_dim);
+    }
+}
+
+#[uzu_test]
+fn rejects_invalid_mxfp4_artifact_tensors() {
+    let context = create_context::<Cpu>();
+    for (tensor, field, value) in [
+        ("weights.weights", "dtype", json!("I8")),
+        ("weights.scales", "shape", json!([4])),
+        ("weights.global_scale", "data_offsets", json!([36, 38])),
+    ] {
+        let file = dense_microfloat_parameter_file::<f32>(|header| {
+            header[tensor][field] = value;
+        });
+        let loader = ParameterLoader::<Cpu>::new(&file, context.as_ref()).expect("read artifact header");
+        let tree = loader.tree();
+        let result = <dyn Linear<Cpu>>::new(32, [2], true, context.as_ref(), DataType::F32, &tree);
+        let error = result.err().expect("reject invalid MXFP4 tensor before projection encoding");
+        let LinearBlockError::LinearMatmulError(LinearMatmulError::WeightMatrix(WeightMatrixError::ParameterError(
+            error,
+        ))) = error
+        else {
+            panic!("unexpected projection error: {error}");
+        };
+        match (field, error) {
+            (
+                "dtype",
+                ParameterLoaderError::InvalidTensor {
+                    data_type: DataType::I8,
+                    expected_data_type: DataType::U8,
+                    ..
+                },
+            ) => {},
+            (
+                "shape",
+                ParameterLoaderError::InvalidTensor {
+                    shape,
+                    expected_shape,
+                    ..
+                },
+            ) => {
+                assert_eq!(&*shape, &[4]);
+                assert_eq!(&*expected_shape, &[2, 2]);
+            },
+            (
+                "data_offsets",
+                ParameterLoaderError::InvalidTensorSize {
+                    size: 2,
+                    expected_size: 4,
+                    ..
+                },
+            ) => {},
+            (_, error) => panic!("unexpected error for {tensor}: {error}"),
+        }
+    }
+}


### PR DESCRIPTION
Allows Uzu to load and validate dense MXFP4 weight matrices, with CPU reference execution. Metal GEMV and GEMM support follows in #777.

Reworks the storage groundwork from #769 around the existing WeightMatrix representation, with typed format errors and loader-to-projection tests.